### PR TITLE
feat(DIN-34, DIN-35): add inventory backend + frontend

### DIFF
--- a/backend/api/routes/players.py
+++ b/backend/api/routes/players.py
@@ -1,9 +1,13 @@
 """Players endpoints: create and manage player characters."""
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
 from config import supabase_client
 from api.dependencies import get_current_user
-from utils.dnd import calculate_hp_max
+from utils.dnd import calculate_hp_max, CLASS_STARTING_INVENTORY
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -120,4 +124,55 @@ async def upsert_player(
     if not upsert_result.data:
         raise HTTPException(status_code=500, detail="Failed to upsert player")
 
+    # Populate starting inventory (best-effort — failure should not block the upsert)
+    try:
+        player_id = upsert_result.data["id"]
+        # Delete any existing inventory for this player (handles class changes)
+        supabase_client.table("player_inventory").delete().eq(
+            "player_id", player_id
+        ).execute()
+        # Insert new starting inventory for the selected class
+        starting_items = CLASS_STARTING_INVENTORY.get(body.character_class, [])
+        if starting_items:
+            rows = [
+                {"player_id": player_id, "item_name": item["item_name"], "quantity": item["quantity"]}
+                for item in starting_items
+            ]
+            supabase_client.table("player_inventory").insert(rows).execute()
+    except Exception as e:
+        logger.warning("Failed to populate inventory for player %s: %s", upsert_result.data.get("id"), e)
+
     return upsert_result.data
+
+
+@router.get("/{game_id}/players/inventory")
+async def get_player_inventory(
+    game_id: str,
+    current_user: str = Depends(get_current_user),
+):
+    """Get inventory items for the current player in a game."""
+    # Find the player for this user in this game
+    player_result = (
+        supabase_client.table("players")
+        .select("id")
+        .eq("game_id", game_id)
+        .eq("profile_id", current_user)
+        .maybe_single()
+        .execute()
+    )
+
+    if not player_result.data:
+        return []
+
+    player_id = player_result.data["id"]
+
+    # Fetch inventory items
+    inventory_result = (
+        supabase_client.table("player_inventory")
+        .select("id, player_id, item_name, quantity, properties, created_at")
+        .eq("player_id", player_id)
+        .order("item_name")
+        .execute()
+    )
+
+    return inventory_result.data or []

--- a/backend/tests/test_players_inventory.py
+++ b/backend/tests/test_players_inventory.py
@@ -1,0 +1,168 @@
+"""Tests for player inventory population and read endpoint."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+SAMPLE_GAME_LOBBY = {
+    "id": "game-uuid-1",
+    "name": "Dragon's Lair",
+    "dm_persona": "A dark and mysterious DM.",
+    "status": "lobby",
+    "created_at": "2026-03-22T10:00:00Z",
+    "created_by": "test-user-uuid-1234",
+}
+
+SAMPLE_UPSERT_RESULT = {
+    "id": "player-uuid-1",
+    "game_id": "game-uuid-1",
+    "profile_id": "test-user-uuid-1234",
+    "character_name": "Thorin",
+    "character_class": "Fighter",
+    "hp_current": 12,
+    "hp_max": 12,
+    "stats": {"str": 16, "dex": 12, "con": 14, "int": 10, "wis": 10, "cha": 8},
+    "status": "active",
+    "joined_at": "2026-03-22T10:00:00Z",
+}
+
+SAMPLE_INVENTORY = [
+    {"id": "inv-1", "player_id": "player-uuid-1", "item_name": "Chain Mail", "quantity": 1, "properties": None, "created_at": "2026-03-22T10:00:00Z"},
+    {"id": "inv-2", "player_id": "player-uuid-1", "item_name": "Explorer's Pack", "quantity": 1, "properties": None, "created_at": "2026-03-22T10:00:00Z"},
+    {"id": "inv-3", "player_id": "player-uuid-1", "item_name": "Handaxe", "quantity": 5, "properties": None, "created_at": "2026-03-22T10:00:00Z"},
+    {"id": "inv-4", "player_id": "player-uuid-1", "item_name": "Longsword", "quantity": 1, "properties": None, "created_at": "2026-03-22T10:00:00Z"},
+    {"id": "inv-5", "player_id": "player-uuid-1", "item_name": "Shield", "quantity": 1, "properties": None, "created_at": "2026-03-22T10:00:00Z"},
+]
+
+PLAYER_POST_BODY = {
+    "character_name": "Thorin",
+    "character_class": "Fighter",
+    "stats": {"str": 16, "dex": 12, "con": 14, "int": 10, "wis": 10, "cha": 8},
+}
+
+
+def _make_table_router(games_mock, players_mock, inventory_mock):
+    """Return a side_effect function that routes table() calls by name."""
+    def table_router(name):
+        return {"games": games_mock, "players": players_mock, "player_inventory": inventory_mock}[name]
+    return table_router
+
+
+class TestInventoryPopulation:
+    """Tests for inventory population during player upsert."""
+
+    def test_upsert_player_populates_inventory_for_fighter(self, client):
+        """Should delete old inventory and insert Fighter starting items after upsert."""
+        # Games table mock
+        games_mock = MagicMock()
+        game_result = MagicMock()
+        game_result.data = SAMPLE_GAME_LOBBY
+        games_mock.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = game_result
+
+        # Players table mock
+        players_mock = MagicMock()
+        upsert_result = MagicMock()
+        upsert_result.data = SAMPLE_UPSERT_RESULT
+        players_mock.upsert.return_value.select.return_value.single.return_value.execute.return_value = upsert_result
+
+        # Inventory table mock
+        inventory_mock = MagicMock()
+        delete_result = MagicMock()
+        delete_result.data = []
+        inventory_mock.delete.return_value.eq.return_value.execute.return_value = delete_result
+        insert_result = MagicMock()
+        insert_result.data = SAMPLE_INVENTORY
+        inventory_mock.insert.return_value.execute.return_value = insert_result
+
+        with patch("api.routes.players.supabase_client") as mock_sb:
+            mock_sb.table.side_effect = _make_table_router(games_mock, players_mock, inventory_mock)
+
+            response = client.post("/games/game-uuid-1/players", json=PLAYER_POST_BODY)
+
+        assert response.status_code == 200
+        assert response.json()["character_class"] == "Fighter"
+
+        # Verify inventory delete was called
+        inventory_mock.delete.assert_called_once()
+        # Verify inventory insert was called with 5 Fighter items
+        inventory_mock.insert.assert_called_once()
+        inserted_rows = inventory_mock.insert.call_args[0][0]
+        assert len(inserted_rows) == 5
+        item_names = {row["item_name"] for row in inserted_rows}
+        assert "Longsword" in item_names
+        assert "Shield" in item_names
+        assert "Chain Mail" in item_names
+
+    def test_upsert_player_inventory_failure_does_not_crash(self, client):
+        """Inventory population failure should not prevent player upsert from succeeding."""
+        # Games table mock
+        games_mock = MagicMock()
+        game_result = MagicMock()
+        game_result.data = SAMPLE_GAME_LOBBY
+        games_mock.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = game_result
+
+        # Players table mock
+        players_mock = MagicMock()
+        upsert_result = MagicMock()
+        upsert_result.data = SAMPLE_UPSERT_RESULT
+        players_mock.upsert.return_value.select.return_value.single.return_value.execute.return_value = upsert_result
+
+        # Inventory table mock — delete raises an exception
+        inventory_mock = MagicMock()
+        inventory_mock.delete.return_value.eq.return_value.execute.side_effect = Exception("DB error")
+
+        with patch("api.routes.players.supabase_client") as mock_sb:
+            mock_sb.table.side_effect = _make_table_router(games_mock, players_mock, inventory_mock)
+
+            response = client.post("/games/game-uuid-1/players", json=PLAYER_POST_BODY)
+
+        # Should still succeed — inventory is best-effort
+        assert response.status_code == 200
+        assert response.json()["character_name"] == "Thorin"
+
+
+class TestGetPlayerInventory:
+    """Tests for GET /games/{game_id}/players/inventory."""
+
+    def test_get_inventory_success(self, client):
+        """Should return inventory items for the current player."""
+        # Players table mock
+        players_mock = MagicMock()
+        player_result = MagicMock()
+        player_result.data = {"id": "player-uuid-1"}
+        players_mock.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value = player_result
+
+        # Inventory table mock
+        inventory_mock = MagicMock()
+        inv_result = MagicMock()
+        inv_result.data = SAMPLE_INVENTORY
+        inventory_mock.select.return_value.eq.return_value.order.return_value.execute.return_value = inv_result
+
+        with patch("api.routes.players.supabase_client") as mock_sb:
+            mock_sb.table.side_effect = lambda name: {"players": players_mock, "player_inventory": inventory_mock}[name]
+
+            response = client.get("/games/game-uuid-1/players/inventory")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 5
+        assert data[0]["item_name"] == "Chain Mail"
+
+    def test_get_inventory_no_player_returns_empty(self, client):
+        """Should return empty array when player not found in game."""
+        players_mock = MagicMock()
+        player_result = MagicMock()
+        player_result.data = None
+        players_mock.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value = player_result
+
+        with patch("api.routes.players.supabase_client") as mock_sb:
+            mock_sb.table.side_effect = lambda name: {"players": players_mock}[name]
+
+            response = client.get("/games/game-uuid-1/players/inventory")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_inventory_unauthorized(self, unauthed_client):
+        """Should return 401 when no auth token is provided."""
+        response = unauthed_client.get("/games/game-uuid-1/players/inventory")
+        assert response.status_code == 401

--- a/backend/utils/dnd.py
+++ b/backend/utils/dnd.py
@@ -15,6 +15,89 @@ HIT_DIE: dict[str, int] = {
     "Wizard": 6,
 }
 
+CLASS_STARTING_INVENTORY: dict[str, list[dict]] = {
+    "Fighter": [
+        {"item_name": "Longsword", "quantity": 1},
+        {"item_name": "Shield", "quantity": 1},
+        {"item_name": "Chain Mail", "quantity": 1},
+        {"item_name": "Explorer's Pack", "quantity": 1},
+        {"item_name": "Handaxe", "quantity": 5},
+    ],
+    "Wizard": [
+        {"item_name": "Spellbook", "quantity": 1},
+        {"item_name": "Arcane Focus (Staff)", "quantity": 1},
+        {"item_name": "Scholar's Pack", "quantity": 1},
+        {"item_name": "Dagger", "quantity": 1},
+    ],
+    "Rogue": [
+        {"item_name": "Shortsword", "quantity": 1},
+        {"item_name": "Shortbow", "quantity": 1},
+        {"item_name": "Arrows", "quantity": 20},
+        {"item_name": "Leather Armor", "quantity": 1},
+        {"item_name": "Thieves' Tools", "quantity": 1},
+        {"item_name": "Burglar's Pack", "quantity": 1},
+    ],
+    "Cleric": [
+        {"item_name": "Mace", "quantity": 1},
+        {"item_name": "Scale Mail", "quantity": 1},
+        {"item_name": "Shield", "quantity": 1},
+        {"item_name": "Holy Symbol", "quantity": 1},
+        {"item_name": "Priest's Pack", "quantity": 1},
+    ],
+    "Ranger": [
+        {"item_name": "Longbow", "quantity": 1},
+        {"item_name": "Arrows", "quantity": 20},
+        {"item_name": "Shortsword", "quantity": 1},
+        {"item_name": "Leather Armor", "quantity": 1},
+        {"item_name": "Explorer's Pack", "quantity": 1},
+    ],
+    "Barbarian": [
+        {"item_name": "Greataxe", "quantity": 1},
+        {"item_name": "Handaxe", "quantity": 2},
+        {"item_name": "Explorer's Pack", "quantity": 1},
+        {"item_name": "Javelin", "quantity": 4},
+    ],
+    "Paladin": [
+        {"item_name": "Longsword", "quantity": 1},
+        {"item_name": "Shield", "quantity": 1},
+        {"item_name": "Chain Mail", "quantity": 1},
+        {"item_name": "Holy Symbol", "quantity": 1},
+        {"item_name": "Explorer's Pack", "quantity": 1},
+    ],
+    "Druid": [
+        {"item_name": "Quarterstaff", "quantity": 1},
+        {"item_name": "Leather Armor", "quantity": 1},
+        {"item_name": "Druidic Focus", "quantity": 1},
+        {"item_name": "Explorer's Pack", "quantity": 1},
+    ],
+    "Bard": [
+        {"item_name": "Rapier", "quantity": 1},
+        {"item_name": "Leather Armor", "quantity": 1},
+        {"item_name": "Lute", "quantity": 1},
+        {"item_name": "Diplomat's Pack", "quantity": 1},
+        {"item_name": "Dagger", "quantity": 1},
+    ],
+    "Monk": [
+        {"item_name": "Shortsword", "quantity": 1},
+        {"item_name": "Dungeoneer's Pack", "quantity": 1},
+        {"item_name": "Dart", "quantity": 10},
+    ],
+    "Sorcerer": [
+        {"item_name": "Light Crossbow", "quantity": 1},
+        {"item_name": "Bolts", "quantity": 20},
+        {"item_name": "Arcane Focus (Crystal)", "quantity": 1},
+        {"item_name": "Dungeoneer's Pack", "quantity": 1},
+        {"item_name": "Dagger", "quantity": 1},
+    ],
+    "Warlock": [
+        {"item_name": "Light Crossbow", "quantity": 1},
+        {"item_name": "Bolts", "quantity": 20},
+        {"item_name": "Arcane Focus (Wand)", "quantity": 1},
+        {"item_name": "Scholar's Pack", "quantity": 1},
+        {"item_name": "Dagger", "quantity": 1},
+    ],
+}
+
 
 def calculate_hp_max(character_class: str, con: int) -> int:
     """Return level-1 HP max per SRD 5e rules.

--- a/frontend/e2e/inventory.spec.ts
+++ b/frontend/e2e/inventory.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from '@playwright/test'
+
+const MOCK_GAME = {
+  id: 'game-123',
+  name: 'Dragon Quest',
+  dm_persona: 'A classic high-fantasy D&D adventure.',
+  status: 'lobby',
+  created_by: 'user-1',
+  created_at: '2026-04-05T00:00:00Z',
+}
+
+const MOCK_PLAYER = {
+  id: 'player-1',
+  game_id: 'game-123',
+  profile_id: 'user-1',
+  character_name: 'Thorin',
+  character_class: 'Fighter',
+  hp_current: 12,
+  hp_max: 12,
+  stats: { str: 16, dex: 12, con: 14, int: 10, wis: 10, cha: 8 },
+  status: 'active',
+  joined_at: '2026-04-05T00:00:00Z',
+}
+
+const MOCK_INVENTORY_FIGHTER = [
+  { id: 'inv-1', item_name: 'Chain Mail', quantity: 1, properties: null, created_at: '2026-04-05T00:00:00Z' },
+  { id: 'inv-2', item_name: "Explorer's Pack", quantity: 1, properties: null, created_at: '2026-04-05T00:00:00Z' },
+  { id: 'inv-3', item_name: 'Handaxe', quantity: 5, properties: null, created_at: '2026-04-05T00:00:00Z' },
+  { id: 'inv-4', item_name: 'Longsword', quantity: 1, properties: null, created_at: '2026-04-05T00:00:00Z' },
+  { id: 'inv-5', item_name: 'Shield', quantity: 1, properties: null, created_at: '2026-04-05T00:00:00Z' },
+]
+
+function setupAuthMocks(page: import('@playwright/test').Page) {
+  return Promise.all([
+    page.route('**/auth/v1/user', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'user-1',
+          email: 'player@example.com',
+        }),
+      })
+    }),
+    page.route('**/auth/v1/token?grant_type=refresh_token', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'mock-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'mock-refresh',
+          user: { id: 'user-1', email: 'player@example.com' },
+        }),
+      })
+    }),
+  ])
+}
+
+test.describe('Inventory display', () => {
+  test('no character — no inventory panel visible', async ({ page }) => {
+    await setupAuthMocks(page)
+
+    await page.route('**/rest/v1/games*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_GAME),
+      })
+    })
+
+    await page.route('**/rest/v1/players*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(null),
+      })
+    })
+
+    await page.route('**/rest/v1/player_inventory*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    })
+
+    await page.goto('/games/game-123')
+
+    // Character panel should be visible but inventory should not
+    await expect(page.getByText('Your Character')).toBeVisible()
+    await expect(page.getByTestId('inventory-panel')).not.toBeVisible()
+  })
+
+  test('character exists with inventory — items displayed', async ({ page }) => {
+    await setupAuthMocks(page)
+
+    await page.route('**/rest/v1/games*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_GAME),
+      })
+    })
+
+    await page.route('**/rest/v1/players*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_PLAYER),
+      })
+    })
+
+    await page.route('**/rest/v1/player_inventory*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_INVENTORY_FIGHTER),
+      })
+    })
+
+    await page.goto('/games/game-123')
+
+    // Inventory panel should be visible
+    await expect(page.getByTestId('inventory-panel')).toBeVisible()
+    await expect(page.getByText(/Starting Equipment/)).toBeVisible()
+
+    // All items should be rendered
+    const items = page.getByTestId('inventory-item')
+    await expect(items).toHaveCount(5)
+
+    // Verify specific items
+    await expect(page.getByText('Longsword')).toBeVisible()
+    await expect(page.getByText('Chain Mail')).toBeVisible()
+    await expect(page.getByText('×5')).toBeVisible()
+
+    // Item count badge
+    await expect(page.getByTestId('inventory-count')).toHaveText('5 items')
+  })
+
+  test('character exists but empty inventory — empty state', async ({ page }) => {
+    await setupAuthMocks(page)
+
+    await page.route('**/rest/v1/games*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_GAME),
+      })
+    })
+
+    await page.route('**/rest/v1/players*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_PLAYER),
+      })
+    })
+
+    await page.route('**/rest/v1/player_inventory*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    })
+
+    await page.goto('/games/game-123')
+
+    // Inventory panel should be visible with empty state
+    await expect(page.getByTestId('inventory-panel')).toBeVisible()
+    await expect(page.getByTestId('inventory-empty')).toBeVisible()
+    await expect(page.getByText(/No items yet/)).toBeVisible()
+  })
+})

--- a/frontend/src/app/games/[gameId]/page.tsx
+++ b/frontend/src/app/games/[gameId]/page.tsx
@@ -1,9 +1,10 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { fetchGameById } from '@/lib/supabase/games'
-import { getPlayer } from '@/lib/supabase/players'
+import { getPlayer, getPlayerInventory } from '@/lib/supabase/players'
 import { CharacterLobbyPanel } from '@/components/games/CharacterLobbyPanel'
 import { InviteSection } from '@/components/games/InviteSection'
+import { InventoryPanel } from '@/components/games/InventoryPanel'
 
 interface GamePageProps {
   params: Promise<{ gameId: string }>
@@ -21,9 +22,10 @@ export default async function GamePage({ params }: GamePageProps) {
     redirect('/auth/login')
   }
 
-  const [game, player] = await Promise.all([
+  const [game, player, inventory] = await Promise.all([
     fetchGameById(gameId),
     getPlayer(gameId, user.id),
+    getPlayerInventory(gameId, user.id),
   ])
 
   if (!game) {
@@ -61,6 +63,16 @@ export default async function GamePage({ params }: GamePageProps) {
             initialPlayer={player}
           />
         </div>
+
+        {player?.character_name && (
+          <div className="mt-4">
+            <InventoryPanel items={inventory.map(i => ({
+              id: i.id,
+              item_name: i.item_name,
+              quantity: i.quantity,
+            }))} />
+          </div>
+        )}
       </div>
     </main>
   )

--- a/frontend/src/components/games/CharacterLobbyPanel.tsx
+++ b/frontend/src/components/games/CharacterLobbyPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { CharacterCreationForm } from './CharacterCreationForm'
 import { CharacterSummaryCard } from './CharacterSummaryCard'
 import type { PlayerRow } from '@/lib/types/player'
@@ -17,12 +18,14 @@ export function CharacterLobbyPanel({
   gameStatus,
   initialPlayer,
 }: CharacterLobbyPanelProps) {
+  const router = useRouter()
   const [player, setPlayer] = useState<PlayerRow | null>(initialPlayer)
   const [isEditing, setIsEditing] = useState(!initialPlayer?.character_name)
 
   const handleSuccess = (updatedPlayer: PlayerRow) => {
-    setPlayer(updatedPlayer)
+    setPlayer(updatedPlayer)   // optimistic: character summary shows immediately
     setIsEditing(false)
+    router.refresh()           // re-fetches server data so InventoryPanel appears
   }
 
   const handleEdit = () => {

--- a/frontend/src/components/games/InventoryPanel.tsx
+++ b/frontend/src/components/games/InventoryPanel.tsx
@@ -1,0 +1,97 @@
+export type InventoryItem = {
+  id: string
+  item_name: string
+  quantity: number
+}
+
+interface InventoryPanelProps {
+  items: InventoryItem[]
+}
+
+export function InventoryPanel({ items }: InventoryPanelProps) {
+  if (items.length === 0) {
+    return (
+      <div className="dnd-card p-6" data-testid="inventory-panel">
+        <div className="text-center py-4" data-testid="inventory-empty">
+          <span className="text-2xl">🎒</span>
+          <p
+            className="dnd-subheading mt-2"
+            style={{ fontStyle: 'italic' }}
+          >
+            No items yet — create a character to receive starting equipment.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const sorted = [...items].sort((a, b) => a.item_name.localeCompare(b.item_name))
+
+  return (
+    <div className="dnd-card p-6" data-testid="inventory-panel">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="dnd-heading text-lg">⚔ Starting Equipment</h3>
+        <span
+          className="dnd-badge dnd-badge-lobby"
+          data-testid="inventory-count"
+        >
+          {items.length} {items.length === 1 ? 'item' : 'items'}
+        </span>
+      </div>
+
+      {/* Subtitle */}
+      <p
+        className="dnd-subheading text-sm mt-1"
+        style={{ fontStyle: 'italic' }}
+      >
+        Your gear for the adventure ahead
+      </p>
+
+      {/* Divider */}
+      <hr className="dnd-divider" />
+
+      {/* Item list */}
+      <ul role="list" className="space-y-2">
+        {sorted.map((item) => (
+          <li
+            key={item.id}
+            className="flex items-center justify-between"
+            data-testid="inventory-item"
+          >
+            <span
+              style={{
+                fontFamily: "'Lora', Georgia, serif",
+                color: 'var(--dnd-parchment)',
+              }}
+            >
+              {item.item_name}
+            </span>
+            <span
+              className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
+              style={{
+                background: item.quantity > 1
+                  ? 'var(--dnd-gold)'
+                  : 'var(--dnd-gold-dim)',
+                color: 'var(--dnd-black)',
+              }}
+            >
+              ×{item.quantity}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {/* Footer note */}
+      <p
+        className="mt-4 text-xs"
+        style={{
+          fontStyle: 'italic',
+          color: 'var(--dnd-parchment-dim)',
+        }}
+      >
+        Inventory updates after page refresh when class changes
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/games/__tests__/InventoryPanel.test.tsx
+++ b/frontend/src/components/games/__tests__/InventoryPanel.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { InventoryPanel } from '../InventoryPanel'
+
+const SAMPLE_ITEMS = [
+  { id: 'inv-3', item_name: 'Handaxe', quantity: 5 },
+  { id: 'inv-1', item_name: 'Chain Mail', quantity: 1 },
+  { id: 'inv-4', item_name: 'Longsword', quantity: 1 },
+  { id: 'inv-2', item_name: "Explorer's Pack", quantity: 1 },
+  { id: 'inv-5', item_name: 'Shield', quantity: 1 },
+]
+
+describe('InventoryPanel', () => {
+  describe('with items', () => {
+    it('renders all inventory items', () => {
+      render(<InventoryPanel items={SAMPLE_ITEMS} />)
+      const items = screen.getAllByTestId('inventory-item')
+      expect(items).toHaveLength(5)
+    })
+
+    it('displays item name and quantity for each item', () => {
+      render(<InventoryPanel items={SAMPLE_ITEMS} />)
+      expect(screen.getByText('Longsword')).toBeInTheDocument()
+      expect(screen.getByText('×5')).toBeInTheDocument()
+    })
+
+    it('sorts items alphabetically by item_name', () => {
+      render(<InventoryPanel items={SAMPLE_ITEMS} />)
+      const items = screen.getAllByTestId('inventory-item')
+      const names = items.map(el => el.querySelector('span')!.textContent)
+      expect(names).toEqual([
+        'Chain Mail',
+        "Explorer's Pack",
+        'Handaxe',
+        'Longsword',
+        'Shield',
+      ])
+    })
+
+    it('shows item count badge with correct count', () => {
+      render(<InventoryPanel items={SAMPLE_ITEMS} />)
+      const badge = screen.getByTestId('inventory-count')
+      expect(badge).toHaveTextContent('5 items')
+    })
+
+    it('shows singular "item" for single item', () => {
+      render(<InventoryPanel items={[{ id: '1', item_name: 'Dagger', quantity: 1 }]} />)
+      const badge = screen.getByTestId('inventory-count')
+      expect(badge).toHaveTextContent('1 item')
+    })
+
+    it('shows header text "Starting Equipment"', () => {
+      render(<InventoryPanel items={SAMPLE_ITEMS} />)
+      expect(screen.getByText(/Starting Equipment/)).toBeInTheDocument()
+    })
+
+    it('shows subtitle text', () => {
+      render(<InventoryPanel items={SAMPLE_ITEMS} />)
+      expect(screen.getByText('Your gear for the adventure ahead')).toBeInTheDocument()
+    })
+
+    it('does not show empty state message', () => {
+      render(<InventoryPanel items={SAMPLE_ITEMS} />)
+      expect(screen.queryByTestId('inventory-empty')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows empty state message with backpack emoji', () => {
+      render(<InventoryPanel items={[]} />)
+      const emptyState = screen.getByTestId('inventory-empty')
+      expect(emptyState).toBeInTheDocument()
+      expect(emptyState).toHaveTextContent('🎒')
+      expect(emptyState).toHaveTextContent('No items yet')
+    })
+
+    it('does not render any inventory items', () => {
+      render(<InventoryPanel items={[]} />)
+      expect(screen.queryAllByTestId('inventory-item')).toHaveLength(0)
+    })
+
+    it('does not show item count badge', () => {
+      render(<InventoryPanel items={[]} />)
+      expect(screen.queryByTestId('inventory-count')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/lib/supabase/players.ts
+++ b/frontend/src/lib/supabase/players.ts
@@ -1,6 +1,15 @@
 import { createClient } from '@/lib/supabase/server'
 import type { PlayerRow } from '@/lib/types/player'
 
+export type InventoryRow = {
+  id: string
+  player_id: string
+  item_name: string
+  quantity: number
+  properties: Record<string, unknown> | null
+  created_at: string
+}
+
 export async function getPlayer(
   gameId: string,
   profileId: string
@@ -19,4 +28,46 @@ export async function getPlayer(
   }
 
   return data
+}
+
+// TODO(DIN-34): Inventory proxy route deferred for MVP.
+// Currently using direct Supabase read (server component).
+// If a client component needs dynamic inventory fetch, create:
+//   frontend/src/app/api/games/[gameId]/inventory/route.ts
+// following the pattern in .../players/route.ts
+
+export async function getPlayerInventory(
+  gameId: string,
+  profileId: string
+): Promise<InventoryRow[]> {
+  const supabase = await createClient()
+
+  // First find the player for this profile in this game
+  const { data: player, error: playerError } = await supabase
+    .from('players')
+    .select('id')
+    .eq('game_id', gameId)
+    .eq('profile_id', profileId)
+    .maybeSingle()
+
+  if (playerError) {
+    throw new Error(`Failed to fetch player: ${playerError.message}`)
+  }
+
+  if (!player) {
+    return []
+  }
+
+  // Then fetch their inventory
+  const { data, error } = await supabase
+    .from('player_inventory')
+    .select('id, player_id, item_name, quantity, properties, created_at')
+    .eq('player_id', player.id)
+    .order('item_name')
+
+  if (error) {
+    throw new Error(`Failed to fetch inventory: ${error.message}`)
+  }
+
+  return data ?? []
 }


### PR DESCRIPTION
## Overview
Adds player inventory management system with backend population of starting equipment and frontend display.

## Backend Changes
- **Player Upsert Enhancement** (`backend/api/routes/players.py`)
  - Auto-populate starting inventory based on character class after player creation
  - Delete existing inventory on class change (best-effort, non-blocking)
  - New endpoint: `GET /games/{game_id}/players/inventory` to retrieve player items

- **D&D Class Starting Inventory** (`backend/utils/dnd.py`)
  - Added `CLASS_STARTING_INVENTORY` dict mapping all 12 classes to starting equipment
  - Fighter, Wizard, Rogue, Cleric, Ranger, Barbarian, Paladin, Druid, Bard, Monk, Sorcerer, Warlock

- **Test Coverage** (`backend/tests/test_players_inventory.py`)
  - Tests for inventory population during player upsert
  - Tests for GET inventory endpoint with auth
  - Tests for error handling (failures don't block upsert)

## Frontend Changes
- **InventoryPanel Component** (`frontend/src/components/games/InventoryPanel.tsx`)
  - Displays alphabetically-sorted equipment list with quantities
  - Shows empty state when no items exist
  - Item count badge and D&D-themed styling

- **Page Integration** (`frontend/src/app/games/[gameId]/page.tsx`)
  - Fetch and display inventory panel only when character exists
  - Server-side data fetching via `getPlayerInventory`

- **Supabase Client** (`frontend/src/lib/supabase/players.ts`)
  - Added `InventoryRow` type and `getPlayerInventory()` function
  - TODO comment for future proxy route if client-side fetch needed

- **Test & E2E Coverage**
  - Unit tests for InventoryPanel component
  - E2E tests for inventory display across character states