### PR TITLE
fix(dashboard-test): correct TS2352 cast in mockSupabaseWithUser

### DIFF
--- a/frontend/src/app/dashboard/__tests__/page.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/page.test.tsx
@@ -30,7 +30,7 @@ function mockSupabaseWithUser(user: { id: string } | null) {
     auth: {
       getUser: jest.fn().mockResolvedValue({ data: { user } }),
     },
-  } as ReturnType<typeof createClient> extends Promise<infer T> ? Promise<T> : never)
+  } as unknown as Awaited<ReturnType<typeof createClient>>)
 }
 
 const sampleGame: Game = {


### PR DESCRIPTION
Replace the broken Promise-level cast with `as unknown as Awaited<ReturnType<typeof createClient>>` so mockResolvedValue receives the correctly typed resolved value, eliminating the TS2352 overlap error.

https://claude.ai/code/session_01W5Zcej5QonJZBhuDLSwh23