### PR TITLE
feat(DIN-64): reduce chat latency via optimistic messages and move embedding to worker

### DIFF
--- a/backend/api/routes/actions.py
+++ b/backend/api/routes/actions.py
@@ -1,17 +1,18 @@
 # backend/api/routes/actions.py
 """
 Actions endpoint: POST /games/{gameId}/actions
-Validates action, embeds, queues Dramatiq task
+Validates action, inserts player message, queues Dramatiq task.
+Embedding and RAG search happen inside the worker (dm_response_task).
 """
 
 from fastapi import APIRouter, Depends, HTTPException
 import logging
 import uuid
 
-from config import supabase_client, openai_client
+from config import supabase_client
 from api.dependencies import get_current_user
 from models.action import ActionInput, ActionResponse
-from services.dm_service import validate_action, search_rag
+from services.dm_service import validate_action
 from tasks.dm_tasks import dm_response_task
 from constants import MESSAGE_ROLE_PLAYER
 
@@ -33,11 +34,10 @@ async def create_action(
     1. Validate action (Pydantic)
     2. Check player is in game & valid player_id
     3. Insert action to game_messages table
-    4. Embed action text via OpenAI
-    5. RAG search on game_events
-    6. Queue Dramatiq task: dm_response_task(game_id, action_id)
-    7. Return 202 Accepted immediately
+    4. Queue Dramatiq task: dm_response_task(game_id, action_id)
+    5. Return 202 Accepted immediately
 
+    Embedding and RAG search happen inside the worker for lower request latency.
     DM response happens async in worker → broadcast via Supabase Realtime
     """
 
@@ -78,28 +78,11 @@ async def create_action(
 
         supabase_client.table("game_messages").insert(message_row).execute()
 
-        # Step 5: Embed action text + RAG search (falls back to empty context on failure)
-        try:
-            embedding = openai_client.embeddings.create(
-                model="text-embedding-3-small",
-                input=action.action_text,
-                dimensions=1536,
-            )
-            embedding_vector = embedding.data[0].embedding
-            rag_context = search_rag(gameId, embedding_vector, top_k=5)
-        except Exception as e:
-            logger.warning(
-                f"[create_action] OpenAI embedding failed (fallback to no RAG): {e}"
-            )
-            rag_context = []
-
-        # Step 6: Queue Dramatiq task with max_retries
-        # Task will handle Claude call, event extraction, response broadcast
+        # Step 5: Queue Dramatiq task — embedding and RAG search happen inside the worker
         dm_response_task.send(
             game_id=gameId,
             message_id=message_id,
             action_text=action.action_text,
-            rag_context=rag_context,  # Pre-computed context
         )
 
         return ActionResponse(

--- a/backend/api/routes/messages.py
+++ b/backend/api/routes/messages.py
@@ -2,10 +2,9 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
-from config import supabase_client, openai_client
+from config import supabase_client
 from api.dependencies import get_current_user
 from constants import MESSAGE_ROLE_PLAYER, MESSAGE_ROLE_DM
-from services.dm_service import search_rag
 from tasks.dm_tasks import dm_response_task
 import logging
 
@@ -147,22 +146,10 @@ async def update_message(
         .execute()
     )
 
-    try:
-        embedding = openai_client.embeddings.create(
-            model="text-embedding-3-small",
-            input=payload.content,
-            dimensions=1536,
-        )
-        rag_context = search_rag(gameId, embedding.data[0].embedding, top_k=5)
-    except Exception as e:
-        logger.warning(f"[update_message] Embedding failed, falling back to no RAG: {e}")
-        rag_context = []
-
     dm_response_task.send(
         game_id=gameId,
         message_id=messageId,
         action_text=payload.content,
-        rag_context=rag_context,
     )
 
     return updated.data

--- a/backend/tasks/dm_tasks.py
+++ b/backend/tasks/dm_tasks.py
@@ -35,6 +35,7 @@ def dm_response_task(
     game_id: str,
     message_id: str,
     action_text: str,
+    rag_context: list | None = None,  # deprecated: kept for in-flight job compat; ignored at runtime
 ):
     """
     Async Dramatiq task: Process DM response
@@ -335,29 +336,35 @@ The acting player's action:
             }
         ).match({"id": game_id}).execute()
 
-        # Step 8: Embed events and insert to game_events — no longer blocks Realtime delivery
-        event_rows = []
-        for event in events:
-            event_embedding = openai_client.embeddings.create(
-                model="text-embedding-3-small",
-                input=event["description"],
-                dimensions=1536,
-            )
+        # Step 8+9: Embed events and insert to game_events — best-effort; failure here must NOT
+        # trigger a task retry because the DM message is already persisted (Step 6). A retry
+        # would re-call Claude and insert a duplicate DM message, corrupting the game timeline.
+        try:
+            event_rows = []
+            for event in events:
+                event_embedding = openai_client.embeddings.create(
+                    model="text-embedding-3-small",
+                    input=event["description"],
+                    dimensions=1536,
+                )
 
-            event_rows.append(
-                {
-                    "game_id": game_id,
-                    "event_type": event["type"],
-                    "summary": event["description"],
-                    "embedding": event_embedding.data[0].embedding,
-                    "source": EVENT_SOURCE_CLAUDE,
-                }
-            )
+                event_rows.append(
+                    {
+                        "game_id": game_id,
+                        "event_type": event["type"],
+                        "summary": event["description"],
+                        "embedding": event_embedding.data[0].embedding,
+                        "source": EVENT_SOURCE_CLAUDE,
+                    }
+                )
 
-        # Step 9: Insert events to game_events
-        if event_rows:
-            supabase_client.table("game_events").insert(event_rows).execute()
-            logger.info(f"[dm_response_task] Inserted {len(event_rows)} events")
+            if event_rows:
+                supabase_client.table("game_events").insert(event_rows).execute()
+                logger.info(f"[dm_response_task] Inserted {len(event_rows)} events")
+        except Exception as embed_err:
+            logger.warning(
+                f"[dm_response_task] Event embedding/insert failed (best-effort, not retried): {embed_err}"
+            )
 
         logger.info(f"[dm_response_task] Success! game_id={game_id}")
 

--- a/backend/tasks/dm_tasks.py
+++ b/backend/tasks/dm_tasks.py
@@ -7,7 +7,6 @@ Dramatiq tasks for async work:
 
 import math
 import dramatiq
-from typing import List, Dict, Any
 import json
 from datetime import datetime
 import logging
@@ -36,22 +35,21 @@ def dm_response_task(
     game_id: str,
     message_id: str,
     action_text: str,
-    rag_context: List[Dict[str, Any]],
 ):
     """
     Async Dramatiq task: Process DM response
 
+    0.  Embed action text + RAG search (moved here from request path for lower latency)
     1.  Fetch game state + players
     1b. Fetch last 20 messages for history context
     1c. Fetch player inventory for each player
     2.  Build Claude system prompt with history, inventory, RAG context
     3.  Call Claude API
-    4.  Extract events from raw response
-    5.  Embed events
-    6.  Strip event markers from displayed message
-    7.  Insert cleaned DM response to game_messages
-    8.  Insert events to game_events
-    9.  Update game timestamp
+    4.  Extract events + state changes + dice rolls from raw response
+    5.  Strip all structured blocks from display message
+    6.  Insert DM response to game_messages  ← fires Realtime immediately
+    7.  Update game state (suggested_actions, timestamp)
+    8.  Embed and insert events to game_events  ← no longer blocks Realtime
 
     On failure: insert system error message, then re-raise for Dramatiq retry.
     If fails 3 times: dead-letter queue (requires manual review)
@@ -60,6 +58,13 @@ def dm_response_task(
     logger.info(f"[dm_response_task] Starting for game={game_id}, message={message_id}")
 
     try:
+        # Step 0: Embed action text + RAG search (moved out of request path for lower latency)
+        try:
+            action_embedding = embed_text(action_text)
+            rag_context = search_rag(game_id, action_embedding, top_k=5)
+        except Exception as e:
+            logger.warning(f"[dm_response_task] RAG search failed (fallback to no RAG): {e}")
+            rag_context = []
         # Step 1: Fetch game state
         game = (
             supabase_client.table("games")
@@ -264,26 +269,7 @@ The acting player's action:
         dice_rolls = extract_dice_rolls(dm_response)
         logger.info(f"[dm_response_task] Extracted {len(dice_rolls)} dice rolls")
 
-        # Step 5: Embed events
-        event_rows = []
-        for event in events:
-            event_embedding = openai_client.embeddings.create(
-                model="text-embedding-3-small",
-                input=event["description"],
-                dimensions=1536,
-            )
-
-            event_rows.append(
-                {
-                    "game_id": game_id,
-                    "event_type": event["type"],
-                    "summary": event["description"],
-                    "embedding": event_embedding.data[0].embedding,
-                    "source": EVENT_SOURCE_CLAUDE,
-                }
-            )
-
-        # Step 6: Parse and strip suggested_actions block
+        # Step 5: Parse and strip suggested_actions block
         suggested_match = re.search(
             r'<suggested_actions>(.*?)</suggested_actions>',
             dm_response,
@@ -329,7 +315,7 @@ The acting player's action:
             flags=re.DOTALL,
         ).strip()
 
-        # Step 7: Insert DM response to game_messages
+        # Step 6: Insert DM response to game_messages — fires Realtime so player sees it now
         response_message = {
             "game_id": game_id,
             "profile_id": None,
@@ -341,18 +327,37 @@ The acting player's action:
         supabase_client.table("game_messages").insert(response_message).execute()
         logger.info("[dm_response_task] Inserted DM response")
 
-        # Step 8: Insert events to game_events
-        if event_rows:
-            supabase_client.table("game_events").insert(event_rows).execute()
-            logger.info(f"[dm_response_task] Inserted {len(event_rows)} events")
-
-        # Step 9: Update game state (including suggested actions)
+        # Step 7: Update game state (suggested_actions, timestamp) — also unblocked
         supabase_client.table("games").update(
             {
                 "updated_at": datetime.utcnow().isoformat(),
                 "suggested_actions": suggested_actions,
             }
         ).match({"id": game_id}).execute()
+
+        # Step 8: Embed events and insert to game_events — no longer blocks Realtime delivery
+        event_rows = []
+        for event in events:
+            event_embedding = openai_client.embeddings.create(
+                model="text-embedding-3-small",
+                input=event["description"],
+                dimensions=1536,
+            )
+
+            event_rows.append(
+                {
+                    "game_id": game_id,
+                    "event_type": event["type"],
+                    "summary": event["description"],
+                    "embedding": event_embedding.data[0].embedding,
+                    "source": EVENT_SOURCE_CLAUDE,
+                }
+            )
+
+        # Step 9: Insert events to game_events
+        if event_rows:
+            supabase_client.table("game_events").insert(event_rows).execute()
+            logger.info(f"[dm_response_task] Inserted {len(event_rows)} events")
 
         logger.info(f"[dm_response_task] Success! game_id={game_id}")
 

--- a/backend/tests/test_actions_route.py
+++ b/backend/tests/test_actions_route.py
@@ -32,17 +32,9 @@ class TestCreateAction:
             return mock
 
         with patch("api.routes.actions.supabase_client") as mock_sb, patch(
-            "api.routes.actions.openai_client"
-        ) as mock_openai, patch(
             "api.routes.actions.dm_response_task"
-        ) as mock_task, patch(
-            "api.routes.actions.search_rag", return_value=[]
-        ):
+        ) as mock_task:
             mock_sb.table.side_effect = table_side_effect
-
-            mock_embedding = MagicMock()
-            mock_embedding.data = [MagicMock(embedding=[0.1] * 1536)]
-            mock_openai.embeddings.create.return_value = mock_embedding
 
             response = client.post(
                 "/games/game-uuid-1/actions",
@@ -98,8 +90,47 @@ class TestCreateAction:
         )
         assert response.status_code == 401
 
-    def test_create_action_embedding_failure_still_queues_task(self, client):
-        """Should return 202 and queue the task even when OpenAI embedding fails."""
+    def test_create_action_does_not_call_openai_embedding(self, client):
+        """DIN-64: actions endpoint must NOT call OpenAI — embedding moved to worker."""
+        mock_player_result = MagicMock()
+        mock_player_result.data = SAMPLE_PLAYER
+        mock_game_result = MagicMock()
+        mock_game_result.data = SAMPLE_GAME
+        mock_insert_result = MagicMock()
+        mock_insert_result.data = {"id": "msg-1"}
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "players":
+                mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
+                    mock_player_result
+                )
+            elif name == "games":
+                mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
+                    mock_game_result
+                )
+            elif name == "game_messages":
+                mock.insert.return_value.execute.return_value = mock_insert_result
+            return mock
+
+        # Patch openai_client from config to verify it's NOT imported/used in actions.py
+        with patch("api.routes.actions.supabase_client") as mock_sb, patch(
+            "api.routes.actions.dm_response_task"
+        ) as mock_task, patch("config.openai_client") as mock_openai:
+            mock_sb.table.side_effect = table_side_effect
+
+            response = client.post(
+                "/games/game-uuid-1/actions",
+                json={"action_text": "I attack the dragon!"},
+            )
+
+        assert response.status_code == 202
+        mock_task.send.assert_called_once()
+        # OpenAI must NOT be called in the request path (DIN-64)
+        mock_openai.embeddings.create.assert_not_called()
+
+    def test_create_action_send_no_rag_context_kwarg(self, client):
+        """DIN-64: dm_response_task.send() must be called without rag_context kwarg."""
         mock_player_result = MagicMock()
         mock_player_result.data = SAMPLE_PLAYER
         mock_game_result = MagicMock()
@@ -122,12 +153,9 @@ class TestCreateAction:
             return mock
 
         with patch("api.routes.actions.supabase_client") as mock_sb, patch(
-            "api.routes.actions.openai_client"
-        ) as mock_openai, patch(
             "api.routes.actions.dm_response_task"
         ) as mock_task:
             mock_sb.table.side_effect = table_side_effect
-            mock_openai.embeddings.create.side_effect = Exception("OpenAI down")
 
             response = client.post(
                 "/games/game-uuid-1/actions",
@@ -135,12 +163,9 @@ class TestCreateAction:
             )
 
         assert response.status_code == 202
-        data = response.json()
-        assert data["status"] == "queued"
         mock_task.send.assert_called_once()
-        # Verify rag_context was passed as empty list (fallback)
         call_kwargs = mock_task.send.call_args[1]
-        assert call_kwargs["rag_context"] == []
+        assert "rag_context" not in call_kwargs
 
     def test_create_action_invalid_game_state(self, client):
         """Should return 500 when game is not active."""

--- a/backend/tests/test_dm_tasks.py
+++ b/backend/tests/test_dm_tasks.py
@@ -276,12 +276,16 @@ class TestDmResponseTask:
             "tasks.dm_tasks.anthropic_client"
         ) as mock_anthropic, patch(
             "tasks.dm_tasks.openai_client"
-        ) as mock_openai:
+        ) as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.return_value = mock_anthropic_response
             mock_openai.embeddings.create.return_value = mock_embedding_result
 
-            dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
 
             # Verify game_messages insert was called
             assert game_messages_mock.insert.called
@@ -360,12 +364,16 @@ class TestDmResponseTask:
             "tasks.dm_tasks.anthropic_client"
         ) as mock_anthropic, patch(
             "tasks.dm_tasks.openai_client"
-        ) as mock_openai:
+        ) as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.return_value = mock_anthropic_response
             mock_openai.embeddings.create.return_value = mock_embedding_result
 
-            dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
 
             # Verify game_events insert was called
             assert game_events_mock.insert.called
@@ -395,12 +403,16 @@ class TestDmResponseTask:
 
         with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
             "tasks.dm_tasks.CurrentMessage"
-        ) as mock_current_message:
+        ) as mock_current_message, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_current_message.get_current_message.return_value = mock_message
 
             with pytest.raises(Exception):
-                dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+                dm_response_task.fn("game-1", "msg-1", "I attack!")
 
             # Assert system error was inserted on the terminal retry
             assert game_messages_mock.insert.called
@@ -432,15 +444,159 @@ class TestDmResponseTask:
 
         with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
             "tasks.dm_tasks.CurrentMessage"
-        ) as mock_current_message:
+        ) as mock_current_message, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_current_message.get_current_message.return_value = mock_message
 
             with pytest.raises(Exception):
-                dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+                dm_response_task.fn("game-1", "msg-1", "I attack!")
 
             # Assert system error was NOT inserted — a later retry may still succeed
             assert not game_messages_mock.insert.called
+
+
+class TestDin64LatencyChanges:
+    """DIN-64: Embedding moved to task, DM insert before event embedding."""
+
+    def _make_standard_mocks(self):
+        game_data = {"id": "game-1", "name": "Quest", "dm_persona": "DM"}
+        players_data = [
+            {
+                "id": "player-1",
+                "character_name": "Hero",
+                "race": "Human",
+                "level": 1,
+                "character_class": "Fighter",
+                "hp_current": 10,
+                "hp_max": 10,
+                "profile_id": "user-1",
+                "stats": {"str": 15, "dex": 12, "con": 13, "int": 8, "wis": 10, "cha": 9},
+            }
+        ]
+        return game_data, players_data
+
+    def test_dm_response_task_embeds_action_text_at_task_start(self):
+        """DIN-64: embed_text must be called with the action text inside the task."""
+        game_data, players_data = self._make_standard_mocks()
+
+        mock_game_result = MagicMock()
+        mock_game_result.data = game_data
+        mock_players_result = MagicMock()
+        mock_players_result.data = players_data
+        mock_messages_result = MagicMock()
+        mock_messages_result.data = []
+        mock_inventory_result = MagicMock()
+        mock_inventory_result.data = []
+        mock_anthropic_response = MagicMock()
+        mock_anthropic_response.content = [MagicMock(text="The adventure continues.")]
+        mock_embedding_result = MagicMock()
+        mock_embedding_result.data = [MagicMock(embedding=[0.1] * 1536)]
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "games":
+                mock.select.return_value.match.return_value.single.return_value.execute.return_value = mock_game_result
+                mock.update.return_value.match.return_value.execute.return_value = MagicMock()
+            elif name == "players":
+                mock.select.return_value.match.return_value.execute.return_value = mock_players_result
+            elif name == "game_messages":
+                mock.select.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = mock_messages_result
+                mock.insert.return_value.execute.return_value = MagicMock()
+            elif name == "player_inventory":
+                mock.select.return_value.eq.return_value.execute.return_value = mock_inventory_result
+            elif name == "game_events":
+                mock.insert.return_value.execute.return_value = MagicMock()
+            return mock
+
+        with patch("tasks.dm_tasks.supabase_client") as mock_sb, \
+             patch("tasks.dm_tasks.anthropic_client") as mock_anthropic, \
+             patch("tasks.dm_tasks.openai_client") as mock_openai, \
+             patch("tasks.dm_tasks.embed_text", return_value=[0.1] * 1536) as mock_embed, \
+             patch("tasks.dm_tasks.search_rag", return_value=[]):
+            mock_sb.table.side_effect = table_side_effect
+            mock_anthropic.messages.create.return_value = mock_anthropic_response
+            mock_openai.embeddings.create.return_value = mock_embedding_result
+
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
+
+            mock_embed.assert_called_with("I attack!")
+
+    def test_dm_response_task_inserts_dm_message_before_game_events(self):
+        """DIN-64: game_messages insert must happen before game_events insert."""
+        game_data, players_data = self._make_standard_mocks()
+
+        mock_game_result = MagicMock()
+        mock_game_result.data = game_data
+        mock_players_result = MagicMock()
+        mock_players_result.data = players_data
+        mock_messages_result = MagicMock()
+        mock_messages_result.data = []
+        mock_inventory_result = MagicMock()
+        mock_inventory_result.data = []
+        mock_anthropic_response = MagicMock()
+        mock_anthropic_response.content = [MagicMock(
+            text='The goblin falls. <event type="combat">Goblin defeated</event>'
+        )]
+        mock_embedding_result = MagicMock()
+        mock_embedding_result.data = [MagicMock(embedding=[0.1] * 1536)]
+
+        call_order: list[str] = []
+
+        game_messages_mock = MagicMock()
+        game_messages_mock.select.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = mock_messages_result
+
+        def gm_insert(data):
+            call_order.append("game_messages")
+            m = MagicMock()
+            m.execute.return_value = MagicMock()
+            return m
+
+        game_messages_mock.insert.side_effect = gm_insert
+
+        game_events_mock = MagicMock()
+
+        def ge_insert(data):
+            call_order.append("game_events")
+            m = MagicMock()
+            m.execute.return_value = MagicMock()
+            return m
+
+        game_events_mock.insert.side_effect = ge_insert
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "games":
+                mock.select.return_value.match.return_value.single.return_value.execute.return_value = mock_game_result
+                mock.update.return_value.match.return_value.execute.return_value = MagicMock()
+            elif name == "players":
+                mock.select.return_value.match.return_value.execute.return_value = mock_players_result
+            elif name == "game_messages":
+                return game_messages_mock
+            elif name == "player_inventory":
+                mock.select.return_value.eq.return_value.execute.return_value = mock_inventory_result
+            elif name == "game_events":
+                return game_events_mock
+            return mock
+
+        with patch("tasks.dm_tasks.supabase_client") as mock_sb, \
+             patch("tasks.dm_tasks.anthropic_client") as mock_anthropic, \
+             patch("tasks.dm_tasks.openai_client") as mock_openai, \
+             patch("tasks.dm_tasks.embed_text", return_value=[0.1] * 1536), \
+             patch("tasks.dm_tasks.search_rag", return_value=[]):
+            mock_sb.table.side_effect = table_side_effect
+            mock_anthropic.messages.create.return_value = mock_anthropic_response
+            mock_openai.embeddings.create.return_value = mock_embedding_result
+
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
+
+            assert "game_messages" in call_order, "game_messages insert not called"
+            assert "game_events" in call_order, "game_events insert not called"
+            assert call_order.index("game_messages") < call_order.index("game_events"), \
+                "game_messages must be inserted before game_events"
 
 
 class TestDmResponseTaskSuggestedActions:
@@ -551,12 +707,16 @@ class TestDmResponseTaskSuggestedActions:
             "tasks.dm_tasks.anthropic_client"
         ) as mock_anthropic, patch(
             "tasks.dm_tasks.openai_client"
-        ) as mock_openai:
+        ) as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.return_value = mock_anthropic_response
             mock_openai.embeddings.create.return_value = mock_embedding_result
 
-            dm_response_task.fn("game-1", "msg-1", "I examine the door.", [])
+            dm_response_task.fn("game-1", "msg-1", "I examine the door.")
 
         assert "suggested_actions" in captured_update_payload
         assert captured_update_payload["suggested_actions"] == [
@@ -633,12 +793,16 @@ class TestDmResponseTaskSuggestedActions:
             "tasks.dm_tasks.anthropic_client"
         ) as mock_anthropic, patch(
             "tasks.dm_tasks.openai_client"
-        ) as mock_openai:
+        ) as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.return_value = mock_anthropic_response
             mock_openai.embeddings.create.return_value = mock_embedding_result
 
-            dm_response_task.fn("game-1", "msg-1", "I approach the guard.", [])
+            dm_response_task.fn("game-1", "msg-1", "I approach the guard.")
 
         assert "suggested_actions" not in captured_insert_content.get("content", "")
         assert narrative in captured_insert_content.get("content", "")
@@ -702,12 +866,16 @@ class TestDmResponseTaskSuggestedActions:
             "tasks.dm_tasks.anthropic_client"
         ) as mock_anthropic, patch(
             "tasks.dm_tasks.openai_client"
-        ) as mock_openai:
+        ) as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.return_value = mock_anthropic_response
             mock_openai.embeddings.create.return_value = mock_embedding_result
 
-            dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
 
         assert captured_update_payload.get("suggested_actions") == []
 
@@ -1180,12 +1348,16 @@ class TestStateChanges:
 
         with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
             "tasks.dm_tasks.anthropic_client"
-        ) as mock_anthropic, patch("tasks.dm_tasks.openai_client") as mock_openai:
+        ) as mock_anthropic, patch("tasks.dm_tasks.openai_client") as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.side_effect = capture_create
             mock_openai.embeddings.create.return_value = MagicMock(data=[MagicMock(embedding=[0.1] * 1536)])
 
-            dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
 
         assert "[ID: player-uuid-1]" in captured_prompt.get("system", ""), \
             "Party line must contain [ID: {uuid}] for Claude state_changes tracking"
@@ -1237,12 +1409,16 @@ class TestStateChanges:
 
         with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
             "tasks.dm_tasks.anthropic_client"
-        ) as mock_anthropic, patch("tasks.dm_tasks.openai_client") as mock_openai:
+        ) as mock_anthropic, patch("tasks.dm_tasks.openai_client") as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.return_value = MagicMock(content=[MagicMock(text=dm_text)])
             mock_openai.embeddings.create.return_value = MagicMock(data=[MagicMock(embedding=[0.1] * 1536)])
 
-            dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
 
         stored_content = captured_content.get("content", "")
         assert "<state_changes>" not in stored_content, "state_changes block must be stripped from stored content"
@@ -1286,12 +1462,16 @@ class TestStateChanges:
 
         with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
             "tasks.dm_tasks.anthropic_client"
-        ) as mock_anthropic, patch("tasks.dm_tasks.openai_client") as mock_openai:
+        ) as mock_anthropic, patch("tasks.dm_tasks.openai_client") as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.return_value = MagicMock(content=[MagicMock(text=dm_text)])
             mock_openai.embeddings.create.return_value = MagicMock(data=[MagicMock(embedding=[0.1] * 1536)])
 
-            dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
 
         stored_content = captured_content.get("content", "")
         assert "Goblin defeated" in stored_content, "Event inner text must be preserved in clean_response"
@@ -1359,12 +1539,16 @@ class TestStateChanges:
 
         with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
             "tasks.dm_tasks.anthropic_client"
-        ) as mock_anthropic, patch("tasks.dm_tasks.openai_client") as mock_openai:
+        ) as mock_anthropic, patch("tasks.dm_tasks.openai_client") as mock_openai, patch(
+            "tasks.dm_tasks.embed_text", return_value=[0.1] * 1536
+        ), patch(
+            "tasks.dm_tasks.search_rag", return_value=[]
+        ):
             mock_sb.table.side_effect = table_side_effect
             mock_anthropic.messages.create.side_effect = capture_create
             mock_openai.embeddings.create.return_value = MagicMock(data=[MagicMock(embedding=[0.1] * 1536)])
 
-            dm_response_task.fn("game-1", "msg-1", "I attack!", [])
+            dm_response_task.fn("game-1", "msg-1", "I attack!")
 
         system_prompt = captured_prompt.get("system", "")
         assert f"Proficiency bonus: {expected_bonus}" in system_prompt, (

--- a/backend/tests/test_messages_route.py
+++ b/backend/tests/test_messages_route.py
@@ -195,14 +195,7 @@ class TestPatchMessage:
 
         with patch("api.routes.messages.supabase_client", _make_supabase(gm)), patch(
             "api.routes.messages.dm_response_task"
-        ) as mock_task, patch(
-            "api.routes.messages.openai_client"
-        ) as mock_openai, patch(
-            "api.routes.messages.search_rag", return_value=[]
-        ):
-            mock_openai.embeddings.create.return_value = MagicMock(
-                data=[MagicMock(embedding=[0.1] * 1536)]
-            )
+        ) as mock_task:
             mock_task.send = MagicMock()
 
             res = client.patch(
@@ -214,19 +207,12 @@ class TestPatchMessage:
         assert res.json()["content"] == "I search for traps."
 
     def test_dm_response_task_send_called(self, client):
-        """PATCH calls dm_response_task.send with updated content."""
+        """PATCH calls dm_response_task.send with updated content (no rag_context — DIN-64)."""
         gm = _build_gm_mock()
 
         with patch("api.routes.messages.supabase_client", _make_supabase(gm)), patch(
             "api.routes.messages.dm_response_task"
-        ) as mock_task, patch(
-            "api.routes.messages.openai_client"
-        ) as mock_openai, patch(
-            "api.routes.messages.search_rag", return_value=[]
-        ):
-            mock_openai.embeddings.create.return_value = MagicMock(
-                data=[MagicMock(embedding=[0.1] * 1536)]
-            )
+        ) as mock_task:
             mock_task.send = MagicMock()
 
             client.patch(
@@ -238,7 +224,6 @@ class TestPatchMessage:
                 game_id=GAME_ID,
                 message_id=MSG_ID,
                 action_text="I search for traps.",
-                rag_context=[],
             )
 
     def test_409_when_not_last_message(self, client):
@@ -303,18 +288,13 @@ class TestPatchMessage:
 
         assert res.status_code == 401
 
-    def test_embedding_failure_falls_back_to_no_rag(self, client):
-        """PATCH still queues DM task even if embedding fails."""
+    def test_send_does_not_include_rag_context_kwarg(self, client):
+        """PATCH: dm_response_task.send must NOT include rag_context kwarg (DIN-64 — embedding moved to worker)."""
         gm = _build_gm_mock()
 
         with patch("api.routes.messages.supabase_client", _make_supabase(gm)), patch(
             "api.routes.messages.dm_response_task"
-        ) as mock_task, patch(
-            "api.routes.messages.openai_client"
-        ) as mock_openai, patch(
-            "api.routes.messages.search_rag", return_value=[]
-        ):
-            mock_openai.embeddings.create.side_effect = Exception("Embedding unavailable")
+        ) as mock_task:
             mock_task.send = MagicMock()
 
             res = client.patch(
@@ -323,9 +303,6 @@ class TestPatchMessage:
             )
 
         assert res.status_code == 200
-        mock_task.send.assert_called_once_with(
-            game_id=GAME_ID,
-            message_id=MSG_ID,
-            action_text="I cast magic missile.",
-            rag_context=[],
-        )
+        mock_task.send.assert_called_once()
+        call_kwargs = mock_task.send.call_args[1]
+        assert "rag_context" not in call_kwargs

--- a/frontend/e2e/dice-roller.spec.ts
+++ b/frontend/e2e/dice-roller.spec.ts
@@ -304,8 +304,11 @@ test.describe('DIN-24 — Dice Roller in DM chat messages', () => {
 
     await page.goto(`/games/${GAME_ID}`)
     await expect(page.getByText('The Shadow Heist')).toBeVisible({ timeout: 5000 })
+    // Wait for initializeSession to complete before dispatching the Realtime event —
+    // otherwise setMessages(fetchedMessages) will overwrite the event-dispatched message
+    await expect(page.getByText('The adventure begins.')).toBeVisible({ timeout: 3000 })
 
-    // Wait for initial load then simulate DM message arriving via Realtime with dice_rolls
+    // Simulate DM message arriving via Realtime with dice_rolls
     await page.evaluate(
       ({ narration, roll }) => {
         const event = new CustomEvent('dm-message', {
@@ -336,6 +339,8 @@ test.describe('DIN-24 — Dice Roller in DM chat messages', () => {
 
     await page.goto(`/games/${GAME_ID}`)
     await expect(page.getByText('The Shadow Heist')).toBeVisible({ timeout: 5000 })
+    // Wait for initializeSession to complete before dispatching the Realtime event
+    await expect(page.getByText('The adventure begins.')).toBeVisible({ timeout: 3000 })
 
     // Simulate a player action arriving
     await page.evaluate(() => {

--- a/frontend/e2e/optimistic-messages.spec.ts
+++ b/frontend/e2e/optimistic-messages.spec.ts
@@ -1,0 +1,393 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ─── DIN-64: Optimistic player messages + reconciliation ──────────────────────
+//
+// Three coordinated latency improvements land in this issue:
+//  1. Optimistic player message — the player's text appears in the chat
+//     bubble immediately on Send, before the 202 response arrives.
+//  2. Reconciliation — when the real Supabase Realtime INSERT fires
+//     (simulated here with a custom DOM event), the optimistic entry is
+//     replaced by the canonical DB row, leaving exactly one copy in the log.
+//  3. Error roll-back — if the actions API returns a non-2xx status *or*
+//     the request fails outright, the optimistic bubble is removed and the
+//     input is re-enabled so the player can try again.
+//
+// The E2E custom-event layer (NEXT_PUBLIC_E2E_TESTING) has been updated in
+// this PR to mirror the Realtime INSERT reconciliation logic, so tests that
+// dispatch 'player-message' events can assert on deduplication behaviour.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAME_ID = 'test-game-optimistic'
+const USER_ID = 'user-1'
+const ACTION_TEXT = 'I search the ancient library for clues about the prophecy.'
+
+// ─── Setup helper ─────────────────────────────────────────────────────────────
+
+async function setupGameMocks(
+  page: Page,
+  options: { actionsDelay?: number; actionsStatus?: number } = {}
+) {
+  const { actionsDelay = 0, actionsStatus = 202 } = options
+
+  // Auth
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+    })
+  )
+  await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'mock-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        user: { id: USER_ID, email: 'test@example.com' },
+      }),
+    })
+  )
+
+  // Game
+  await page.route('**.supabase.co/rest/v1/games**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: GAME_ID,
+            name: 'The Arcane Vault',
+            dm_persona: 'A scholarly Dungeon Master',
+            status: 'active',
+            created_by: USER_ID,
+            updated_at: '2026-01-01T00:00:00Z',
+            suggested_actions: null,
+          },
+        ]),
+      })
+    }
+  })
+
+  // Players
+  await page.route('**.supabase.co/rest/v1/players**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'player-1',
+            game_id: GAME_ID,
+            profile_id: USER_ID,
+            character_name: 'Lyra Brightmantle',
+            character_class: 'Wizard',
+            race: 'Half-Elf',
+            level: 3,
+            hp_current: 18,
+            hp_max: 20,
+          },
+        ]),
+      })
+    }
+  })
+
+  // game_messages — start with a DM message so isWaitingForDm=false
+  const initMsg = {
+    id: 'msg-dm-init',
+    game_id: GAME_ID,
+    profile_id: null,
+    role: 'dm',
+    content: 'The library doors creak open before you.',
+    dice_rolls: null,
+    created_at: '2026-01-01T00:00:01Z',
+  }
+  await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+    if (route.request().method() === 'GET') {
+      const url = route.request().url()
+      if (url.includes('select=role')) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([{ id: initMsg.id, role: 'dm', created_at: initMsg.created_at }]),
+        })
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([initMsg]),
+        })
+      }
+    }
+  })
+
+  // Actions endpoint — configurable delay and status
+  await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+    if (route.request().method() === 'POST') {
+      if (actionsDelay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, actionsDelay))
+      }
+      if (actionsStatus === 202) {
+        route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'queued', message_id: 'msg-player-1' }),
+        })
+      } else {
+        route.fulfill({
+          status: actionsStatus,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Internal server error' }),
+        })
+      }
+    }
+  })
+}
+
+async function gotoGame(page: Page) {
+  await page.goto(`/games/${GAME_ID}`)
+  await expect(page.getByText('The Arcane Vault')).toBeVisible({ timeout: 5000 })
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('DIN-64 — Optimistic player messages', () => {
+  test('optimistic message appears in chat immediately, before 202 response arrives', async ({
+    page,
+  }) => {
+    // Delay the actions endpoint by 600ms — the optimistic message must be
+    // visible while the request is still in-flight.
+    await setupGameMocks(page, { actionsDelay: 600 })
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await expect(textarea).toBeEnabled()
+
+    await textarea.fill(ACTION_TEXT)
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // The optimistic message should be rendered synchronously (before the
+    // delayed 202 comes back).  Use a tight timeout to confirm it was
+    // immediate and not waiting for the round-trip.
+    await expect(page.getByText(ACTION_TEXT)).toBeVisible({ timeout: 300 })
+
+    // Input disabled while waiting
+    await expect(textarea).toBeDisabled()
+
+    // Wait for the delayed fetch to complete (give it a generous buffer)
+    await expect(textarea).toBeDisabled({ timeout: 800 })
+  })
+
+  test('no duplicate message when Realtime player-message event fires after submit', async ({
+    page,
+  }) => {
+    await setupGameMocks(page)
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill(ACTION_TEXT)
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Optimistic message appears
+    await expect(page.getByText(ACTION_TEXT)).toBeVisible({ timeout: 3000 })
+
+    // Simulate Supabase Realtime INSERT for the same player message (real DB row)
+    await page.evaluate(
+      ({ gameId, userId, content }) => {
+        window.dispatchEvent(
+          new CustomEvent('player-message', {
+            detail: {
+              id: 'msg-player-real-1',
+              game_id: gameId,
+              profile_id: userId,
+              role: 'player',
+              content,
+              created_at: new Date().toISOString(),
+            },
+          })
+        )
+      },
+      { gameId: GAME_ID, userId: USER_ID, content: ACTION_TEXT }
+    )
+
+    // Wait a tick for reconciliation to complete
+    await page.waitForTimeout(150)
+
+    // The optimistic entry is replaced by the real one — exactly ONE copy of
+    // the action text must be visible in the chat log.
+    const matches = page.getByText(ACTION_TEXT, { exact: true })
+    await expect(matches).toHaveCount(1)
+  })
+
+  test('optimistic message is removed and input re-enabled on API error (non-2xx)', async ({
+    page,
+  }) => {
+    await setupGameMocks(page, { actionsStatus: 500 })
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill(ACTION_TEXT)
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Optimistic message briefly appears
+    await expect(page.getByText(ACTION_TEXT)).toBeVisible({ timeout: 3000 })
+
+    // After the 500 response, the optimistic bubble must disappear
+    await expect(page.getByText(ACTION_TEXT)).not.toBeVisible({ timeout: 3000 })
+
+    // Input must be re-enabled so the player can try again
+    await expect(textarea).toBeEnabled({ timeout: 3000 })
+  })
+
+  test('optimistic message is removed and input re-enabled on network failure', async ({
+    page,
+  }) => {
+    // Simulate a hard network failure (connection refused)
+    await page.route(`**/api/games/${GAME_ID}/actions`, (route) => {
+      if (route.request().method() === 'POST') {
+        route.abort('connectionrefused')
+      }
+    })
+
+    // Still need the other mocks
+    await page.route('**/auth/v1/user', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+      })
+    )
+    await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'mock-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'mock-refresh',
+          user: { id: USER_ID, email: 'test@example.com' },
+        }),
+      })
+    )
+    await page.route('**.supabase.co/rest/v1/games**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: GAME_ID,
+              name: 'The Arcane Vault',
+              dm_persona: 'DM',
+              status: 'active',
+              created_by: USER_ID,
+              updated_at: '2026-01-01T00:00:00Z',
+              suggested_actions: null,
+            },
+          ]),
+        })
+      }
+    })
+    await page.route('**.supabase.co/rest/v1/players**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 'player-1',
+              game_id: GAME_ID,
+              profile_id: USER_ID,
+              character_name: 'Lyra Brightmantle',
+              character_class: 'Wizard',
+              race: 'Half-Elf',
+              level: 3,
+              hp_current: 18,
+              hp_max: 20,
+            },
+          ]),
+        })
+      }
+    })
+    await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+      if (route.request().method() === 'GET') {
+        const url = route.request().url()
+        if (url.includes('select=role')) {
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([{ id: 'msg-1', role: 'dm', created_at: '2026-01-01T00:00:01Z' }]),
+          })
+        } else {
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              {
+                id: 'msg-1',
+                game_id: GAME_ID,
+                profile_id: null,
+                role: 'dm',
+                content: 'The library doors creak open.',
+                dice_rolls: null,
+                created_at: '2026-01-01T00:00:01Z',
+              },
+            ]),
+          })
+        }
+      }
+    })
+
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill(ACTION_TEXT)
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Optimistic message briefly appears then is removed after the fetch throws
+    await expect(page.getByText(ACTION_TEXT)).toBeVisible({ timeout: 3000 })
+    await expect(page.getByText(ACTION_TEXT)).not.toBeVisible({ timeout: 5000 })
+
+    // Input re-enabled
+    await expect(textarea).toBeEnabled({ timeout: 3000 })
+  })
+
+  test('typing indicator appears while waiting for DM after optimistic submit', async ({
+    page,
+  }) => {
+    await setupGameMocks(page)
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill(ACTION_TEXT)
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Optimistic message visible AND typing indicator active simultaneously
+    await expect(page.getByText(ACTION_TEXT)).toBeVisible({ timeout: 3000 })
+    await expect(page.getByText(/The Dungeon Master is writing/i)).toBeVisible({ timeout: 3000 })
+
+    // When DM response arrives, typing indicator disappears and input re-enables
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('dm-message', {
+          detail: {
+            game_id: 'test-game-optimistic',
+            role: 'dm',
+            content: 'Shelves of ancient tomes line the walls, their spines gleaming with arcane sigils.',
+            created_at: new Date().toISOString(),
+          },
+        })
+      )
+    })
+
+    await expect(
+      page.getByText(/Shelves of ancient tomes line the walls/)
+    ).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText(/The Dungeon Master is writing/i)).not.toBeVisible()
+    await expect(textarea).toBeEnabled()
+  })
+})

--- a/frontend/e2e/optimistic-messages.spec.ts
+++ b/frontend/e2e/optimistic-messages.spec.ts
@@ -225,7 +225,8 @@ test.describe('DIN-64 — Optimistic player messages', () => {
   test('optimistic message is removed and input re-enabled on API error (non-2xx)', async ({
     page,
   }) => {
-    await setupGameMocks(page, { actionsStatus: 500 })
+    // Small delay ensures the optimistic message is painted before the 500 arrives
+    await setupGameMocks(page, { actionsStatus: 500, actionsDelay: 50 })
     await gotoGame(page)
 
     const textarea = page.getByTestId('chat-textarea')
@@ -245,9 +246,11 @@ test.describe('DIN-64 — Optimistic player messages', () => {
   test('optimistic message is removed and input re-enabled on network failure', async ({
     page,
   }) => {
-    // Simulate a hard network failure (connection refused)
-    await page.route(`**/api/games/${GAME_ID}/actions`, (route) => {
+    // Simulate a hard network failure (connection refused) with a tiny delay so the
+    // optimistic message is painted before the abort arrives
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
       if (route.request().method() === 'POST') {
+        await new Promise((resolve) => setTimeout(resolve, 50))
         route.abort('connectionrefused')
       }
     })

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -26,8 +26,12 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev',
+    command: 'E2E_TESTING=true NEXT_PUBLIC_E2E_TESTING=true npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
+    env: {
+      E2E_TESTING: 'true',
+      NEXT_PUBLIC_E2E_TESTING: 'true',
+    },
   },
 })

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -144,13 +144,27 @@ export function GameSessionView({
         },
         (payload) => {
           const newMsg = payload.new as GameMessage
-          setMessages((prev) => [...prev, newMsg])
 
-          // If DM or system (error) responded, we're no longer waiting
-          if (newMsg.role === 'dm' || newMsg.role === 'system') {
-            setIsWaitingForDm(false)
-          } else if (newMsg.role === 'player') {
+          if (newMsg.role === 'player') {
+            // Reconcile: replace any optimistic message matching this player+content
+            setMessages((prev) => {
+              const filtered = prev.filter(
+                (m) =>
+                  !(
+                    m.id.startsWith('optimistic-') &&
+                    m.profile_id === newMsg.profile_id &&
+                    m.content === newMsg.content
+                  )
+              )
+              return [...filtered, newMsg]
+            })
             setIsWaitingForDm(true)
+          } else {
+            setMessages((prev) => [...prev, newMsg])
+            // If DM or system (error) responded, we're no longer waiting
+            if (newMsg.role === 'dm' || newMsg.role === 'system') {
+              setIsWaitingForDm(false)
+            }
           }
         }
       )
@@ -312,9 +326,20 @@ export function GameSessionView({
 
   const handleSubmit = async (actionText: string) => {
     setShowRetryTimeout(false)
-    try {
-      setIsWaitingForDm(true)
 
+    // Push optimistic message immediately so the player sees their action right away
+    const optimisticMsg: GameMessage = {
+      id: `optimistic-${crypto.randomUUID()}`,
+      game_id: gameId,
+      role: 'player',
+      profile_id: userId,
+      content: actionText,
+      created_at: new Date().toISOString(),
+    }
+    setMessages((prev) => [...prev, optimisticMsg])
+    setIsWaitingForDm(true)
+
+    try {
       const response = await fetch(`/api/games/${gameId}/actions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -323,14 +348,15 @@ export function GameSessionView({
 
       if (!response.ok) {
         const errorData = await response.json()
-        // On error, re-enable input
+        // On error, remove the optimistic message and re-enable input
+        setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id))
         setIsWaitingForDm(false)
-        // Optionally show error to user
         console.error('Action failed:', errorData.error)
       }
-      // On success, message will appear via Realtime subscription
-      // DM response will also arrive via Realtime, clearing isWaitingForDm
+      // On success, the real player message will arrive via Realtime and reconcile
+      // the optimistic message. DM response will also arrive via Realtime.
     } catch {
+      setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id))
       setIsWaitingForDm(false)
     }
   }

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -270,11 +270,26 @@ export function GameSessionView({
         created_at: detail.created_at || new Date().toISOString(),
         dice_rolls: detail.dice_rolls ?? null,
       }
-      setMessages((prev) => [...prev, msg])
-      if (msg.role === 'dm' || msg.role === 'system') {
-        setIsWaitingForDm(false)
-      } else if (msg.role === 'player') {
+      if (msg.role === 'player') {
+        // Reconcile: mirror the Realtime INSERT handler — remove any optimistic
+        // message with a matching profile_id + content before adding the real one.
+        setMessages((prev) => {
+          const filtered = prev.filter(
+            (m) =>
+              !(
+                m.id.startsWith('optimistic-') &&
+                m.profile_id === msg.profile_id &&
+                m.content === msg.content
+              )
+          )
+          return [...filtered, msg]
+        })
         setIsWaitingForDm(true)
+      } else {
+        setMessages((prev) => [...prev, msg])
+        if (msg.role === 'dm' || msg.role === 'system') {
+          setIsWaitingForDm(false)
+        }
       }
     }
 

--- a/frontend/src/components/games/__tests__/GameSessionView.test.tsx
+++ b/frontend/src/components/games/__tests__/GameSessionView.test.tsx
@@ -35,6 +35,7 @@ jest.mock('../ChatInput', () => ({
       <div data-testid="is-waiting">{isWaitingForDm ? 'true' : 'false'}</div>
       <div data-testid="has-on-submit">{onSubmit ? 'true' : 'false'}</div>
       <div data-testid="suggested-actions-count">{suggestedActions ? suggestedActions.length : 0}</div>
+      <button data-testid="submit-action" onClick={() => onSubmit?.('I attack the dragon')}>Submit</button>
     </div>
   ),
 }))
@@ -538,6 +539,89 @@ describe('GameSessionView', () => {
             body: JSON.stringify({ action_text: 'I attack the dragon!' }),
           })
         )
+      })
+    })
+  })
+
+  describe('DIN-64: optimistic player message', () => {
+    it('optimistic message appears immediately before fetch resolves', async () => {
+      // fetch never resolves during this test
+      ;(global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}))
+
+      testContext.playersData = [{ id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' }]
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+
+      await waitFor(() => expect(screen.getByTestId('chat-input')).toBeInTheDocument())
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      // Optimistic message should cause messages count to increase immediately
+      await waitFor(() => {
+        expect(screen.getByTestId('messages-count')).toHaveTextContent('1')
+      })
+    })
+
+    it('optimistic message is replaced (not duplicated) when Realtime INSERT fires with matching content', async () => {
+      let realtimeInsertCallback: ((payload: any) => void) | null = null
+
+      const channelObj: any = {
+        on: jest.fn().mockImplementation((_event: any, _filter: any, cb: any) => {
+          realtimeInsertCallback = cb
+          return channelObj
+        }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+      }
+      mockSupabaseClient.channel.mockReturnValue(channelObj)
+
+      ;(global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}))
+      testContext.playersData = [{ id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' }]
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() => expect(screen.getByTestId('chat-input')).toBeInTheDocument())
+
+      // Push optimistic message
+      act(() => { fireEvent.click(screen.getByTestId('submit-action')) })
+      await waitFor(() => expect(screen.getByTestId('messages-count')).toHaveTextContent('1'))
+
+      // Realtime fires the real message
+      act(() => {
+        realtimeInsertCallback?.({
+          new: {
+            id: 'real-msg-1',
+            game_id: 'game-1',
+            role: 'player',
+            profile_id: 'user-1',
+            content: 'I attack the dragon',
+            created_at: new Date().toISOString(),
+          },
+        })
+      })
+
+      // Still exactly 1 message — optimistic replaced, not duplicated
+      await waitFor(() => {
+        expect(screen.getByTestId('messages-count')).toHaveTextContent('1')
+      })
+    })
+
+    it('optimistic message is removed and isWaiting becomes false on fetch error', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: 'Server error' }),
+      })
+      testContext.playersData = [{ id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' }]
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() => expect(screen.getByTestId('chat-input')).toBeInTheDocument())
+
+      act(() => { fireEvent.click(screen.getByTestId('submit-action')) })
+
+      // After error, message should be gone and not waiting
+      await waitFor(() => {
+        expect(screen.getByTestId('messages-count')).toHaveTextContent('0')
+        expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
       })
     })
   })


### PR DESCRIPTION
## Summary

- **Remove embedding from HTTP request path**: `POST /actions` and `PATCH /messages` no longer call OpenAI or search RAG — they return 202 immediately after inserting the player message and queuing the task
- **Move embed + RAG to task Step 0**: `dm_response_task` now runs `embed_text` + `search_rag` at the start of the worker; degrades gracefully to no-RAG context on failure
- **Realtime fires earlier**: DM message is inserted to `game_messages` (triggering Supabase Realtime broadcast) *before* event embedding, so the player sees the DM response without waiting for N×OpenAI calls
- **Optimistic player message**: Frontend pushes a temporary message to the chat immediately on submit, before the fetch completes; reconciled with the Realtime INSERT by `profile_id + content` match; removed on fetch error

## Test plan

- [ ] All 177 backend tests pass (`pytest -q`)
- [ ] All 502 frontend tests pass (`npx jest --no-coverage`)
- [ ] `test_create_action_does_not_call_openai_embedding` — verifies OpenAI is never called in the request path
- [ ] `test_create_action_send_no_rag_context_kwarg` — verifies `rag_context` kwarg removed from `send()`
- [ ] `test_dm_response_task_embeds_action_text_at_task_start` — verifies `embed_text` called inside task
- [ ] `test_dm_response_task_inserts_dm_message_before_game_events` — verifies ordering: `game_messages` insert before `game_events`
- [ ] `DIN-64: optimistic player message` test suite (3 tests) — appearance, reconciliation, removal on error

https://claude.ai/code/session_0126Ds6pbRKUMTUWz72fxuZk