### PR TITLE
Add race and level to players + fix backend column names

### DIFF
--- a/backend/api/routes/actions.py
+++ b/backend/api/routes/actions.py
@@ -11,6 +11,7 @@ from api.dependencies import get_current_user
 from models.action import ActionInput, ActionResponse
 from services.dm_service import validate_action, search_rag
 from tasks.dm_tasks import dm_response_task
+from constants import MESSAGE_ROLE_PLAYER
 
 router = APIRouter()
 
@@ -61,7 +62,7 @@ async def create_action(
         message_row = {
             "game_id": gameId,
             "profile_id": current_user,
-            "role": "player",
+            "role": MESSAGE_ROLE_PLAYER,
             "content": action.action_text,
         }
 

--- a/backend/api/routes/actions.py
+++ b/backend/api/routes/actions.py
@@ -4,31 +4,15 @@ Actions endpoint: POST /games/{gameId}/actions
 Validates action, embeds, queues Dramatiq task
 """
 from fastapi import APIRouter, Depends, HTTPException, status
-from typing import Optional
-from pydantic import BaseModel
 import uuid
-from datetime import datetime
 
 from config import supabase_client, openai_client, settings
 from api.dependencies import get_current_user
+from models.action import ActionInput, ActionResponse
 from services.dm_service import validate_action, search_rag
 from tasks.dm_tasks import dm_response_task
 
 router = APIRouter()
-
-# Models
-class ActionInput(BaseModel):
-    """Player action input"""
-    player_id: str
-    action_text: str
-    action_type: str = "general"  # "spell", "attack", "dialogue", "general"
-
-class ActionResponse(BaseModel):
-    """Immediate response confirming action queued"""
-    action_id: str
-    game_id: str
-    status: str = "queued"
-    message: str = "Action received, processing DM response..."
 
 @router.post("/{gameId}/actions", response_model=ActionResponse, status_code=202)
 async def create_action(
@@ -54,36 +38,35 @@ async def create_action(
     try:
         # Step 1: Verify player is in this game
         player = supabase_client.table("players").select("*").match(
-            {"game_id": gameId, "player_id": action.player_id}
+            {"game_id": gameId, "profile_id": current_user}
         ).single().execute()
-        
+
         if not player.data:
             raise HTTPException(
                 status_code=403,
                 detail="Player not in this game"
             )
-        
+
         # Step 2: Validate action against game rules
         game = supabase_client.table("games").select("*").match(
             {"id": gameId}
         ).single().execute()
-        
+
         validate_action(action, player.data, game.data)
-        
-        # Step 3: Generate action_id
-        action_id = str(uuid.uuid4())
-        
+
+        # Step 3: Generate message_id
+        message_id = str(uuid.uuid4())
+
         # Step 4: Insert action to game_messages
         message_row = {
             "game_id": gameId,
-            "player_id": action.player_id,
-            "message_type": "action",
+            "profile_id": current_user,
+            "role": "player",
             "content": action.action_text,
-            "created_at": datetime.utcnow().isoformat(),
         }
-        
+
         supabase_client.table("game_messages").insert(message_row).execute()
-        
+
         # Step 5: Embed action text
         embedding = openai_client.embeddings.create(
             model="text-embedding-3-small",
@@ -91,25 +74,23 @@ async def create_action(
             dimensions=1536,
         )
         embedding_vector = embedding.data[0].embedding
-        
+
         # Step 6: RAG search for relevant events
         rag_context = search_rag(gameId, embedding_vector, top_k=5)
-        
+
         # Step 7: Queue Dramatiq task with max_retries
         # Task will handle Claude call, event extraction, response broadcast
         dm_response_task.send(
             game_id=gameId,
-            action_id=action_id,
+            message_id=message_id,
             action_text=action.action_text,
-            player_id=action.player_id,
             rag_context=rag_context,  # Pre-computed context
         )
-        
+
         return ActionResponse(
-            action_id=action_id,
+            message_id=message_id,
             game_id=gameId,
             status="queued",
-            message="Action received! DM is thinking...",
         )
     
     except HTTPException:

--- a/backend/api/routes/players.py
+++ b/backend/api/routes/players.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, field_validator
 from config import supabase_client
 from api.dependencies import get_current_user
 from utils.dnd import calculate_hp_max, CLASS_STARTING_INVENTORY
+from constants import GAME_STATUS_LOBBY
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +98,7 @@ async def upsert_player(
         raise HTTPException(status_code=404, detail="Game not found")
 
     game = game_result.data
-    if game["status"] != "lobby":
+    if game["status"] != GAME_STATUS_LOBBY:
         raise HTTPException(status_code=403, detail="Game is not in lobby")
 
     # For MVP, any authenticated user can create a character in a lobby game.

--- a/backend/api/routes/players.py
+++ b/backend/api/routes/players.py
@@ -45,6 +45,8 @@ class UpsertPlayerRequest(BaseModel):
 
     character_name: str = Field(min_length=1, max_length=50)
     character_class: str
+    race: str = "Human"
+    level: int = Field(ge=1, le=20, default=1)
     stats: StatBlock
 
     @field_validator("character_class")
@@ -63,6 +65,8 @@ class PlayerOut(BaseModel):
     profile_id: str
     character_name: str
     character_class: str
+    race: str
+    level: int
     hp_current: int
     hp_max: int
     stats: dict
@@ -110,13 +114,15 @@ async def upsert_player(
                 "profile_id": current_user,
                 "character_name": body.character_name,
                 "character_class": body.character_class,
+                "race": body.race,
+                "level": body.level,
                 "stats": stats_dict,
                 "hp_max": hp_max,
                 "hp_current": hp_max,
             },
             on_conflict="game_id,profile_id",
         )
-        .select("id, game_id, profile_id, character_name, character_class, hp_current, hp_max, stats, status, joined_at")
+        .select("id, game_id, profile_id, character_name, character_class, race, level, hp_current, hp_max, stats, status, joined_at")
         .single()
         .execute()
     )

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,9 +20,9 @@ class Settings(BaseSettings):
     
     # Redis (Dramatiq broker)
     REDIS_URL: str = "redis://localhost:6379"
-    
+
     # Database
-    DATABASE_URL: str  # Supabase Postgres connection string
+    DATABASE_URL: str = ""  # Currently unused — all DB ops use supabase-py
 
     # Frontend
     FRONTEND_URL: str = "http://localhost:3000"

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,0 +1,21 @@
+"""Game constants matching Supabase enums."""
+
+# Message roles (matches game_messages.role enum in Supabase)
+MESSAGE_ROLE_PLAYER = "player"
+MESSAGE_ROLE_DM = "dm"
+MESSAGE_ROLE_SYSTEM = "system"
+
+# Event sources (matches game_events.source enum in Supabase)
+EVENT_SOURCE_CLAUDE = "claude"
+EVENT_SOURCE_PLAYER = "player"
+
+# Game statuses (matches games.status enum in Supabase)
+GAME_STATUS_LOBBY = "lobby"
+GAME_STATUS_ACTIVE = "active"
+GAME_STATUS_PAUSED = "paused"
+GAME_STATUS_ENDED = "ended"
+
+# Player statuses (matches players.status enum in Supabase)
+PLAYER_STATUS_ACTIVE = "active"
+PLAYER_STATUS_DEAD = "dead"
+PLAYER_STATUS_INACTIVE = "inactive"

--- a/backend/models/action.py
+++ b/backend/models/action.py
@@ -4,14 +4,11 @@ from pydantic import BaseModel
 
 class ActionInput(BaseModel):
     """Player action submitted to the DM."""
-    player_id: str
     action_text: str
-    action_type: str = "general"
 
 
 class ActionResponse(BaseModel):
     """Immediate response confirming action was queued."""
-    action_id: str
+    message_id: str
     game_id: str
     status: str = "queued"
-    message: str = "Action received, processing DM response..."

--- a/backend/models/player.py
+++ b/backend/models/player.py
@@ -10,6 +10,8 @@ class Player(BaseModel):
     profile_id: str
     character_name: str
     character_class: str
+    race: str = "Human"
+    level: int = 1
     hp_current: int
     hp_max: int
     stats: dict[str, Any]

--- a/backend/services/dm_service.py
+++ b/backend/services/dm_service.py
@@ -18,7 +18,7 @@ def validate_action(action: Any, player: dict, game: dict) -> None:
         raise ValueError("Action text cannot be empty")
     if len(action.action_text) > 2000:
         raise ValueError("Action text exceeds 2000 character limit")
-    if game.get("status") not in ("active", "lobby"):
+    if game.get("status") != "active":
         raise ValueError(f"Game is not active (status: {game.get('status')})")
     if player.get("status") == "dead":
         raise ValueError("Dead players cannot take actions")

--- a/backend/services/dm_service.py
+++ b/backend/services/dm_service.py
@@ -6,6 +6,7 @@ This module handles synchronous pre-processing before enqueueing.
 import re
 from typing import Any
 from config import supabase_client
+from constants import GAME_STATUS_ACTIVE, PLAYER_STATUS_DEAD
 
 
 def validate_action(action: Any, player: dict, game: dict) -> None:
@@ -18,9 +19,9 @@ def validate_action(action: Any, player: dict, game: dict) -> None:
         raise ValueError("Action text cannot be empty")
     if len(action.action_text) > 2000:
         raise ValueError("Action text exceeds 2000 character limit")
-    if game.get("status") != "active":
+    if game.get("status") != GAME_STATUS_ACTIVE:
         raise ValueError(f"Game is not active (status: {game.get('status')})")
-    if player.get("status") == "dead":
+    if player.get("status") == PLAYER_STATUS_DEAD:
         raise ValueError("Dead players cannot take actions")
 
 

--- a/backend/tasks/dm_tasks.py
+++ b/backend/tasks/dm_tasks.py
@@ -20,14 +20,13 @@ logger = logging.getLogger(__name__)
 @dramatiq.actor(max_retries=3, min_backoff=1000)
 def dm_response_task(
     game_id: str,
-    action_id: str,
+    message_id: str,
     action_text: str,
-    player_id: str,
     rag_context: List[Dict[str, Any]],
 ):
     """
     Async Dramatiq task: Process DM response
-    
+
     1. Fetch game state + relevant events
     2. Build Claude system prompt with RAG context
     3. Call Claude API
@@ -36,11 +35,11 @@ def dm_response_task(
     6. Insert DM response to game_messages
     7. Insert events to game_events
     8. Update game state
-    
+
     If fails 3 times: dead-letter queue (requires manual review)
     """
-    
-    logger.info(f"[dm_response_task] Starting for game={game_id}, action={action_id}")
+
+    logger.info(f"[dm_response_task] Starting for game={game_id}, message={message_id}")
     
     try:
         # Step 1: Fetch game state
@@ -53,39 +52,29 @@ def dm_response_task(
         ).execute()
         
         # Step 2: Build Claude system prompt
-        system_prompt = f"""
-You are the Dungeon Master for a multiplayer D&D campaign.
-Game: {game.data['name']}
-Setting: {game.data['setting']}
-Campaign: {game.data['campaign_description']}
+        system_prompt = f"""You are {game.data['dm_persona']}. You are the Dungeon Master for a D&D 5e campaign called "{game.data['name']}".
 
 CURRENT PARTY:
-{json.dumps([{
-    'name': p['character_name'],
-    'class': p['class'],
-    'level': p['level'],
-    'health': p['stats']['health'] if p['stats'] else 'Unknown',
-} for p in players.data], indent=2)}
+{chr(10).join(f"- {p['character_name']}, Level {p.get('level', 1)} {p.get('race', 'Human')} {p['character_class']}. HP: {p['hp_current']}/{p['hp_max']}" for p in players.data)}
 
 RELEVANT PAST EVENTS (Context from RAG):
-{json.dumps(rag_context, indent=2)}
+{json.dumps(rag_context, indent=2) if rag_context else "No past events yet."}
 
 RULES:
-- Respond in character as the DM
-- Be engaging and descriptive
-- Track game state changes (health, inventory, position)
+- Respond in character as the DM — never break the fourth wall
+- Be vivid and engaging but keep responses to 2–3 paragraphs
 - If important story events happen, mark them with:
-  <event type="combat|discovery|dialogue|death|milestone">Event description</event>
-- Keep responses to 2-3 paragraphs
+  <event type="combat|discovery|dialogue|death|milestone">Brief factual description</event>
+- End with a clear invitation for the party to act
 
 PLAYER ACTION:
-{player_id} says: "{action_text}"
+"{action_text}"
 """
         
         # Step 3: Call Claude API
         response = anthropic_client.messages.create(
-            model="claude-3-5-sonnet-20241022",
-            max_tokens=500,
+            model="claude-sonnet-4-20250514",
+            max_tokens=1024,
             system=system_prompt,
             messages=[
                 {
@@ -110,24 +99,23 @@ PLAYER ACTION:
                 input=event['description'],
                 dimensions=1536,
             )
-            
+
             event_rows.append({
                 "game_id": game_id,
                 "event_type": event['type'],
-                "description": event['description'],
-                "created_at": datetime.utcnow().isoformat(),
-                "vector": event_embedding.data[0].embedding,  # pgvector column
+                "summary": event['description'],
+                "embedding": event_embedding.data[0].embedding,
+                "source": "claude",
             })
         
         # Step 6: Insert DM response to game_messages
         response_message = {
             "game_id": game_id,
-            "player_id": None,  # DM messages have no player
-            "message_type": "dm_response",
+            "profile_id": None,
+            "role": "dm",
             "content": dm_response,
-            "created_at": datetime.utcnow().isoformat(),
         }
-        
+
         supabase_client.table("game_messages").insert(response_message).execute()
         logger.info(f"[dm_response_task] Inserted DM response")
         
@@ -136,11 +124,9 @@ PLAYER ACTION:
             supabase_client.table("game_events").insert(event_rows).execute()
             logger.info(f"[dm_response_task] Inserted {len(event_rows)} events")
         
-        # Step 8: Update game state (if needed)
-        # Example: Increment turn counter, update player health, etc.
+        # Step 8: Update game state
         supabase_client.table("games").update({
-            "last_dm_response": datetime.utcnow().isoformat(),
-            "turn_count": game.data.get('turn_count', 0) + 1,
+            "updated_at": datetime.utcnow().isoformat(),
         }).match({"id": game_id}).execute()
         
         logger.info(f"[dm_response_task] Success! game_id={game_id}")

--- a/backend/tasks/dm_tasks.py
+++ b/backend/tasks/dm_tasks.py
@@ -14,6 +14,7 @@ import logging
 from config import supabase_client, anthropic_client, openai_client
 import redis_broker  # noqa: F401 — ensure broker is set before defining actors
 from services.dm_service import extract_events_from_response
+from constants import MESSAGE_ROLE_DM, EVENT_SOURCE_CLAUDE
 
 logger = logging.getLogger(__name__)
 
@@ -105,14 +106,14 @@ PLAYER ACTION:
                 "event_type": event['type'],
                 "summary": event['description'],
                 "embedding": event_embedding.data[0].embedding,
-                "source": "claude",
+                "source": EVENT_SOURCE_CLAUDE,
             })
         
         # Step 6: Insert DM response to game_messages
         response_message = {
             "game_id": game_id,
             "profile_id": None,
-            "role": "dm",
+            "role": MESSAGE_ROLE_DM,
             "content": dm_response,
         }
 

--- a/frontend/src/components/games/CharacterCreationForm.tsx
+++ b/frontend/src/components/games/CharacterCreationForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { characterSchema, type CharacterFormData } from '@/lib/validations/character'
-import { CHARACTER_CLASSES, STAT_NAMES } from '@/lib/constants/game'
+import { CHARACTER_CLASSES, CHARACTER_RACES, STAT_NAMES } from '@/lib/constants/game'
 import type { PlayerRow } from '@/lib/types/player'
 
 interface CharacterCreationFormProps {
@@ -30,6 +30,8 @@ export function CharacterCreationForm({
     defaultValues: {
       characterName: defaultValues?.characterName || '',
       characterClass: defaultValues?.characterClass || CHARACTER_CLASSES[0],
+      race: defaultValues?.race || CHARACTER_RACES[0],
+      level: defaultValues?.level || 1,
       stats: defaultValues?.stats || {
         str: 10,
         dex: 10,
@@ -52,6 +54,8 @@ export function CharacterCreationForm({
         body: JSON.stringify({
           character_name: data.characterName,
           character_class: data.characterClass,
+          race: data.race,
+          level: data.level,
           stats: data.stats,
         }),
       })
@@ -111,6 +115,45 @@ export function CharacterCreationForm({
         {errors.characterClass && (
           <p className="mt-1 text-sm text-red-600">
             {errors.characterClass.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-900">
+          Race
+        </label>
+        <select
+          {...register('race')}
+          className="mt-2 w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          {CHARACTER_RACES.map((race) => (
+            <option key={race} value={race}>
+              {race}
+            </option>
+          ))}
+        </select>
+        {errors.race && (
+          <p className="mt-1 text-sm text-red-600">
+            {errors.race.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-900">
+          Level
+        </label>
+        <input
+          type="number"
+          {...register('level', { valueAsNumber: true })}
+          min="1"
+          max="20"
+          className="mt-2 w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        {errors.level && (
+          <p className="mt-1 text-sm text-red-600">
+            {errors.level.message}
           </p>
         )}
       </div>

--- a/frontend/src/components/games/CharacterLobbyPanel.tsx
+++ b/frontend/src/components/games/CharacterLobbyPanel.tsx
@@ -51,6 +51,8 @@ export function CharacterLobbyPanel({
             ? {
                 characterName: player.character_name,
                 characterClass: player.character_class as CharacterFormData['characterClass'],
+                race: player.race as CharacterFormData['race'],
+                level: player.level,
                 stats: player.stats,
               }
             : undefined

--- a/frontend/src/components/games/CharacterSummaryCard.tsx
+++ b/frontend/src/components/games/CharacterSummaryCard.tsx
@@ -33,7 +33,9 @@ export function CharacterSummaryCard({
           <h2 className="text-2xl font-bold text-gray-900">
             {player.character_name}
           </h2>
-          <p className="text-lg text-gray-600">{player.character_class}</p>
+          <p className="text-lg text-gray-600">
+            Level {player.level} {player.race} {player.character_class}
+          </p>
         </div>
         {isLobby && (
           <button

--- a/frontend/src/lib/constants/game.ts
+++ b/frontend/src/lib/constants/game.ts
@@ -13,6 +13,18 @@ export const CHARACTER_CLASSES = [
   'Warlock',
 ] as const
 
+export const CHARACTER_RACES = [
+  'Human',
+  'Elf',
+  'Dwarf',
+  'Halfling',
+  'Gnome',
+  'Half-Elf',
+  'Half-Orc',
+  'Tiefling',
+  'Dragonborn',
+] as const
+
 export const GAME_STATUSES = ['lobby', 'active', 'paused', 'ended'] as const
 
 export const STAT_NAMES = [

--- a/frontend/src/lib/supabase/players.ts
+++ b/frontend/src/lib/supabase/players.ts
@@ -18,7 +18,7 @@ export async function getPlayer(
 
   const { data, error } = await supabase
     .from('players')
-    .select('id, game_id, profile_id, character_name, character_class, hp_current, hp_max, stats, status, joined_at')
+    .select('id, game_id, profile_id, character_name, character_class, race, level, hp_current, hp_max, stats, status, joined_at')
     .eq('game_id', gameId)
     .eq('profile_id', profileId)
     .maybeSingle()

--- a/frontend/src/lib/types/player.ts
+++ b/frontend/src/lib/types/player.ts
@@ -4,6 +4,8 @@ export type PlayerRow = {
   profile_id: string
   character_name: string
   character_class: string
+  race: string
+  level: number
   hp_current: number
   hp_max: number
   stats: {

--- a/frontend/src/lib/validations/character.ts
+++ b/frontend/src/lib/validations/character.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import {
   CHARACTER_CLASSES,
+  CHARACTER_RACES,
   CHARACTER_CONSTRAINTS,
   STAT_CONSTRAINTS,
 } from '@/lib/constants/game'
@@ -11,6 +12,8 @@ export const characterSchema = z.object({
     .min(CHARACTER_CONSTRAINTS.name.min, 'Name is required')
     .max(CHARACTER_CONSTRAINTS.name.max, 'Max 50 characters'),
   characterClass: z.enum(CHARACTER_CLASSES, { message: 'Select a class' }),
+  race: z.enum(CHARACTER_RACES, { message: 'Select a race' }),
+  level: z.number().int().min(1).max(20).default(1),
   stats: z.object({
     str: z
       .number({ error: 'Must be a number' })

--- a/frontend/src/lib/validations/character.ts
+++ b/frontend/src/lib/validations/character.ts
@@ -13,7 +13,7 @@ export const characterSchema = z.object({
     .max(CHARACTER_CONSTRAINTS.name.max, 'Max 50 characters'),
   characterClass: z.enum(CHARACTER_CLASSES, { message: 'Select a class' }),
   race: z.enum(CHARACTER_RACES, { message: 'Select a race' }),
-  level: z.number().int().min(1).max(20).default(1),
+  level: z.number().int().min(1).max(20),
   stats: z.object({
     str: z
       .number({ error: 'Must be a number' })

--- a/supabase/migrations/20260407000001_add_race_level_to_players.sql
+++ b/supabase/migrations/20260407000001_add_race_level_to_players.sql
@@ -1,0 +1,7 @@
+-- Add race and level columns to players table
+-- Required by all Claude DM prompt templates (DIN-8, DIN-10, DIN-12)
+ALTER TABLE players ADD COLUMN race text NOT NULL DEFAULT 'Human';
+ALTER TABLE players ADD COLUMN level integer NOT NULL DEFAULT 1;
+
+-- Add CHECK constraint for level (D&D 5e levels are 1-20)
+ALTER TABLE players ADD CONSTRAINT players_level_range CHECK (level >= 1 AND level <= 20);


### PR DESCRIPTION
## Changes

### Backend
- **Models**: Moved `ActionInput` and `ActionResponse` to dedicated model file, removed redundant fields (`player_id`, `action_type`, `message`)
- **Routes**: Updated to use `profile_id` instead of `player_id`, added `race` and `level` fields to player upsert
- **Services**: Tightened game status validation (active only, not lobby)
- **Tasks**: Refactored `dm_response_task` to use `message_id`, improved Claude prompt formatting, updated model to `claude-sonnet-4-20250514`, fixed column names (`summary` → `embedding`, `created_at` handling)
- **Config**: Clarified `DATABASE_URL` usage

### Frontend
- **CharacterCreationForm**: Added race selector and level input with validation
- **CharacterSummaryCard**: Display character as "Level X Race Class"
- **Constants**: Added `CHARACTER_RACES` enum
- **Types**: Added `race` and `level` to `PlayerRow`
- **Validation**: Updated schema to include race and level fields

### Database
- Migration: Added `race` (text, default 'Human') and `level` (int, default 1, range 1-20) columns to `players` table

## Context
Aligns frontend/backend player models and fixes column name mismatches in game_messages and game_events tables.