### PR TITLE
DIN-59: add profile dropdown, account page, logout and password reset flows

### DIFF
--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from 'next/navigation'
+import { AccountView } from '@/components/account/AccountView'
+import { createClient } from '@/lib/supabase/server'
+
+export default async function AccountPage() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('username')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  return (
+    <div className="dnd-page-bg min-h-screen py-12">
+      <div className="mx-auto w-full max-w-lg px-4">
+        <AccountView
+          initialUsername={profile?.username ?? ''}
+          email={user.email ?? ''}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,28 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const cookieStore = await cookies()
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options)
+          })
+        },
+      },
+    }
+  )
+
+  await supabase.auth.signOut()
+
+  return NextResponse.redirect(new URL('/', request.nextUrl.origin))
+}

--- a/frontend/src/app/api/auth/profile/route.ts
+++ b/frontend/src/app/api/auth/profile/route.ts
@@ -1,0 +1,64 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const profileSchema = z.object({
+  username: z
+    .string()
+    .trim()
+    .min(1, { error: 'Display name is required' })
+    .max(50, { error: 'Display name is too long' }),
+})
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  const body = await request.json().catch(() => null)
+  const parsed = profileSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0].message },
+      { status: 400 }
+    )
+  }
+
+  const cookieStore = await cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options)
+          })
+        },
+      },
+    }
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ username: parsed.data.username })
+    .eq('id', user.id)
+
+  if (error) {
+    return NextResponse.json(
+      { error: 'Failed to update profile' },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ success: true, username: parsed.data.username })
+}

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+import { ResetPasswordForm } from '@/components/auth/ResetPasswordForm'
+import { createClient } from '@/lib/supabase/server'
+
+export default async function ResetPasswordPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return (
+      <div className="dnd-page-bg flex min-h-screen items-center justify-center px-4">
+        <div className="dnd-card w-full max-w-sm px-6 py-8">
+          <div className="mb-6 text-center">
+            <p className="dnd-brand mb-3">Realm &amp; Ruin</p>
+            <h1 className="dnd-heading text-2xl font-bold">Set a new password</h1>
+          </div>
+          <div className="dnd-error-banner">
+            Your reset session has expired or is invalid. Please request a new reset email.
+          </div>
+          <div className="mt-4 text-center">
+            <Link className="dnd-link text-sm" href="/auth/login">
+              Return to login
+            </Link>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return <ResetPasswordForm />
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { fetchGamesByUserId } from '@/lib/supabase/games'
 import type { Game } from '@/lib/supabase/games'
+import { DashboardHeader } from '@/components/layout/DashboardHeader'
 
 function getStatusBadgeClass(status: string): string {
   switch (status) {
@@ -94,8 +95,9 @@ export default async function DashboardPage() {
   const games = await fetchGamesByUserId(user.id)
 
   return (
-    <div className="dnd-page-bg min-h-screen px-4 py-12">
-      <div className="mx-auto max-w-2xl">
+    <div className="dnd-page-bg min-h-screen">
+      <DashboardHeader />
+      <div className="mx-auto max-w-2xl px-4 py-12">
         <div className="mb-8 flex items-center justify-between">
           <div>
             <h1 className="dnd-heading text-2xl font-bold">Your Campaigns</h1>

--- a/frontend/src/app/games/[gameId]/page.tsx
+++ b/frontend/src/app/games/[gameId]/page.tsx
@@ -7,6 +7,7 @@ import { InviteSection } from '@/components/games/InviteSection'
 import { InventoryPanel } from '@/components/games/InventoryPanel'
 import { GameSessionView } from '@/components/games/GameSessionView'
 import { StartSessionButton } from '@/components/games/StartSessionButton'
+import { DashboardHeader } from '@/components/layout/DashboardHeader'
 
 interface GamePageProps {
   params: Promise<{ gameId: string }>
@@ -45,8 +46,9 @@ export default async function GamePage({ params }: GamePageProps) {
 
   // Show lobby view when status is 'lobby'
   return (
-    <main className="dnd-page-bg min-h-screen p-6">
-      <div className="mx-auto max-w-2xl">
+    <main className="dnd-page-bg min-h-screen">
+      <DashboardHeader />
+      <div className="mx-auto max-w-2xl p-6">
         <div className="mb-6 space-y-2">
           <h1
             className="text-3xl font-bold tracking-wide"

--- a/frontend/src/components/account/AccountView.tsx
+++ b/frontend/src/components/account/AccountView.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/client'
+import { getInitials } from '@/lib/utils/profile'
+
+const displayNameSchema = z.object({
+  username: z
+    .string()
+    .trim()
+    .min(1, { error: 'Display name is required' })
+    .max(50, { error: 'Display name is too long' }),
+})
+
+const emailSchema = z.object({
+  email: z.email({ error: 'Please enter a valid email address' }),
+})
+
+interface AccountViewProps {
+  initialUsername: string
+  email: string
+}
+
+export function AccountView({ initialUsername, email }: AccountViewProps) {
+  const [username, setUsername] = useState(initialUsername)
+  const [saveState, setSaveState] = useState('')
+  const [passwordResetState, setPasswordResetState] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [sendingReset, setSendingReset] = useState(false)
+  const [signingOut, setSigningOut] = useState(false)
+
+  async function handleSaveDisplayName(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSaveState('')
+
+    const parsed = displayNameSchema.safeParse({ username })
+    if (!parsed.success) {
+      setSaveState(parsed.error.issues[0].message)
+      return
+    }
+
+    setSaving(true)
+    try {
+      const response = await fetch('/api/auth/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: parsed.data.username }),
+      })
+
+      const data = (await response.json().catch(() => null)) as
+        | { error?: string }
+        | null
+
+      if (!response.ok) {
+        setSaveState(data?.error ?? 'Failed to save display name')
+        return
+      }
+
+      setUsername(parsed.data.username)
+      setSaveState('Display name saved.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleSendPasswordReset() {
+    setPasswordResetState('')
+    const parsedEmail = emailSchema.safeParse({ email })
+    if (!parsedEmail.success) {
+      setPasswordResetState(parsedEmail.error.issues[0].message)
+      return
+    }
+
+    setSendingReset(true)
+    try {
+      const supabase = createClient()
+      const redirectTo = `${window.location.origin}/auth/callback?next=/auth/reset-password`
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo,
+      })
+
+      if (error) {
+        setPasswordResetState(error.message)
+        return
+      }
+
+      setPasswordResetState('Check your inbox for a password reset link.')
+    } finally {
+      setSendingReset(false)
+    }
+  }
+
+  async function handleSignOut() {
+    setSigningOut(true)
+    try {
+      await fetch('/api/auth/logout', { method: 'POST' })
+      window.location.assign('/')
+    } finally {
+      setSigningOut(false)
+    }
+  }
+
+  return (
+    <div className="dnd-card p-6">
+      <div className="mb-6 flex items-center gap-4">
+        <div
+          className="flex h-12 w-12 items-center justify-center rounded-full border text-base font-semibold"
+          style={{
+            borderColor: 'var(--dnd-gold-dim)',
+            color: 'var(--dnd-parchment)',
+            background: 'var(--input-bg)',
+          }}
+        >
+          {getInitials(username)}
+        </div>
+        <div>
+          <h1 className="dnd-heading text-xl font-bold">{username}</h1>
+          <p className="text-sm" style={{ color: 'var(--muted)' }}>{email}</p>
+        </div>
+      </div>
+
+      <div className="mb-6 border-t pt-6" style={{ borderColor: 'var(--dnd-brown)' }}>
+        <h2 className="dnd-heading mb-3 text-sm font-semibold">Display Name</h2>
+        <form className="space-y-3" onSubmit={handleSaveDisplayName}>
+          <div className="flex items-end gap-2">
+            <input
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              className="dnd-input"
+              aria-label="Display name"
+            />
+            <button type="submit" className="dnd-btn-secondary" disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+          {saveState && (
+            <p className="text-sm" style={{ color: saveState.includes('saved') ? 'var(--dnd-emerald)' : 'var(--error)' }}>
+              {saveState}
+            </p>
+          )}
+        </form>
+      </div>
+
+      <div className="mb-6 border-t pt-6" style={{ borderColor: 'var(--dnd-brown)' }}>
+        <h2 className="dnd-heading mb-3 text-sm font-semibold">Password</h2>
+        <button
+          type="button"
+          className="dnd-btn-secondary"
+          onClick={handleSendPasswordReset}
+          disabled={sendingReset}
+        >
+          {sendingReset ? 'Sending…' : 'Send password reset email'}
+        </button>
+        {passwordResetState && (
+          <p className="mt-3 text-sm" style={{ color: passwordResetState.includes('inbox') ? 'var(--dnd-emerald)' : 'var(--error)' }}>
+            {passwordResetState}
+          </p>
+        )}
+      </div>
+
+      <div className="border-t pt-6" style={{ borderColor: 'var(--dnd-brown)' }}>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            className="dnd-btn-secondary"
+            onClick={handleSignOut}
+            disabled={signingOut}
+            style={{ color: 'var(--dnd-crimson-bright)', borderColor: 'rgba(139, 34, 50, 0.5)' }}
+          >
+            {signingOut ? 'Signing out…' : 'Sign Out'}
+          </button>
+          <Link href="/dashboard" className="dnd-link text-sm">
+            Back to dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -1,14 +1,18 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { z } from 'zod'
 import { createClient } from '@/lib/supabase/client'
-import Link from 'next/link'
 
 const loginSchema = z.object({
   email: z.email({ error: 'Please enter a valid email address' }),
   password: z.string().min(1, { error: 'Password is required' }),
+})
+
+const forgotPasswordSchema = z.object({
+  email: z.email({ error: 'Please enter a valid email address' }),
 })
 
 export function LoginForm() {
@@ -17,6 +21,8 @@ export function LoginForm() {
   const [password, setPassword] = useState('')
   const [mode, setMode] = useState<'password' | 'magic'>('password')
   const [magicLinkSent, setMagicLinkSent] = useState(false)
+  const [showForgotPassword, setShowForgotPassword] = useState(false)
+  const [forgotPasswordStatus, setForgotPasswordStatus] = useState('')
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [formError, setFormError] = useState('')
   const [loading, setLoading] = useState(false)
@@ -63,9 +69,7 @@ export function LoginForm() {
     setFieldErrors({})
     setFormError('')
 
-    const emailResult = z
-      .email({ error: 'Please enter a valid email address' })
-      .safeParse(email)
+    const emailResult = forgotPasswordSchema.safeParse({ email })
     if (!emailResult.success) {
       setFieldErrors({ email: emailResult.error.issues[0].message })
       return
@@ -89,6 +93,39 @@ export function LoginForm() {
       }
 
       setMagicLinkSent(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleForgotPasswordSubmit() {
+    setForgotPasswordStatus('')
+    setFieldErrors((prev) => {
+      const next = { ...prev }
+      delete next.email
+      return next
+    })
+
+    const parsed = forgotPasswordSchema.safeParse({ email })
+    if (!parsed.success) {
+      setFieldErrors({ email: parsed.error.issues[0].message })
+      return
+    }
+
+    setLoading(true)
+    try {
+      const supabase = createClient()
+      const redirectTo = `${window.location.origin}/auth/callback?next=/auth/reset-password`
+      const { error } = await supabase.auth.resetPasswordForEmail(parsed.data.email, {
+        redirectTo,
+      })
+
+      if (error) {
+        setForgotPasswordStatus(error.message)
+        return
+      }
+
+      setForgotPasswordStatus('Check your inbox for a password reset link.')
     } finally {
       setLoading(false)
     }
@@ -145,6 +182,44 @@ export function LoginForm() {
                 )}
               </div>
 
+              <div>
+                <button
+                  type="button"
+                  className="dnd-link text-xs"
+                  onClick={() => {
+                    setShowForgotPassword((prev) => !prev)
+                    setForgotPasswordStatus('')
+                  }}
+                >
+                  Forgot password?
+                </button>
+              </div>
+
+              {showForgotPassword && (
+                <div className="space-y-3 rounded-md border p-3" style={{ borderColor: 'var(--dnd-brown)' }}>
+                  <div className="space-y-3">
+                    <p className="text-xs" style={{ color: 'var(--muted)' }}>
+                      Send a password reset link to your email.
+                    </p>
+                    <input
+                      type="email"
+                      value={email}
+                      onChange={(event) => setEmail(event.target.value)}
+                      className="dnd-input"
+                      aria-label="Forgot password email"
+                    />
+                    <button type="button" className="dnd-btn-secondary" disabled={loading} onClick={handleForgotPasswordSubmit}>
+                      {loading ? 'Sending…' : 'Send reset email'}
+                    </button>
+                    {forgotPasswordStatus && (
+                      <p className="text-xs" style={{ color: forgotPasswordStatus.includes('inbox') ? 'var(--dnd-emerald)' : 'var(--error)' }}>
+                        {forgotPasswordStatus}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+
               {formError && (
                 <div data-testid="form-error" className="dnd-error-banner">
                   {formError}
@@ -157,7 +232,7 @@ export function LoginForm() {
                 disabled={loading}
                 className="dnd-btn-primary"
               >
-                {loading ? 'Signing in\u2026' : 'Enter the Realm'}
+                {loading ? 'Signing in…' : 'Enter the Realm'}
               </button>
 
               <p className="mt-4 text-center text-xs" style={{ color: 'var(--muted)' }}>
@@ -167,6 +242,8 @@ export function LoginForm() {
                     setMode('magic')
                     setFormError('')
                     setFieldErrors({})
+                    setShowForgotPassword(false)
+                    setForgotPasswordStatus('')
                   }}
                   className="dnd-link"
                   data-testid="magic-link-toggle"
@@ -208,7 +285,7 @@ export function LoginForm() {
                 disabled={loading}
                 className="dnd-btn-primary"
               >
-                {loading ? 'Sending\u2026' : 'Send Magic Link'}
+                {loading ? 'Sending…' : 'Send Magic Link'}
               </button>
 
               <p className="mt-4 text-center text-xs" style={{ color: 'var(--muted)' }}>

--- a/frontend/src/components/auth/ResetPasswordForm.tsx
+++ b/frontend/src/components/auth/ResetPasswordForm.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/client'
+
+const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, { error: 'Password must be at least 8 characters' }),
+    confirmPassword: z.string(),
+  })
+  .refine((value) => value.password === value.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  })
+
+export function ResetPasswordForm() {
+  const router = useRouter()
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setErrorMessage('')
+
+    const parsed = resetPasswordSchema.safeParse({
+      password,
+      confirmPassword,
+    })
+
+    if (!parsed.success) {
+      setErrorMessage(parsed.error.issues[0].message)
+      return
+    }
+
+    setLoading(true)
+    try {
+      const supabase = createClient()
+      const { error } = await supabase.auth.updateUser({
+        password: parsed.data.password,
+      })
+
+      if (error) {
+        setErrorMessage(error.message)
+        return
+      }
+
+      router.push('/dashboard')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="dnd-page-bg flex min-h-screen items-center justify-center px-4">
+      <div className="dnd-fade-in w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <p className="dnd-brand mb-3">Realm &amp; Ruin</p>
+          <h1 className="dnd-heading text-2xl font-bold">Set a new password</h1>
+        </div>
+
+        <div className="dnd-card px-6 py-8">
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label htmlFor="password" className="dnd-label">
+                New password
+              </label>
+              <input
+                id="password"
+                type="password"
+                className="dnd-input"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="confirm-password" className="dnd-label">
+                Confirm password
+              </label>
+              <input
+                id="confirm-password"
+                type="password"
+                className="dnd-input"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+              />
+            </div>
+
+            {errorMessage && <div className="dnd-error-banner">{errorMessage}</div>}
+
+            <button type="submit" className="dnd-btn-primary" disabled={loading}>
+              {loading ? 'Updating…' : 'Update password'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/DashboardHeader.tsx
+++ b/frontend/src/components/layout/DashboardHeader.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/server'
+import { getInitials } from '@/lib/utils/profile'
+import { ProfileDropdown } from '@/components/layout/ProfileDropdown'
+
+export async function DashboardHeader() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  let username = ''
+  if (user) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('username')
+      .eq('id', user.id)
+      .maybeSingle()
+
+    username = profile?.username ?? ''
+  }
+
+  const initials = getInitials(username)
+
+  return (
+    <header
+      className="border-b"
+      style={{
+        borderColor: 'var(--dnd-brown)',
+        background: 'var(--dnd-charcoal)',
+      }}
+    >
+      <div className="mx-auto flex h-14 w-full max-w-5xl items-center justify-between px-4">
+        <Link href="/dashboard" className="dnd-heading text-lg font-bold tracking-wide">
+          ⚔ Realm &amp; Ruin
+        </Link>
+        <ProfileDropdown initials={initials} />
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/layout/ProfileDropdown.tsx
+++ b/frontend/src/components/layout/ProfileDropdown.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface ProfileDropdownProps {
+  initials: string
+}
+
+export function ProfileDropdown({ initials }: ProfileDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const [signingOut, setSigningOut] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    function onDocumentClick(event: MouseEvent) {
+      if (!containerRef.current) return
+
+      if (!containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+
+    function onEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', onDocumentClick)
+    document.addEventListener('keydown', onEscape)
+
+    return () => {
+      document.removeEventListener('mousedown', onDocumentClick)
+      document.removeEventListener('keydown', onEscape)
+    }
+  }, [])
+
+  const handleSignOut = useCallback(async () => {
+    setSigningOut(true)
+    try {
+      await fetch('/api/auth/logout', { method: 'POST' })
+      window.location.assign('/')
+    } finally {
+      setSigningOut(false)
+      setOpen(false)
+    }
+  }, [])
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex h-9 w-9 items-center justify-center rounded-full border text-sm font-semibold"
+        style={{
+          borderColor: 'var(--dnd-gold-dim)',
+          background: 'var(--dnd-charcoal)',
+          color: 'var(--dnd-parchment)',
+        }}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Open profile menu"
+      >
+        {initials}
+      </button>
+
+      {open && (
+        <div
+          className="dnd-card absolute right-0 top-11 z-20 min-w-40 overflow-hidden"
+          role="menu"
+          aria-label="Profile menu"
+        >
+          <Link
+            href="/account"
+            className="block px-4 py-2 text-sm"
+            style={{ color: 'var(--dnd-parchment)' }}
+            onClick={() => setOpen(false)}
+            role="menuitem"
+          >
+            My Profile
+          </Link>
+          <div
+            className="mx-2"
+            style={{ borderTop: '1px solid var(--dnd-brown)' }}
+            aria-hidden="true"
+          />
+          <button
+            type="button"
+            className="block w-full px-4 py-2 text-left text-sm"
+            style={{ color: 'var(--dnd-parchment)' }}
+            onClick={handleSignOut}
+            disabled={signingOut}
+            role="menuitem"
+          >
+            {signingOut ? 'Signing out…' : 'Sign Out'}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/utils/profile.ts
+++ b/frontend/src/lib/utils/profile.ts
@@ -1,0 +1,22 @@
+export function getInitials(username: string | null | undefined): string {
+  const normalized = (username ?? '').trim()
+
+  if (!normalized) {
+    return '??'
+  }
+
+  const parts = normalized
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+  if (parts.length === 0) {
+    return '??'
+  }
+
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase()
+  }
+
+  return `${parts[0][0] ?? ''}${parts[1][0] ?? ''}`.toUpperCase()
+}

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -32,7 +32,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
     data: { user },
   } = await supabase.auth.getUser()
 
-  const protectedPrefixes = ['/dashboard', '/games']
+  const protectedPrefixes = ['/dashboard', '/games', '/account']
   const isProtectedRoute = protectedPrefixes.some(
     (prefix) =>
       request.nextUrl.pathname === prefix ||


### PR DESCRIPTION
### Motivation
- Close three gaps in account self-service: provide a discoverable profile dropdown + logout, enable password reset/set flows, and allow editing the display name stored in `profiles.username`.
- Make account management available from the dashboard and game lobby while keeping the existing `GameSessionView` unchanged.

### Description
- Added a server-rendered header and client dropdown: `DashboardHeader` (reads current user/profile) and `ProfileDropdown` (initials avatar, keyboard/outside-click close, links to `My Profile` and `Sign Out`).
- Implemented account routes and pages: `POST /api/auth/logout` (calls `supabase.auth.signOut()`), `PATCH /api/auth/profile` (Zod-validated update of `profiles.username`), the protected `/account` page (`AccountView` client UI), and `/auth/reset-password` with `ResetPasswordForm` (Zod validation + `supabase.auth.updateUser`).
- Enhanced login UI: inline "Forgot password?" sub-form in `LoginForm` that calls `supabase.auth.resetPasswordForEmail()` with `redirectTo` set to `auth/callback?next=/auth/reset-password`.
- Wired header into `frontend/src/app/dashboard/page.tsx` and the `lobby` branch of `frontend/src/app/games/[gameId]/page.tsx`, added `getInitials` utility at `frontend/src/lib/utils/profile.ts`, and added `/account` to `proxy.ts` protected prefixes.

### Testing
- Ran a production frontend build with `npm run build` and the Next.js build completed successfully (pages and routes generated).
- Ran unit tests for the login form with `npm run test -- LoginForm.test.tsx` and the suite passed.
- Ran `npm run lint` which reported pre-existing unrelated lint issues in game components/tests; these lint failures were present outside of the changes in this PR and did not block the build or the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6eac1b0dc83228d0d3fbe93ff7000)