### PR TITLE
feat(DIN-33): invite creation flow + 3 bug fixes

### DIFF
--- a/backend/api/routes/games.py
+++ b/backend/api/routes/games.py
@@ -11,7 +11,7 @@ router = APIRouter()
 class CreateGameInput(BaseModel):
     """Input for creating a new game."""
     name: str
-    dm_persona: str = "You are a creative and engaging Dungeon Master."
+    dm_persona: str = "A classic high-fantasy D&D adventure."
 
 
 class GameOut(BaseModel):
@@ -20,6 +20,7 @@ class GameOut(BaseModel):
     name: str
     dm_persona: str
     status: str
+    created_by: str
     created_at: str
 
 
@@ -32,7 +33,7 @@ async def create_game(
     result = (
         supabase_client.table("games")
         .insert({"name": payload.name, "dm_persona": payload.dm_persona, "created_by": current_user})
-        .select("id, name, dm_persona, status, created_at")
+        .select("id, name, dm_persona, status, created_by, created_at")
         .single()
         .execute()
     )
@@ -46,7 +47,7 @@ async def list_games(current_user: str = Depends(get_current_user)):
     """List all games created by the authenticated user."""
     result = (
         supabase_client.table("games")
-        .select("id, name, dm_persona, status, created_at")
+        .select("id, name, dm_persona, status, created_by, created_at")
         .eq("created_by", current_user)
         .order("created_at", desc=True)
         .execute()
@@ -59,7 +60,7 @@ async def get_game(game_id: str, current_user: str = Depends(get_current_user)):
     """Retrieve a single game by ID."""
     result = (
         supabase_client.table("games")
-        .select("id, name, dm_persona, status, created_at")
+        .select("id, name, dm_persona, status, created_by, created_at")
         .eq("id", game_id)
         .maybe_single()
         .execute()

--- a/backend/api/routes/invites.py
+++ b/backend/api/routes/invites.py
@@ -1,0 +1,58 @@
+"""Invite endpoints: generate invite codes for games."""
+import secrets
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from config import settings, supabase_client
+from api.dependencies import get_current_user
+
+router = APIRouter()
+
+
+class InviteOut(BaseModel):
+    """Invite response model."""
+    code: str
+    invite_url: str
+
+
+@router.post("/{game_id}/invites", response_model=InviteOut, status_code=201)
+async def create_invite(
+    game_id: str,
+    current_user: str = Depends(get_current_user),
+):
+    """Generate an invite code for a game. Only the game creator can do this."""
+    # Verify game exists and user is the creator
+    game_result = (
+        supabase_client.table("games")
+        .select("id, status, created_by")
+        .eq("id", game_id)
+        .maybe_single()
+        .execute()
+    )
+    if not game_result.data:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    game = game_result.data
+    if game["created_by"] != current_user:
+        raise HTTPException(status_code=403, detail="Only the game creator can generate invites")
+
+    if game["status"] != "lobby":
+        raise HTTPException(status_code=403, detail="Can only invite players when game is in lobby")
+
+    # Generate a URL-safe random code
+    code = secrets.token_urlsafe(16)
+
+    # Insert invite row (service role bypasses RLS)
+    insert_result = (
+        supabase_client.table("invites")
+        .insert({"code": code, "game_id": game_id})
+        .execute()
+    )
+    if not insert_result.data:
+        raise HTTPException(status_code=500, detail="Failed to create invite")
+
+    # Build the invite URL
+    # Use FRONTEND_URL env var, fall back to localhost for dev
+    frontend_url = getattr(settings, "FRONTEND_URL", "http://localhost:3000")
+    invite_url = f"{frontend_url}/auth/signup?code={code}"
+
+    return {"code": code, "invite_url": invite_url}

--- a/backend/api/routes/players.py
+++ b/backend/api/routes/players.py
@@ -92,22 +92,9 @@ async def upsert_player(
     if game["status"] != "lobby":
         raise HTTPException(status_code=403, detail="Game is not in lobby")
 
-    is_creator = game.get("created_by") == current_user
-    if not is_creator:
-        invite_result = (
-            supabase_client.table("invites")
-            .select("id")
-            .eq("game_id", game_id)
-            .eq("invitee_id", current_user)
-            .eq("status", "active")
-            .maybe_single()
-            .execute()
-        )
-        if not invite_result.data:
-            raise HTTPException(
-                status_code=403,
-                detail="You are not invited to this game"
-            )
+    # For MVP, any authenticated user can create a character in a lobby game.
+    # Invite validation happens at signup time (POST /api/auth/signup),
+    # not at character creation time.
 
     hp_max = calculate_hp_max(body.character_class, body.stats.con)
     stats_dict = body.stats.model_dump(by_alias=True)

--- a/backend/config.py
+++ b/backend/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     
     # Database
     DATABASE_URL: str  # Supabase Postgres connection string
+
+    # Frontend
+    FRONTEND_URL: str = "http://localhost:3000"
     
     # CORS
     ALLOWED_ORIGINS: List[str] = [

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from redis import Redis
 from config import settings
 from redis_broker import redis_broker, dramatiq_app
 from api.middleware import add_middleware
-from api.routes import games, players, actions
+from api.routes import games, players, actions, invites
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -36,6 +36,7 @@ add_middleware(app)
 app.include_router(games.router, prefix="/games", tags=["games"])
 app.include_router(players.router, prefix="/games", tags=["players"])
 app.include_router(actions.router, prefix="/games", tags=["actions"])
+app.include_router(invites.router, prefix="/games", tags=["invites"])
 
 @app.get("/health")
 async def health_check():

--- a/backend/tests/test_games_routes.py
+++ b/backend/tests/test_games_routes.py
@@ -31,7 +31,7 @@ class TestCreateGame:
         mock_result = MagicMock()
         mock_result.data = {
             **SAMPLE_GAME,
-            "dm_persona": "You are a creative and engaging Dungeon Master.",
+            "dm_persona": "A classic high-fantasy D&D adventure.",
         }
 
         with patch("api.routes.games.supabase_client") as mock_sb:

--- a/backend/tests/test_invites_route.py
+++ b/backend/tests/test_invites_route.py
@@ -1,0 +1,118 @@
+"""Tests for the invites API routes."""
+import pytest
+from unittest.mock import MagicMock, patch
+from tests.conftest import SAMPLE_GAME
+
+
+SAMPLE_INVITE = {
+    "id": "invite-uuid-1",
+    "code": "abc123def456ghi7",
+    "game_id": "game-uuid-1",
+    "created_at": "2026-04-05T10:00:00Z",
+    "used_at": None,
+}
+
+LOBBY_GAME = {**SAMPLE_GAME, "status": "lobby"}
+
+
+class TestCreateInvite:
+    """Tests for POST /games/{game_id}/invites."""
+
+    def test_create_invite_success(self, client):
+        """Should create an invite and return 201 with code and invite_url."""
+        mock_game_result = MagicMock()
+        mock_game_result.data = LOBBY_GAME
+
+        mock_insert_result = MagicMock()
+        mock_insert_result.data = [SAMPLE_INVITE]
+
+        with patch("api.routes.invites.supabase_client") as mock_sb:
+            mock_sb.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = mock_game_result
+            mock_sb.table.return_value.insert.return_value.execute.return_value = mock_insert_result
+
+            response = client.post("/games/game-uuid-1/invites")
+
+        assert response.status_code == 201
+        data = response.json()
+        assert "code" in data
+        assert "invite_url" in data
+
+    def test_create_invite_game_not_found(self, client):
+        """Should return 404 when game does not exist."""
+        mock_game_result = MagicMock()
+        mock_game_result.data = None
+
+        with patch("api.routes.invites.supabase_client") as mock_sb:
+            mock_sb.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = mock_game_result
+
+            response = client.post("/games/nonexistent-uuid/invites")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Game not found"
+
+    def test_create_invite_not_creator(self, client):
+        """Should return 403 when user is not the game creator."""
+        mock_game_result = MagicMock()
+        mock_game_result.data = {**LOBBY_GAME, "created_by": "other-user-uuid"}
+
+        with patch("api.routes.invites.supabase_client") as mock_sb:
+            mock_sb.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = mock_game_result
+
+            response = client.post("/games/game-uuid-1/invites")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Only the game creator can generate invites"
+
+    def test_create_invite_game_not_in_lobby(self, client):
+        """Should return 403 when game is not in lobby status."""
+        mock_game_result = MagicMock()
+        mock_game_result.data = {**SAMPLE_GAME, "status": "active"}
+
+        with patch("api.routes.invites.supabase_client") as mock_sb:
+            mock_sb.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = mock_game_result
+
+            response = client.post("/games/game-uuid-1/invites")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Can only invite players when game is in lobby"
+
+    def test_create_invite_db_failure(self, client):
+        """Should return 500 when database insert fails."""
+        mock_game_result = MagicMock()
+        mock_game_result.data = LOBBY_GAME
+
+        mock_insert_result = MagicMock()
+        mock_insert_result.data = None
+
+        with patch("api.routes.invites.supabase_client") as mock_sb:
+            mock_sb.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = mock_game_result
+            mock_sb.table.return_value.insert.return_value.execute.return_value = mock_insert_result
+
+            response = client.post("/games/game-uuid-1/invites")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to create invite"
+
+    def test_create_invite_unauthorized(self, unauthed_client):
+        """Should return 401 when no auth token is provided."""
+        response = unauthed_client.post("/games/game-uuid-1/invites")
+        assert response.status_code == 401
+
+    def test_invite_url_contains_code(self, client):
+        """The invite_url in the response should contain the generated code."""
+        mock_game_result = MagicMock()
+        mock_game_result.data = LOBBY_GAME
+
+        mock_insert_result = MagicMock()
+        mock_insert_result.data = [SAMPLE_INVITE]
+
+        with patch("api.routes.invites.supabase_client") as mock_sb:
+            mock_sb.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = mock_game_result
+            mock_sb.table.return_value.insert.return_value.execute.return_value = mock_insert_result
+
+            response = client.post("/games/game-uuid-1/invites")
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["code"] in data["invite_url"]
+        assert "/auth/signup?code=" in data["invite_url"]

--- a/frontend/e2e/invite-generation.spec.ts
+++ b/frontend/e2e/invite-generation.spec.ts
@@ -11,6 +11,9 @@ const MOCK_GAME = {
 
 test.describe('Invite generation (host flow)', () => {
   test.beforeEach(async ({ page }) => {
+    // Grant clipboard-write permission so handleCopy() resolves and shows 'Copied!'
+    await page.context().grantPermissions(['clipboard-write'])
+
     // Mock authenticated user
     await page.route('**/auth/v1/user', (route) => {
       route.fulfill({

--- a/frontend/e2e/invite-generation.spec.ts
+++ b/frontend/e2e/invite-generation.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test'
+
+const MOCK_GAME = {
+  id: 'game-123',
+  name: 'Dragon Quest',
+  dm_persona: 'A classic high-fantasy D&D adventure.',
+  status: 'lobby',
+  created_by: 'user-1',
+  created_at: '2026-04-05T00:00:00Z',
+}
+
+test.describe('Invite generation (host flow)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock authenticated user
+    await page.route('**/auth/v1/user', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'user-1',
+          email: 'host@example.com',
+        }),
+      })
+    })
+
+    // Mock auth token refresh
+    await page.route('**/auth/v1/token?grant_type=refresh_token', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'mock-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'mock-refresh',
+          user: { id: 'user-1', email: 'host@example.com' },
+        }),
+      })
+    })
+
+    // Mock Supabase REST API: game fetch
+    await page.route('**/rest/v1/games*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_GAME),
+      })
+    })
+
+    // Mock Supabase REST API: player fetch (no existing character)
+    await page.route('**/rest/v1/players*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(null),
+      })
+    })
+  })
+
+  test('happy path: generate invite link and copy it', async ({ page }) => {
+    // Mock the invite generation API route
+    await page.route('**/api/games/game-123/invites', (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 'abc123def456ghi7',
+            invite_url:
+              'http://localhost:3000/auth/signup?code=abc123def456ghi7',
+          }),
+        })
+      }
+    })
+
+    await page.goto('/games/game-123')
+
+    // InviteSection is shown for host in lobby
+    await expect(page.getByTestId('generate-invite-button')).toBeVisible()
+
+    // Click generate
+    await page.getByTestId('generate-invite-button').click()
+
+    // URL input should appear with the invite URL
+    await expect(page.getByTestId('invite-url-input')).toBeVisible()
+    await expect(page.getByTestId('invite-url-input')).toHaveValue(
+      'http://localhost:3000/auth/signup?code=abc123def456ghi7'
+    )
+
+    // Copy button should be visible
+    await expect(page.getByTestId('copy-button')).toBeVisible()
+
+    // Click copy (clipboard API may not work in headless, but button should respond)
+    await page.getByTestId('copy-button').click()
+    await expect(page.getByTestId('copy-button')).toHaveText('Copied!')
+  })
+
+  test('generate another link: resets UI to initial state', async ({
+    page,
+  }) => {
+    await page.route('**/api/games/game-123/invites', (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 'abc123def456ghi7',
+            invite_url:
+              'http://localhost:3000/auth/signup?code=abc123def456ghi7',
+          }),
+        })
+      }
+    })
+
+    await page.goto('/games/game-123')
+    await page.getByTestId('generate-invite-button').click()
+    await expect(page.getByTestId('invite-url-input')).toBeVisible()
+
+    // Click "Generate another link"
+    await page.getByTestId('generate-another-link').click()
+
+    // Should show the generate button again
+    await expect(page.getByTestId('generate-invite-button')).toBeVisible()
+    await expect(page.getByTestId('invite-url-input')).not.toBeVisible()
+    await expect(page.getByTestId('generate-another-link')).not.toBeVisible()
+  })
+
+  test('error state: shows error message on failure', async ({ page }) => {
+    await page.route('**/api/games/game-123/invites', (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 403,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: 'Only the game creator can generate invites',
+          }),
+        })
+      }
+    })
+
+    await page.goto('/games/game-123')
+    await page.getByTestId('generate-invite-button').click()
+
+    await expect(page.getByTestId('invite-error')).toBeVisible()
+    await expect(page.getByTestId('invite-error')).toContainText(
+      'Only the game creator can generate invites'
+    )
+  })
+})

--- a/frontend/src/app/api/auth/signup/route.ts
+++ b/frontend/src/app/api/auth/signup/route.ts
@@ -79,6 +79,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       )
     }
 
+    // Mark the invite as used (best-effort — signup already succeeded)
+    await supabase.rpc('mark_invite_used', { p_invite_code: invite_code })
+
     return NextResponse.json({ success: true }, { status: 201 })
   } catch {
     return NextResponse.json(

--- a/frontend/src/app/api/games/[gameId]/invites/route.ts
+++ b/frontend/src/app/api/games/[gameId]/invites/route.ts
@@ -1,0 +1,59 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ gameId: string }> }
+): Promise<NextResponse> {
+  try {
+    const cookieStore = await cookies()
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll()
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options)
+            })
+          },
+        },
+      }
+    )
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { gameId } = await params
+
+    const backendUrl =
+      process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'
+    const response = await fetch(`${backendUrl}/games/${gameId}/invites`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+    })
+
+    const responseText = await response.text()
+    return new NextResponse(responseText, {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/app/api/games/[gameId]/invites/route.ts
+++ b/frontend/src/app/api/games/[gameId]/invites/route.ts
@@ -45,11 +45,16 @@ export async function POST(
       },
     })
 
-    const responseText = await response.text()
-    return new NextResponse(responseText, {
-      status: response.status,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    if (!response.ok) {
+      const errorData = await response.json()
+      return NextResponse.json(
+        { error: errorData.detail || 'Failed to create invite' },
+        { status: response.status }
+      )
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data, { status: response.status })
   } catch {
     return NextResponse.json(
       { error: 'Internal server error' },

--- a/frontend/src/app/dashboard/__tests__/page.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/page.test.tsx
@@ -38,6 +38,7 @@ const sampleGame: Game = {
   name: 'Dragon Quest',
   dm_persona: 'A dark fantasy realm',
   status: 'lobby',
+  created_by: 'user-123',
   created_at: '2026-03-22T00:00:00Z',
 }
 

--- a/frontend/src/app/games/[gameId]/page.tsx
+++ b/frontend/src/app/games/[gameId]/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { fetchGameById } from '@/lib/supabase/games'
 import { getPlayer } from '@/lib/supabase/players'
 import { CharacterLobbyPanel } from '@/components/games/CharacterLobbyPanel'
+import { InviteSection } from '@/components/games/InviteSection'
 
 interface GamePageProps {
   params: Promise<{ gameId: string }>
@@ -43,6 +44,12 @@ export default async function GamePage({ params }: GamePageProps) {
             <span className="font-semibold capitalize">{game.status}</span>
           </p>
         </div>
+
+        {game.created_by === user.id && game.status === 'lobby' && (
+          <div className="mb-6">
+            <InviteSection gameId={gameId} />
+          </div>
+        )}
 
         <div className="rounded-lg bg-white p-6 shadow-sm">
           <h2 className="mb-4 text-xl font-semibold text-gray-900">

--- a/frontend/src/components/games/InviteSection.tsx
+++ b/frontend/src/components/games/InviteSection.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useState } from 'react'
+
+interface InviteSectionProps {
+  gameId: string
+}
+
+export function InviteSection({ gameId }: InviteSectionProps) {
+  const [inviteUrl, setInviteUrl] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [copied, setCopied] = useState(false)
+
+  async function handleGenerate() {
+    setLoading(true)
+    setError('')
+
+    try {
+      const response = await fetch(`/api/games/${gameId}/invites`, {
+        method: 'POST',
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        setError(data.error || 'Failed to generate invite')
+        return
+      }
+
+      const data = await response.json()
+      setInviteUrl(data.invite_url)
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(inviteUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback: select the text in the input
+    }
+  }
+
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm">
+      <h2 className="mb-4 text-xl font-semibold text-gray-900">
+        Invite Players
+      </h2>
+
+      {!inviteUrl ? (
+        <div>
+          <p className="mb-4 text-sm text-gray-600">
+            Generate an invite link to share with your players. Each link is
+            single-use.
+          </p>
+          <button
+            data-testid="generate-invite-button"
+            onClick={handleGenerate}
+            disabled={loading}
+            className="rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:bg-gray-400"
+          >
+            {loading ? 'Generating...' : 'Generate Invite Link'}
+          </button>
+        </div>
+      ) : (
+        <div>
+          <p className="mb-2 text-sm text-gray-600">
+            Share this link with a player:
+          </p>
+          <div className="flex gap-2">
+            <input
+              data-testid="invite-url-input"
+              type="text"
+              readOnly
+              value={inviteUrl}
+              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm text-gray-700"
+            />
+            <button
+              data-testid="copy-button"
+              onClick={handleCopy}
+              className="rounded bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+          <button
+            data-testid="generate-another-link"
+            onClick={() => {
+              setInviteUrl('')
+              setCopied(false)
+            }}
+            className="mt-3 text-sm text-blue-600 hover:text-blue-800"
+          >
+            Generate another link
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div
+          data-testid="invite-error"
+          className="mt-3 rounded bg-red-50 p-3 text-sm text-red-800"
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/games/__tests__/InviteSection.test.tsx
+++ b/frontend/src/components/games/__tests__/InviteSection.test.tsx
@@ -1,0 +1,327 @@
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { InviteSection } from '../InviteSection'
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+const mockWriteText = jest.fn().mockResolvedValue(undefined)
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: mockWriteText },
+  writable: true,
+  configurable: true,
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe('InviteSection', () => {
+  describe('rendering', () => {
+    it('renders the "Generate Invite Link" button', () => {
+      render(<InviteSection gameId="game-1" />)
+      expect(screen.getByTestId('generate-invite-button')).toBeInTheDocument()
+      expect(screen.getByTestId('generate-invite-button')).toHaveTextContent(
+        'Generate Invite Link'
+      )
+    })
+
+    it('does not show invite URL input initially', () => {
+      render(<InviteSection gameId="game-1" />)
+      expect(screen.queryByTestId('invite-url-input')).not.toBeInTheDocument()
+    })
+
+    it('does not show error initially', () => {
+      render(<InviteSection gameId="game-1" />)
+      expect(screen.queryByTestId('invite-error')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('successful generation', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            code: 'abc123',
+            invite_url: 'http://localhost:3000/auth/signup?code=abc123',
+          }),
+      })
+    })
+
+    it('calls POST /api/games/{gameId}/invites on button click', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-42" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith('/api/games/game-42/invites', {
+          method: 'POST',
+        })
+      })
+    })
+
+    it('shows invite URL input after success', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('invite-url-input')).toBeInTheDocument()
+        expect(screen.getByTestId('invite-url-input')).toHaveValue(
+          'http://localhost:3000/auth/signup?code=abc123'
+        )
+      })
+    })
+
+    it('shows Copy button after success', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('copy-button')).toBeInTheDocument()
+        expect(screen.getByTestId('copy-button')).toHaveTextContent('Copy')
+      })
+    })
+
+    it('shows "Generate another link" after success', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('generate-another-link')).toBeInTheDocument()
+      })
+    })
+
+    it('hides the generate button after success', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('generate-invite-button')
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('copy to clipboard', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            code: 'abc123',
+            invite_url: 'http://localhost:3000/auth/signup?code=abc123',
+          }),
+      })
+    })
+
+    it('calls navigator.clipboard.writeText with invite URL', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      // Spy after userEvent.setup() which may install its own clipboard stub
+      const writeTextSpy = jest
+        .spyOn(navigator.clipboard, 'writeText')
+        .mockResolvedValue(undefined)
+
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+      await waitFor(() => screen.getByTestId('copy-button'))
+
+      await user.click(screen.getByTestId('copy-button'))
+
+      await waitFor(() => {
+        expect(writeTextSpy).toHaveBeenCalledWith(
+          'http://localhost:3000/auth/signup?code=abc123'
+        )
+      })
+
+      writeTextSpy.mockRestore()
+    })
+
+    it('shows "Copied!" text after copy', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+      await waitFor(() => screen.getByTestId('copy-button'))
+
+      await user.click(screen.getByTestId('copy-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('copy-button')).toHaveTextContent('Copied!')
+      })
+    })
+
+    it('resets "Copied!" text back to "Copy" after 2 seconds', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+      await waitFor(() => screen.getByTestId('copy-button'))
+
+      await user.click(screen.getByTestId('copy-button'))
+      await waitFor(() =>
+        expect(screen.getByTestId('copy-button')).toHaveTextContent('Copied!')
+      )
+
+      act(() => jest.advanceTimersByTime(2000))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('copy-button')).toHaveTextContent('Copy')
+      })
+    })
+  })
+
+  describe('generate another link', () => {
+    it('resets UI to initial state when "Generate another link" is clicked', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            code: 'abc123',
+            invite_url: 'http://localhost:3000/auth/signup?code=abc123',
+          }),
+      })
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+      await waitFor(() => screen.getByTestId('generate-another-link'))
+
+      await user.click(screen.getByTestId('generate-another-link'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('generate-invite-button')).toBeInTheDocument()
+        expect(
+          screen.queryByTestId('invite-url-input')
+        ).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId('generate-another-link')
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('error handling', () => {
+    it('shows error message from server', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        json: () =>
+          Promise.resolve({ error: 'Only the game creator can generate invites' }),
+      })
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('invite-error')).toBeInTheDocument()
+        expect(screen.getByTestId('invite-error')).toHaveTextContent(
+          'Only the game creator can generate invites'
+        )
+      })
+    })
+
+    it('shows fallback error when server returns no error message', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({}),
+      })
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('invite-error')).toHaveTextContent(
+          'Failed to generate invite'
+        )
+      })
+    })
+
+    it('shows network error message when fetch throws', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'))
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('invite-error')).toHaveTextContent(
+          'Network error. Please try again.'
+        )
+      })
+    })
+
+    it('re-enables the button after an error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Server error' }),
+      })
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('generate-invite-button')).not.toBeDisabled()
+      })
+    })
+  })
+
+  describe('loading state', () => {
+    it('disables the button while loading', async () => {
+      let resolveFetch: (value: unknown) => void
+      mockFetch.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+      )
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<InviteSection gameId="game-1" />)
+
+      await user.click(screen.getByTestId('generate-invite-button'))
+
+      expect(screen.getByTestId('generate-invite-button')).toBeDisabled()
+      expect(screen.getByTestId('generate-invite-button')).toHaveTextContent(
+        'Generating...'
+      )
+
+      resolveFetch!({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            code: 'abc123',
+            invite_url: 'http://localhost:3000/auth/signup?code=abc123',
+          }),
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('generate-invite-button')
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/frontend/src/lib/supabase/__tests__/games.test.ts
+++ b/frontend/src/lib/supabase/__tests__/games.test.ts
@@ -26,6 +26,7 @@ const sampleGame: Game = {
   name: 'Dragon Quest',
   dm_persona: 'A dark fantasy realm',
   status: 'lobby',
+  created_by: 'user-1',
   created_at: '2026-03-22T00:00:00Z',
 }
 
@@ -34,6 +35,7 @@ const sampleGame2: Game = {
   name: 'Sword Coast',
   dm_persona: 'High fantasy adventure',
   status: 'active',
+  created_by: 'user-1',
   created_at: '2026-03-23T00:00:00Z',
 }
 
@@ -60,7 +62,7 @@ describe('fetchGamesByUserId', () => {
 
     expect(mockFrom).toHaveBeenCalledWith('games')
     expect(mockSelect).toHaveBeenCalledWith(
-      'id, name, dm_persona, status, created_at'
+      'id, name, dm_persona, status, created_by, created_at'
     )
     expect(mockEq).toHaveBeenCalledWith('created_by', 'user-xyz')
     expect(mockOrder).toHaveBeenCalledWith('created_at', { ascending: false })
@@ -139,7 +141,7 @@ describe('createGame', () => {
     })
 
     expect(mockSelect).toHaveBeenCalledWith(
-      'id, name, dm_persona, status, created_at'
+      'id, name, dm_persona, status, created_by, created_at'
     )
   })
 
@@ -222,7 +224,7 @@ describe('fetchGameById', () => {
     await fetchGameById('game-1')
 
     expect(mockSelect).toHaveBeenCalledWith(
-      'id, name, dm_persona, status, created_at'
+      'id, name, dm_persona, status, created_by, created_at'
     )
   })
 })

--- a/frontend/src/lib/supabase/games.ts
+++ b/frontend/src/lib/supabase/games.ts
@@ -5,6 +5,7 @@ export type Game = {
   name: string
   dm_persona: string
   status: string
+  created_by: string
   created_at: string
 }
 
@@ -19,7 +20,7 @@ export async function fetchGamesByUserId(userId: string): Promise<Game[]> {
 
   const { data, error } = await supabase
     .from('games')
-    .select('id, name, dm_persona, status, created_at')
+    .select('id, name, dm_persona, status, created_by, created_at')
     .eq('created_by', userId)
     .order('created_at', { ascending: false })
 
@@ -40,7 +41,7 @@ export async function createGame(input: CreateGameInput): Promise<Game> {
       dm_persona: input.dm_persona,
       created_by: input.host_id,
     })
-    .select('id, name, dm_persona, status, created_at')
+    .select('id, name, dm_persona, status, created_by, created_at')
     .single()
 
   if (error) {
@@ -55,7 +56,7 @@ export async function fetchGameById(gameId: string): Promise<Game | null> {
 
   const { data, error } = await supabase
     .from('games')
-    .select('id, name, dm_persona, status, created_at')
+    .select('id, name, dm_persona, status, created_by, created_at')
     .eq('id', gameId)
     .maybeSingle()
 

--- a/supabase/migrations/20260405000001_mark_invite_used.sql
+++ b/supabase/migrations/20260405000001_mark_invite_used.sql
@@ -1,0 +1,17 @@
+-- RPC to mark an invite code as used after successful signup.
+-- Uses security definer (same pattern as validate_invite_code)
+-- so it works even for users who just signed up and don't have
+-- RLS permissions on the invites table yet.
+create or replace function public.mark_invite_used(p_invite_code text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.invites
+  set used_at = now()
+  where code = p_invite_code
+    and used_at is null;
+end;
+$$;


### PR DESCRIPTION
Bug fixes:
- Remove broken invite auth check in players.py that referenced
  nonexistent invitee_id/status columns on the invites table
- Add created_by to Game/GameOut types and all .select() calls in
  both frontend (games.ts) and backend (games.py)
- Fix backend DM persona default to match frontend default value

Features:
- POST /games/{game_id}/invites endpoint (creator + lobby checks,
  secrets.token_urlsafe, returns {code, invite_url})
- FRONTEND_URL setting in backend config
- Frontend proxy route api/games/[gameId]/invites/route.ts
- InviteSection component with generate/copy/reset UI and data-testid attrs
- Game lobby page renders InviteSection for host in lobby state only
- Signup route calls mark_invite_used RPC after successful signup
- mark_invite_used SQL migration (security definer RPC)

Tests:
- 7 pytest cases for POST /games/{game_id}/invites
- Updated test_games_routes.py default persona assertion
- Updated games.test.ts fixtures + 3 select column assertions
- 16 Jest/RTL cases for InviteSection component
- 3 Playwright E2E cases for invite generation flow

Results: 70/70 backend, 124/124 frontend unit tests passing

https://claude.ai/code/session_01H6XZnzW8bgSztji4VVakTt