### PR TITLE
feat(DIN-21): Order dashboard by updated_at and show timestamp

### DIFF
--- a/backend/api/routes/games.py
+++ b/backend/api/routes/games.py
@@ -22,6 +22,7 @@ class GameOut(BaseModel):
     status: str
     created_by: str
     created_at: str
+    updated_at: str
 
 
 @router.post("/", response_model=GameOut, status_code=201)
@@ -33,7 +34,7 @@ async def create_game(
     result = (
         supabase_client.table("games")
         .insert({"name": payload.name, "dm_persona": payload.dm_persona, "created_by": current_user})
-        .select("id, name, dm_persona, status, created_by, created_at")
+        .select("id, name, dm_persona, status, created_by, created_at, updated_at")
         .single()
         .execute()
     )
@@ -47,9 +48,9 @@ async def list_games(current_user: str = Depends(get_current_user)):
     """List all games created by the authenticated user."""
     result = (
         supabase_client.table("games")
-        .select("id, name, dm_persona, status, created_by, created_at")
+        .select("id, name, dm_persona, status, created_by, created_at, updated_at")
         .eq("created_by", current_user)
-        .order("created_at", desc=True)
+        .order("updated_at", desc=True)
         .execute()
     )
     return result.data or []
@@ -60,7 +61,7 @@ async def get_game(game_id: str, current_user: str = Depends(get_current_user)):
     """Retrieve a single game by ID."""
     result = (
         supabase_client.table("games")
-        .select("id, name, dm_persona, status, created_by, created_at")
+        .select("id, name, dm_persona, status, created_by, created_at, updated_at")
         .eq("id", game_id)
         .maybe_single()
         .execute()

--- a/frontend/src/app/dashboard/__tests__/page.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/page.test.tsx
@@ -40,6 +40,7 @@ const sampleGame: Game = {
   status: 'lobby',
   created_by: 'user-123',
   created_at: '2026-03-22T00:00:00Z',
+  updated_at: '2026-03-22T00:00:00Z',
 }
 
 beforeEach(() => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -65,7 +65,7 @@ function GameCard({ game }: { game: Game }) {
         </p>
       )}
       <p className="mt-3 text-xs" style={{ color: 'var(--dnd-parchment-dim)' }}>
-        Created {formatRelativeTime(game.created_at)}
+        Updated {formatRelativeTime(game.updated_at)}
       </p>
     </div>
   )

--- a/frontend/src/lib/supabase/games.ts
+++ b/frontend/src/lib/supabase/games.ts
@@ -7,6 +7,7 @@ export type Game = {
   status: string
   created_by: string
   created_at: string
+  updated_at: string
 }
 
 export type CreateGameInput = {
@@ -20,9 +21,9 @@ export async function fetchGamesByUserId(userId: string): Promise<Game[]> {
 
   const { data, error } = await supabase
     .from('games')
-    .select('id, name, dm_persona, status, created_by, created_at')
+    .select('id, name, dm_persona, status, created_by, created_at, updated_at')
     .eq('created_by', userId)
-    .order('created_at', { ascending: false })
+    .order('updated_at', { ascending: false })
 
   if (error) {
     throw new Error(`Failed to fetch games: ${error.message}`)
@@ -41,7 +42,7 @@ export async function createGame(input: CreateGameInput): Promise<Game> {
       dm_persona: input.dm_persona,
       created_by: input.host_id,
     })
-    .select('id, name, dm_persona, status, created_by, created_at')
+    .select('id, name, dm_persona, status, created_by, created_at, updated_at')
     .single()
 
   if (error) {
@@ -56,7 +57,7 @@ export async function fetchGameById(gameId: string): Promise<Game | null> {
 
   const { data, error } = await supabase
     .from('games')
-    .select('id, name, dm_persona, status, created_by, created_at')
+    .select('id, name, dm_persona, status, created_by, created_at, updated_at')
     .eq('id', gameId)
     .maybeSingle()
 


### PR DESCRIPTION
## Changes

- Added `updated_at` field to Game type across frontend and backend
- Changed dashboard ordering from `created_at` to `updated_at` (descending)
- Updated game card to display "Updated X ago" instead of "Created X ago"
- Updated all Supabase queries to select and use the `updated_at` field
- Updated test fixtures with `updated_at` field

## Files Modified

- `backend/api/routes/games.py` - Added `updated_at` to GameOut model and all queries
- `frontend/src/lib/supabase/games.ts` - Added `updated_at` to Game type and queries
- `frontend/src/app/dashboard/page.tsx` - Changed timestamp display to use `updated_at`
- `frontend/src/app/dashboard/__tests__/page.test.tsx` - Updated test data