### PR TITLE
Fix git commit message handling in dependency-check workflow

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -117,7 +117,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git add -A
-          git commit -m "$(cat <<'COMMIT_MSG'
+
+          # Create commit message file to avoid shell escaping issues
+          cat > /tmp/commit_msg.txt << 'EOF'
 chore(deps): automated dependency updates
 
 Frontend:
@@ -127,8 +129,8 @@ Backend:
 - pip dependencies reviewed
 
 For security details, see DEPENDENCY_AUDIT.md (available in workflow artifacts)
-COMMIT_MSG
-)"
+EOF
+          git commit -F /tmp/commit_msg.txt
 
       - name: Push to Develop
         if: steps.detect-changes.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary
Refactored the git commit message handling in the dependency-check workflow to avoid shell escaping issues and improve reliability.

## Key Changes
- Replaced inline heredoc syntax in `git commit -m` with a temporary file approach
- Created `/tmp/commit_msg.txt` file containing the commit message using `cat` with EOF delimiter
- Updated git commit command to use `-F` flag to read message from file instead of `-m` with inline string

## Implementation Details
The previous approach used a heredoc directly within the `-m` flag, which can be problematic with complex multi-line messages and special characters. The new approach:
- Writes the commit message to a temporary file first
- Uses `git commit -F` to read the message from the file
- Eliminates potential shell escaping issues and improves maintainability
- Maintains the exact same commit message content and formatting

https://claude.ai/code/session_01TXHEEF8LHwKQzfAP8wQ5B8