### PR TITLE
feat(DIN-58, DIN-26, DIN-28): theme lobby + combat narration + XP awards and level-up flow

### DIFF
--- a/backend/api/routes/level_up.py
+++ b/backend/api/routes/level_up.py
@@ -1,0 +1,116 @@
+"""Level-up endpoint: POST /games/{game_id}/level-up."""
+
+import logging
+import math
+import random
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from config import supabase_client
+from api.dependencies import get_current_user
+from utils.dnd import HIT_DICE_BY_CLASS, SPELL_SLOTS_BY_CLASS_LEVEL
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_PROFICIENCY_BONUS_BY_LEVEL: dict[int, int] = {
+    1: 2, 2: 2, 3: 2, 4: 2,
+    5: 3, 6: 3, 7: 3, 8: 3,
+    9: 4, 10: 4, 11: 4, 12: 4,
+    13: 5, 14: 5, 15: 5, 16: 5,
+    17: 6, 18: 6, 19: 6, 20: 6,
+}
+
+
+class LevelUpRequest(BaseModel):
+    character_id: str
+    hp_choice: str  # "roll" | "average"
+
+
+class LevelUpResponse(BaseModel):
+    level: int
+    hp_max: int
+    hp_gained: int
+
+
+@router.post("/{game_id}/level-up", response_model=LevelUpResponse)
+async def level_up(
+    game_id: str,
+    body: LevelUpRequest,
+    current_user: str = Depends(get_current_user),
+):
+    """Confirm a level-up: increment level, increase HP, update spell slots."""
+    if body.hp_choice not in ("roll", "average"):
+        raise HTTPException(status_code=422, detail="hp_choice must be 'roll' or 'average'")
+
+    # Fetch character, verify ownership
+    player_result = (
+        supabase_client.table("players")
+        .select("id, game_id, profile_id, character_class, level, hp_current, hp_max, stats")
+        .eq("game_id", game_id)
+        .eq("id", body.character_id)
+        .maybe_single()
+        .execute()
+    )
+
+    if not player_result.data:
+        raise HTTPException(status_code=404, detail="Character not found in this game")
+
+    player = player_result.data
+
+    if player["profile_id"] != current_user:
+        raise HTTPException(status_code=403, detail="You do not own this character")
+
+    current_level = player["level"]
+    new_level = current_level + 1
+    character_class = player["character_class"]
+    stats = player.get("stats") or {}
+    con_score = stats.get("con", 10)
+    con_mod = math.floor((con_score - 10) / 2)
+
+    # Determine hit die sides for this class
+    die_sides = HIT_DICE_BY_CLASS.get(character_class.lower(), 8)
+
+    # Server-side HP roll (never trust client value)
+    if body.hp_choice == "roll":
+        roll = random.randint(1, die_sides)
+    else:
+        roll = math.ceil(die_sides / 2)
+
+    hp_gained = max(1, roll + con_mod)
+    new_hp_max = player["hp_max"] + hp_gained
+    new_hp_current = player["hp_current"] + hp_gained
+
+    # Update spell slots for new level
+    new_spell_slots = None
+    class_slots = SPELL_SLOTS_BY_CLASS_LEVEL.get(character_class.lower())
+    if class_slots is not None:
+        raw_slots = class_slots.get(min(new_level, 5), {})
+        if raw_slots:
+            new_spell_slots = {
+                str(lvl): {"max": count, "used": 0}
+                for lvl, count in raw_slots.items()
+            }
+        else:
+            new_spell_slots = {}
+
+    # Update proficiency bonus if level crossed a threshold
+    new_prof = _PROFICIENCY_BONUS_BY_LEVEL.get(new_level, 2)
+    stats["proficiency_bonus"] = new_prof
+
+    if new_spell_slots is not None:
+        stats["spell_slots"] = new_spell_slots
+
+    supabase_client.table("players").update({
+        "level": new_level,
+        "hp_max": new_hp_max,
+        "hp_current": new_hp_current,
+        "stats": stats,
+    }).eq("id", body.character_id).execute()
+
+    logger.info(
+        f"[level_up] {player['character_class']} {body.character_id} "
+        f"levelled to {new_level}, hp_gained={hp_gained}"
+    )
+
+    return LevelUpResponse(level=new_level, hp_max=new_hp_max, hp_gained=hp_gained)

--- a/backend/api/routes/players.py
+++ b/backend/api/routes/players.py
@@ -118,6 +118,7 @@ async def upsert_player(
             str(lvl): {"max": raw_slots.get(lvl, 0), "used": 0}
             for lvl in range(1, 4)
         }
+    stats_dict["xp"] = 0
     upsert_result = (
         supabase_client.table("players")
         .upsert(

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from dramatiq import get_broker
 from config import settings, supabase_client
 from redis_broker import redis_client
 from api.middleware import add_middleware
-from api.routes import games, players, actions, invites, messages
+from api.routes import games, players, actions, invites, messages, level_up
 
 
 @asynccontextmanager
@@ -55,6 +55,7 @@ app.include_router(players.router, prefix="/games", tags=["players"])
 app.include_router(actions.router, prefix="/games", tags=["actions"])
 app.include_router(invites.router, prefix="/games", tags=["invites"])
 app.include_router(messages.router, prefix="/games", tags=["messages"])
+app.include_router(level_up.router, prefix="/games", tags=["level-up"])
 
 
 @app.get("/health")

--- a/backend/services/dm_service.py
+++ b/backend/services/dm_service.py
@@ -6,10 +6,13 @@ This module handles synchronous pre-processing before enqueueing.
 
 import json
 import logging
+import os
 import re
 from typing import Any
+import httpx
 from config import supabase_client
 from constants import GAME_STATUS_ACTIVE, PLAYER_STATUS_DEAD
+from utils.dnd import XP_THRESHOLDS
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +137,39 @@ def extract_state_changes(dm_response: str) -> dict:
     return parsed
 
 
-def apply_state_changes(state_changes: dict) -> None:
+def broadcast_level_up_available(game_id: str, character_id: str, new_level: int) -> None:
+    """Broadcast level_up_available event to Supabase Realtime channel via REST API."""
+    supabase_url = os.environ.get("SUPABASE_URL", "")
+    service_role_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    if not supabase_url or not service_role_key:
+        logger.warning("broadcast_level_up_available: missing SUPABASE_URL or key; skipping")
+        return
+    try:
+        httpx.post(
+            f"{supabase_url}/realtime/v1/api/broadcast",
+            headers={
+                "apikey": service_role_key,
+                "Authorization": f"Bearer {service_role_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "messages": [{
+                    "topic": f"realtime:game:{game_id}",
+                    "event": "level_up_available",
+                    "payload": {
+                        "type": "level_up_available",
+                        "character_id": character_id,
+                        "new_level": new_level,
+                    },
+                }]
+            },
+            timeout=5.0,
+        )
+    except Exception as e:
+        logger.error(f"broadcast_level_up_available: failed for game={game_id}: {e}")
+
+
+def apply_state_changes(state_changes: dict, game_id: str | None = None) -> None:
     """
     Apply mechanical state mutations from a <state_changes> block to the DB.
     All operations are best-effort — failures are logged but do NOT propagate.
@@ -234,6 +269,35 @@ def apply_state_changes(state_changes: dict) -> None:
             ).execute()
         except Exception as e:
             logger.error(f"apply_state_changes: spell_slots_recharge failed for {change}: {e}")
+
+    # XP awards (DIN-28)
+    for award in state_changes.get("xp_awards", []):
+        try:
+            character_id = award["character_id"]
+            amount = int(award["amount"])
+            player = (
+                supabase_client.table("players")
+                .select("stats, level")
+                .eq("id", character_id)
+                .single()
+                .execute()
+            )
+            stats = player.data.get("stats") or {}
+            current_xp = stats.get("xp") or 0
+            new_xp = current_xp + amount
+            stats["xp"] = new_xp
+            supabase_client.table("players").update({"stats": stats}).eq(
+                "id", character_id
+            ).execute()
+
+            # Check level threshold
+            current_level = player.data.get("level", 1)
+            next_level = current_level + 1
+            next_threshold = XP_THRESHOLDS.get(next_level)
+            if next_threshold is not None and new_xp >= next_threshold and game_id:
+                broadcast_level_up_available(game_id, character_id, next_level)
+        except Exception as e:
+            logger.error(f"apply_state_changes: xp_awards failed for {award}: {e}")
 
     # Inventory removals
     for item in state_changes.get("inventory_remove", []):

--- a/backend/tasks/dm_tasks.py
+++ b/backend/tasks/dm_tasks.py
@@ -264,14 +264,30 @@ RULES:
        "modifier": <signed integer, 0 if none>,
        "total": <result + modifier>,
        "label": "<human-readable label, e.g. Stealth Check>",
-       "dc": <integer, only for checks/saves>,
-       "success": <true|false, only when dc is present>,
+       "dc": <integer, only for ability checks/saves>,
+       "ac": <integer, only for attack rolls — use instead of dc>,
+       "success": <true|false, required when dc or ac is present>,
        "advantage": <true|false, only when relevant>,
        "all_rolls": [<roll1>, <roll2>]
      }}
    ]
    </dice_rolls>
    Rules: result must satisfy 1 ≤ result ≤ (count × die_sides). Include one entry per distinct roll.
+   For attack rolls use "ac" (not "dc"). For ability checks/saves use "dc" (not "ac").
+11. COMBAT RULES:
+   - When a player declares a combat action, adjudicate the exchange narratively:
+     1. Roll player attack (d20 + STR/DEX mod + proficiency if proficient) vs target AC
+     2. On a hit: roll damage dice per weapon type, add modifier
+     3. Narrate enemy reaction and counterattack if applicable
+     4. Embed ALL rolls in <dice_rolls> block (attack + damage + enemy rolls as separate entries)
+     5. Emit <state_changes> with hp_changes for all HP deltas in the exchange
+   - Use SRD 5e weapon damage for player characters based on their equipment list
+   - Invent plausible NPC ACs by creature type: Goblin 13, Bandit 12, Orc 13, Guard 16
+   - Critical Hit (natural 20): double the damage dice (e.g. 2d8 instead of 1d8),
+     add modifier once, note it explicitly in narration
+   - Critical Miss (natural 1): automatic miss, narrate the fumble
+   - At 0 HP: narrate unconsciousness; prompt Death Saving Throw on next player action
+   - Death Saving Throw: d20, no modifier, dc: 10, label: "Death Saving Throw"
 
 The acting player's action:
 "{action_text}"

--- a/backend/tasks/dm_tasks.py
+++ b/backend/tasks/dm_tasks.py
@@ -288,6 +288,11 @@ RULES:
    - Critical Miss (natural 1): automatic miss, narrate the fumble
    - At 0 HP: narrate unconsciousness; prompt Death Saving Throw on next player action
    - Death Saving Throw: d20, no modifier, dc: 10, label: "Death Saving Throw"
+12. XP AWARDS: When players defeat enemies or complete objectives, award XP via the
+   xp_awards field in <state_changes>. Use SRD 5e encounter XP values as a guide.
+   Award XP to all players present.
+   Format: "xp_awards": [{{"character_id": "<ID>", "amount": 100, "reason": "Defeated goblin"}}]
+   Typical values: Goblin 50 XP, Bandit 100 XP, Orc 100 XP, completing a minor quest 150–300 XP.
 
 The acting player's action:
 "{action_text}"
@@ -316,7 +321,7 @@ The acting player's action:
         # Step 4b: Extract and apply state changes (HP, inventory)
         state_changes = extract_state_changes(dm_response)
         if state_changes:
-            apply_state_changes(state_changes)
+            apply_state_changes(state_changes, game_id=game_id)
             logger.info(
                 f"[dm_response_task] Applied state changes: {list(state_changes.keys())}"
             )

--- a/backend/tests/test_dm_tasks.py
+++ b/backend/tests/test_dm_tasks.py
@@ -1805,3 +1805,73 @@ class TestDin27SpellSlotsInSystemPrompt:
         # Should not raise ValueError
         prompt = self._run_task_and_capture_prompt(players_data)
         assert isinstance(prompt, str)
+
+
+class TestDin26CombatInstruction:
+    """DIN-26: Combat instruction block in dm_response_task system prompt."""
+
+    def _run_task_and_capture_prompt(self, players_data):
+        """Helper: run dm_response_task and return the captured system prompt."""
+        game_data = {"id": "game-1", "name": "Quest", "dm_persona": "DM"}
+        captured_prompt = {}
+
+        game_messages_mock = MagicMock()
+        game_messages_mock.select.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = MagicMock(data=[])
+        game_messages_mock.insert.return_value.execute.return_value = MagicMock()
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "games":
+                mock.select.return_value.match.return_value.single.return_value.execute.return_value = MagicMock(data=game_data)
+                mock.update.return_value.match.return_value.execute.return_value = MagicMock()
+                return mock
+            elif name == "players":
+                mock.select.return_value.match.return_value.execute.return_value = MagicMock(data=players_data)
+            elif name == "game_messages":
+                return game_messages_mock
+            elif name == "player_inventory":
+                mock.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+            elif name == "game_events":
+                mock.insert.return_value.execute.return_value = MagicMock()
+            return mock
+
+        def capture_create(**kwargs):
+            captured_prompt["system"] = kwargs.get("system", "")
+            resp = MagicMock()
+            resp.content = [MagicMock(text="The goblin falls.")]
+            return resp
+
+        with patch("tasks.dm_tasks.supabase_client") as mock_sb, \
+             patch("tasks.dm_tasks.anthropic_client") as mock_anthropic, \
+             patch("tasks.dm_tasks.openai_client") as mock_openai, \
+             patch("tasks.dm_tasks.embed_text", return_value=[0.1] * 1536), \
+             patch("tasks.dm_tasks.search_rag", return_value=[]):
+            mock_sb.table.side_effect = table_side_effect
+            mock_anthropic.messages.create.side_effect = capture_create
+            mock_openai.embeddings.create.return_value = MagicMock(data=[MagicMock(embedding=[0.1] * 1536)])
+            dm_response_task.fn("game-1", "msg-1", "I attack the goblin!")
+
+        return captured_prompt.get("system", "")
+
+    def test_combat_instruction_block_in_system_prompt(self):
+        """DIN-26: system prompt must include COMBAT RULES instruction block."""
+        players_data = [
+            {
+                "id": "player-1",
+                "character_name": "Hero",
+                "race": "Human",
+                "level": 1,
+                "character_class": "Fighter",
+                "hp_current": 10,
+                "hp_max": 10,
+                "profile_id": "user-1",
+                "stats": {"str": 16, "dex": 12, "con": 14, "int": 10, "wis": 10, "cha": 8},
+            }
+        ]
+        prompt = self._run_task_and_capture_prompt(players_data)
+        assert "COMBAT RULES" in prompt, \
+            "System prompt must include COMBAT RULES instruction block"
+        assert "ac" in prompt.lower(), \
+            "System prompt must mention 'ac' (armor class) for attack rolls"
+        assert "goblin" in prompt.lower() or "npc" in prompt.lower() or "13" in prompt, \
+            "System prompt must include NPC AC reference values"

--- a/backend/tests/test_dm_tasks.py
+++ b/backend/tests/test_dm_tasks.py
@@ -24,6 +24,7 @@ with patch("config.supabase_client", MagicMock()), patch(
         generate_end_message,
         generate_resume_narration,
     )
+    from services.dm_service import apply_state_changes
 
 
 class TestGenerateOpeningNarration:
@@ -1875,3 +1876,81 @@ class TestDin26CombatInstruction:
             "System prompt must mention 'ac' (armor class) for attack rolls"
         assert "goblin" in prompt.lower() or "npc" in prompt.lower() or "13" in prompt, \
             "System prompt must include NPC AC reference values"
+
+
+class TestDin28XpAwards:
+    """DIN-28: xp_awards in apply_state_changes + threshold broadcast."""
+
+    def _player(self, xp: int = 0, level: int = 1, con: int = 14) -> dict:
+        return {
+            "id": "player-1",
+            "game_id": "game-1",
+            "profile_id": "user-1",
+            "character_name": "Hero",
+            "character_class": "Fighter",
+            "level": level,
+            "hp_current": 10,
+            "hp_max": 10,
+            "stats": {
+                "str": 16, "dex": 12, "con": con, "int": 10, "wis": 10, "cha": 8,
+                "xp": xp,
+            },
+        }
+
+    def test_xp_awards_increments_stats_xp(self):
+        """apply_state_changes with xp_awards should increment stats.xp."""
+        player = self._player(xp=100, level=1)
+        captured_update: dict = {}
+
+        def update_side_effect(payload):
+            captured_update.update(payload)
+            mock = MagicMock()
+            mock.eq.return_value.execute.return_value = MagicMock()
+            return mock
+
+        with patch("services.dm_service.supabase_client") as mock_sb, \
+             patch("services.dm_service.broadcast_level_up_available"):
+            mock_sb.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(data=player)
+            mock_sb.table.return_value.update.side_effect = update_side_effect
+
+            apply_state_changes(
+                {"xp_awards": [{"character_id": "player-1", "amount": 50, "reason": "Defeated goblin"}]},
+                game_id="game-1",
+            )
+
+        assert "stats" in captured_update
+        assert captured_update["stats"]["xp"] == 150
+
+    def test_broadcast_called_when_xp_crosses_level_threshold(self):
+        """Broadcast level_up_available when new XP >= XP_THRESHOLDS[level + 1]."""
+        # Level 1, xp=250 + 100 = 350 >= threshold for level 2 (300) → broadcast
+        player = self._player(xp=250, level=1)
+
+        with patch("services.dm_service.supabase_client") as mock_sb, \
+             patch("services.dm_service.broadcast_level_up_available") as mock_broadcast:
+            mock_sb.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(data=player)
+            mock_sb.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+
+            apply_state_changes(
+                {"xp_awards": [{"character_id": "player-1", "amount": 100, "reason": "Quest complete"}]},
+                game_id="game-1",
+            )
+
+        mock_broadcast.assert_called_once_with("game-1", "player-1", 2)
+
+    def test_broadcast_not_called_when_xp_below_threshold(self):
+        """Broadcast NOT called when new XP does not reach the next level threshold."""
+        # Level 1, xp=0 + 100 = 100 < 300 → no broadcast
+        player = self._player(xp=0, level=1)
+
+        with patch("services.dm_service.supabase_client") as mock_sb, \
+             patch("services.dm_service.broadcast_level_up_available") as mock_broadcast:
+            mock_sb.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(data=player)
+            mock_sb.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+
+            apply_state_changes(
+                {"xp_awards": [{"character_id": "player-1", "amount": 100, "reason": "Minor task"}]},
+                game_id="game-1",
+            )
+
+        mock_broadcast.assert_not_called()

--- a/backend/tests/test_level_up.py
+++ b/backend/tests/test_level_up.py
@@ -1,0 +1,105 @@
+"""Tests for POST /games/{game_id}/level-up endpoint (DIN-28)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+FIGHTER_PLAYER = {
+    "id": "player-1",
+    "game_id": "game-1",
+    "profile_id": "test-user-uuid-1234",  # matches conftest mock_auth_user
+    "character_name": "Thorin",
+    "character_class": "Fighter",
+    "level": 1,
+    "hp_current": 12,
+    "hp_max": 12,
+    "stats": {"str": 18, "dex": 10, "con": 16, "int": 8, "wis": 12, "cha": 9, "xp": 300},
+}
+
+WIZARD_PLAYER = {
+    "id": "player-2",
+    "game_id": "game-1",
+    "profile_id": "test-user-uuid-1234",
+    "character_name": "Elara",
+    "character_class": "Wizard",
+    "level": 1,
+    "hp_current": 7,
+    "hp_max": 7,
+    "stats": {"str": 8, "dex": 14, "con": 6, "int": 18, "wis": 12, "cha": 10, "xp": 300},
+}
+
+
+class TestLevelUpEndpoint:
+    """Tests for POST /games/{game_id}/level-up."""
+
+    def test_level_up_increments_level_and_hp(self, client, mock_supabase):
+        """Successful roll path: level, hp_max, hp_current all increase correctly."""
+        # Fighter: hit die d10. CON 16 → mod +3. Server rolls 8 → hp_gain = 8+3 = 11.
+        with patch("api.routes.level_up.supabase_client") as mock_sb, \
+             patch("random.randint", return_value=8):
+            mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value \
+                .maybe_single.return_value.execute.return_value = MagicMock(data=FIGHTER_PLAYER)
+            mock_sb.table.return_value.update.return_value.eq.return_value.execute.return_value = \
+                MagicMock(data={**FIGHTER_PLAYER, "level": 2, "hp_max": 23, "hp_current": 23})
+
+            response = client.post(
+                "/games/game-1/level-up",
+                json={"character_id": "player-1", "hp_choice": "roll"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["level"] == 2
+        assert data["hp_gained"] == 11   # 8 roll + 3 CON
+        assert data["hp_max"] == 23      # 12 + 11
+
+    def test_hp_gain_minimum_1(self, client, mock_supabase):
+        """hp_gain floors at 1 even with roll=1 and negative CON modifier."""
+        # Wizard: d6, CON 6 → mod -2. Roll 1 → max(1, 1-2) = max(1, -1) = 1.
+        with patch("api.routes.level_up.supabase_client") as mock_sb, \
+             patch("random.randint", return_value=1):
+            mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value \
+                .maybe_single.return_value.execute.return_value = MagicMock(data=WIZARD_PLAYER)
+            mock_sb.table.return_value.update.return_value.eq.return_value.execute.return_value = \
+                MagicMock(data={**WIZARD_PLAYER, "level": 2, "hp_max": 8, "hp_current": 8})
+
+            response = client.post(
+                "/games/game-1/level-up",
+                json={"character_id": "player-2", "hp_choice": "roll"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["hp_gained"] == 1
+
+    def test_server_roll_uses_class_hit_die(self, client, mock_supabase):
+        """Server calls random.randint(1, hit_die_sides) — never trusts client roll."""
+        with patch("api.routes.level_up.supabase_client") as mock_sb, \
+             patch("random.randint") as mock_randint:
+            mock_randint.return_value = 6
+            mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value \
+                .maybe_single.return_value.execute.return_value = MagicMock(data=FIGHTER_PLAYER)
+            mock_sb.table.return_value.update.return_value.eq.return_value.execute.return_value = \
+                MagicMock(data={**FIGHTER_PLAYER, "level": 2, "hp_max": 21, "hp_current": 21})
+
+            client.post(
+                "/games/game-1/level-up",
+                json={"character_id": "player-1", "hp_choice": "roll"},
+            )
+
+        # Fighter hit die = d10
+        mock_randint.assert_called_once_with(1, 10)
+
+    def test_caller_must_own_character(self, client, mock_supabase):
+        """Returns 403 when the character belongs to a different user."""
+        other_player = {**FIGHTER_PLAYER, "profile_id": "another-user-uuid"}
+
+        with patch("api.routes.level_up.supabase_client") as mock_sb:
+            mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value \
+                .maybe_single.return_value.execute.return_value = MagicMock(data=other_player)
+
+            response = client.post(
+                "/games/game-1/level-up",
+                json={"character_id": "player-1", "hp_choice": "roll"},
+            )
+
+        assert response.status_code == 403

--- a/backend/utils/dnd.py
+++ b/backend/utils/dnd.py
@@ -1,5 +1,108 @@
 """D&D 5e rules helpers for character generation."""
 
+# XP thresholds for levels 1–6 (MVP cap: level 5)
+XP_THRESHOLDS: dict[int, int] = {
+    1: 0,
+    2: 300,
+    3: 900,
+    4: 2700,
+    5: 6500,
+    6: 14000,
+}
+
+# Hit die sides by class (lowercase keys for case-insensitive lookup)
+HIT_DICE_BY_CLASS: dict[str, int] = {
+    "sorcerer": 6,
+    "wizard": 6,
+    "bard": 8,
+    "cleric": 8,
+    "druid": 8,
+    "monk": 8,
+    "rogue": 8,
+    "warlock": 8,
+    "fighter": 10,
+    "paladin": 10,
+    "ranger": 10,
+    "barbarian": 12,
+}
+
+# Class features unlocked at each level (levels 2–5, MVP scope)
+CLASS_FEATURES_BY_LEVEL: dict[str, dict[int, str]] = {
+    "barbarian": {
+        2: "Reckless Attack, Danger Sense",
+        3: "Primal Path feature",
+        4: "Ability Score Improvement",
+        5: "Extra Attack, Fast Movement",
+    },
+    "bard": {
+        2: "Jack of All Trades, Song of Rest",
+        3: "Bard College feature, Expertise",
+        4: "Ability Score Improvement",
+        5: "Bardic Inspiration (d8), Font of Inspiration",
+    },
+    "cleric": {
+        2: "Channel Divinity, Divine Domain feature",
+        3: "Divine Domain feature",
+        4: "Ability Score Improvement",
+        5: "Destroy Undead (CR 1/2)",
+    },
+    "druid": {
+        2: "Wild Shape, Druid Circle feature",
+        3: "Druid Circle feature",
+        4: "Wild Shape improvement, Ability Score Improvement",
+        5: "Wild Shape (CR 1)",
+    },
+    "fighter": {
+        2: "Action Surge, Fighting Style",
+        3: "Martial Archetype feature",
+        4: "Ability Score Improvement",
+        5: "Extra Attack",
+    },
+    "monk": {
+        2: "Ki, Unarmored Movement",
+        3: "Monastic Tradition feature, Deflect Missiles",
+        4: "Slow Fall, Ability Score Improvement",
+        5: "Extra Attack, Stunning Strike",
+    },
+    "paladin": {
+        2: "Divine Smite, Fighting Style, Spellcasting",
+        3: "Sacred Oath feature, Divine Health",
+        4: "Ability Score Improvement",
+        5: "Extra Attack",
+    },
+    "ranger": {
+        2: "Fighting Style, Spellcasting, Primeval Awareness",
+        3: "Ranger Archetype feature, Primeval Awareness",
+        4: "Ability Score Improvement",
+        5: "Extra Attack",
+    },
+    "rogue": {
+        2: "Cunning Action",
+        3: "Roguish Archetype feature, Sneak Attack (2d6)",
+        4: "Ability Score Improvement",
+        5: "Uncanny Dodge, Sneak Attack (3d6)",
+    },
+    "sorcerer": {
+        2: "Font of Magic",
+        3: "Sorcerous Origin feature, Metamagic",
+        4: "Ability Score Improvement",
+        5: "Sorcerous Origin feature",
+    },
+    "warlock": {
+        2: "Eldritch Invocations",
+        3: "Pact Boon",
+        4: "Ability Score Improvement",
+        5: "Eldritch Invocations improvement",
+    },
+    "wizard": {
+        2: "Arcane Tradition feature",
+        3: "Arcane Tradition feature",
+        4: "Ability Score Improvement",
+        5: "Arcane Tradition feature",
+    },
+}
+
+
 HIT_DIE: dict[str, int] = {
     "Barbarian": 12,
     "Fighter": 10,

--- a/frontend/e2e/combat-narration.spec.ts
+++ b/frontend/e2e/combat-narration.spec.ts
@@ -1,0 +1,683 @@
+import { test, expect, Page } from '@playwright/test'
+import type { DiceRollEvent } from '../src/lib/types/message'
+
+// ─── DIN-26: Combat narration — attack & damage dice display ─────────────────
+//
+// Verifies that combat-specific dice roll features in ChatMessage.tsx work
+// correctly:
+//  • attack-outcome-N display (total vs AC — Hit/Miss)
+//  • Critical hit styling  (data-crit="hit", gold border)
+//  • Critical miss styling (data-crit="miss", crimson border)
+//  • Full combat round: attack + damage dice rendered sequentially
+//  • Death Saving Throw rolls show cumulative tally
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAME_ID = 'test-game-combat'
+const USER_ID = 'user-1'
+const PLAYER_ID = 'player-combat-1'
+
+const MOCK_PLAYER = {
+  id: PLAYER_ID,
+  game_id: GAME_ID,
+  profile_id: USER_ID,
+  character_name: 'Thorin Ironforge',
+  character_class: 'Fighter',
+  race: 'Dwarf',
+  level: 3,
+  hp_current: 28,
+  hp_max: 34,
+  stats: { str: 16, dex: 10, con: 14, int: 10, wis: 12, cha: 8 },
+}
+
+// ─── Common mock helpers ──────────────────────────────────────────────────────
+
+async function setupCombatMocks(
+  page: Page,
+  options: {
+    initialDmMessage?: {
+      content: string
+      dice_rolls?: DiceRollEvent[] | null
+    }
+  } = {}
+) {
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+    })
+  )
+  await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'mock-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        user: { id: USER_ID, email: 'test@example.com' },
+      }),
+    })
+  )
+
+  await page.route('**.supabase.co/rest/v1/games**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: GAME_ID,
+            name: 'The Iron Mines',
+            dm_persona: 'A gritty combat DM',
+            status: 'active',
+            created_by: USER_ID,
+            updated_at: '2026-01-01T00:00:00Z',
+            suggested_actions: null,
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/players**', (route) => {
+    if (route.request().method() !== 'GET') return
+    const url = route.request().url()
+    if (url.includes(`id=eq.${PLAYER_ID}`)) {
+      // CharacterSheetPanel single-player fetch (.single()) — returns object, not array
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_PLAYER),
+      })
+    } else {
+      // GameSessionView player-list fetch
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([MOCK_PLAYER]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    }
+  })
+
+  const dmMsg = options.initialDmMessage ?? {
+    content: 'You stand at the entrance of the mines.',
+    dice_rolls: null,
+  }
+
+  const initialMessage = {
+    id: 'msg-dm-combat-1',
+    game_id: GAME_ID,
+    profile_id: null,
+    role: 'dm',
+    content: dmMsg.content,
+    dice_rolls: dmMsg.dice_rolls ?? null,
+    created_at: '2026-01-01T00:00:01Z',
+  }
+
+  await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+    if (route.request().method() === 'GET') {
+      const url = route.request().url()
+      if (url.includes('select=role')) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            { id: initialMessage.id, role: 'dm', created_at: initialMessage.created_at },
+          ]),
+        })
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([initialMessage]),
+        })
+      }
+    }
+  })
+}
+
+async function gotoGame(page: Page) {
+  await page.goto(`/games/${GAME_ID}`)
+  await expect(page.getByText('The Iron Mines')).toBeVisible({ timeout: 5000 })
+}
+
+// ─── DIN-26: Attack roll vs AC outcome display ───────────────────────────────
+
+test.describe('DIN-26 — Attack roll vs AC outcome', () => {
+  test('hit attack shows total vs AC with "Hit!" label (reduced motion)', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const attackRoll: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 15,
+      modifier: 4,
+      total: 19,
+      label: 'Attack Roll',
+      ac: 13,
+      success: true,
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: 'Your blade finds its mark!',
+        dice_rolls: [attackRoll],
+      },
+    })
+
+    await gotoGame(page)
+
+    const outcome = page.getByTestId('attack-outcome-0')
+    await expect(outcome).toBeVisible({ timeout: 3000 })
+    await expect(outcome).toContainText('19')
+    await expect(outcome).toContainText('AC 13')
+    await expect(outcome).toContainText('Hit!')
+  })
+
+  test('miss attack shows total vs AC with "Miss" label (reduced motion)', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const missRoll: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 6,
+      modifier: 3,
+      total: 9,
+      label: 'Attack Roll',
+      ac: 13,
+      success: false,
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: 'Your swing goes wide — the goblin ducks aside.',
+        dice_rolls: [missRoll],
+      },
+    })
+
+    await gotoGame(page)
+
+    const outcome = page.getByTestId('attack-outcome-0')
+    await expect(outcome).toBeVisible({ timeout: 3000 })
+    await expect(outcome).toContainText('9')
+    await expect(outcome).toContainText('AC 13')
+    await expect(outcome).toContainText('Miss')
+  })
+
+  test('attack outcome not rendered for non-attack rolls (no ac field)', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const stealth: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 14,
+      modifier: 3,
+      total: 17,
+      label: 'Stealth Check',
+      dc: 15,
+      success: true,
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: { content: 'You slip into the shadows.', dice_rolls: [stealth] },
+    })
+
+    await gotoGame(page)
+
+    // No attack-outcome for a stealth check
+    await expect(page.getByTestId('attack-outcome-0')).not.toBeVisible({ timeout: 3000 })
+  })
+
+  test('attack outcome appears via Realtime dm-message (reduced motion)', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await setupCombatMocks(page)
+    await gotoGame(page)
+    await expect(page.getByText('You stand at the entrance of the mines.')).toBeVisible({
+      timeout: 3000,
+    })
+
+    const attackRoll: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 18,
+      modifier: 4,
+      total: 22,
+      label: 'Attack Roll',
+      ac: 13,
+      success: true,
+    }
+
+    await page.evaluate(
+      ({ content, roll }) => {
+        window.dispatchEvent(
+          new CustomEvent('dm-message', {
+            detail: {
+              game_id: 'test-game-combat',
+              role: 'dm',
+              content,
+              dice_rolls: [roll],
+              created_at: new Date().toISOString(),
+            },
+          })
+        )
+      },
+      { content: 'Steel meets flesh!', roll: attackRoll }
+    )
+
+    const outcome = page.getByTestId('attack-outcome-0')
+    await expect(outcome).toBeVisible({ timeout: 3000 })
+    await expect(outcome).toContainText('22')
+    await expect(outcome).toContainText('Hit!')
+  })
+})
+
+// ─── DIN-26: Critical hit / miss styling ──────────────────────────────────────
+
+test.describe('DIN-26 — Critical hit and miss', () => {
+  test('natural 20 attack roll gets data-crit="hit" (reduced motion)', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const critHit: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 20,
+      modifier: 4,
+      total: 24,
+      label: 'Attack Roll',
+      ac: 13,
+      success: true,
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: '💥 Critical Hit! You score a devastating blow!',
+        dice_rolls: [critHit],
+      },
+    })
+
+    await gotoGame(page)
+
+    const card = page.getByTestId('dice-roll-card-0')
+    await expect(card).toBeVisible({ timeout: 3000 })
+    await expect(card).toHaveAttribute('data-crit', 'hit')
+  })
+
+  test('natural 1 attack roll gets data-crit="miss" (reduced motion)', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const critMiss: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 1,
+      modifier: 4,
+      total: 5,
+      label: 'Attack Roll',
+      ac: 13,
+      success: false,
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: '💀 Critical Miss! Your weapon slips from your grasp!',
+        dice_rolls: [critMiss],
+      },
+    })
+
+    await gotoGame(page)
+
+    const card = page.getByTestId('dice-roll-card-0')
+    await expect(card).toBeVisible({ timeout: 3000 })
+    await expect(card).toHaveAttribute('data-crit', 'miss')
+  })
+
+  test('non-nat-20 hit roll does NOT get data-crit attribute (reduced motion)', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const normalHit: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 15,
+      modifier: 4,
+      total: 19,
+      label: 'Attack Roll',
+      ac: 13,
+      success: true,
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: 'A solid hit!',
+        dice_rolls: [normalHit],
+      },
+    })
+
+    await gotoGame(page)
+
+    const card = page.getByTestId('dice-roll-card-0')
+    await expect(card).toBeVisible({ timeout: 3000 })
+    await expect(card).not.toHaveAttribute('data-crit')
+  })
+
+  test('damage roll (no ac field) never gets data-crit attribute (reduced motion)', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const damageRoll: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd8',
+      count: 1,
+      result: 7,
+      modifier: 3,
+      total: 10,
+      label: 'Longsword Damage',
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: 'The blade bites deep.',
+        dice_rolls: [damageRoll],
+      },
+    })
+
+    await gotoGame(page)
+
+    const card = page.getByTestId('dice-roll-card-0')
+    await expect(card).toBeVisible({ timeout: 3000 })
+    await expect(card).not.toHaveAttribute('data-crit')
+  })
+})
+
+// ─── DIN-26: Full combat round (multiple dice) ───────────────────────────────
+
+test.describe('DIN-26 — Full combat round dice sequence', () => {
+  test('four dice (player attack + damage + enemy attack + enemy damage) all render (reduced motion)', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const playerAttack: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 15,
+      modifier: 4,
+      total: 19,
+      label: 'Attack Roll',
+      ac: 13,
+      success: true,
+    }
+    const playerDamage: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd8',
+      count: 1,
+      result: 6,
+      modifier: 3,
+      total: 9,
+      label: 'Longsword Damage',
+    }
+    const enemyAttack: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 8,
+      modifier: 2,
+      total: 10,
+      label: 'Goblin Attack',
+      ac: 16,
+      success: false,
+    }
+    const enemyDamage: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd6',
+      count: 1,
+      result: 3,
+      modifier: 1,
+      total: 4,
+      label: 'Goblin Damage',
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: 'Steel clashes with steel in the dim corridor!',
+        dice_rolls: [playerAttack, playerDamage, enemyAttack, enemyDamage],
+      },
+    })
+
+    await gotoGame(page)
+
+    // All 4 dice cards should render
+    await expect(page.getByTestId('dice-roll-card-0')).toBeVisible({ timeout: 3000 })
+    await expect(page.getByTestId('dice-roll-card-1')).toBeVisible()
+    await expect(page.getByTestId('dice-roll-card-2')).toBeVisible()
+    await expect(page.getByTestId('dice-roll-card-3')).toBeVisible()
+
+    // 4 die-type badges total
+    await expect(page.getByTestId('die-type-badge')).toHaveCount(4)
+
+    // Labels visible
+    await expect(page.getByText('Attack Roll')).toBeVisible()
+    await expect(page.getByText('Longsword Damage')).toBeVisible()
+    await expect(page.getByText('Goblin Attack')).toBeVisible()
+    await expect(page.getByText('Goblin Damage')).toBeVisible()
+
+    // Player attack hit, enemy attack missed
+    await expect(page.getByTestId('attack-outcome-0')).toContainText('Hit!')
+    await expect(page.getByTestId('attack-outcome-2')).toContainText('Miss')
+
+    // Narration visible after all dice settle
+    await expect(page.getByText('Steel clashes with steel in the dim corridor!')).toBeVisible()
+  })
+
+  test('critical hit in combat round: first dice card has data-crit=hit (reduced motion)', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const critHitAttack: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 20,
+      modifier: 4,
+      total: 24,
+      label: 'Attack Roll',
+      ac: 13,
+      success: true,
+    }
+    const critDamage: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd8',
+      count: 2, // doubled on crit
+      result: 13,
+      modifier: 3,
+      total: 16,
+      label: 'Critical Damage (2d8)',
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: '💥 Critical Hit! Double damage flies!',
+        dice_rolls: [critHitAttack, critDamage],
+      },
+    })
+
+    await gotoGame(page)
+
+    await expect(page.getByTestId('dice-roll-card-0')).toHaveAttribute('data-crit', 'hit', {
+      timeout: 3000,
+    })
+    // Damage card has no data-crit
+    await expect(page.getByTestId('dice-roll-card-1')).not.toHaveAttribute('data-crit')
+  })
+})
+
+// ─── DIN-26: Death Saving Throw tally ────────────────────────────────────────
+
+test.describe('DIN-26 — Death Saving Throw tally display', () => {
+  test('death saving throw shows tally when priorDeathSaves supplied via Realtime (reduced motion)', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await setupCombatMocks(page)
+    await gotoGame(page)
+    await expect(page.getByText('You stand at the entrance of the mines.')).toBeVisible({
+      timeout: 3000,
+    })
+
+    const deathSave: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 14,
+      modifier: 0,
+      total: 14,
+      label: 'Death Saving Throw',
+      dc: 10,
+      success: true,
+    }
+
+    // The chat message component receives priorDeathSaves via the ChatLog.
+    // In E2E, we dispatch a dm-message without priorDeathSaves to first verify
+    // the tally container does NOT appear; then we check the label logic.
+    // priorDeathSaves is derived from narration context (not stored in DB).
+    // Since the E2E setup doesn't wire priorDeathSaves we verify the base roll renders.
+    await page.evaluate(
+      ({ content, roll }) => {
+        window.dispatchEvent(
+          new CustomEvent('dm-message', {
+            detail: {
+              game_id: 'test-game-combat',
+              role: 'dm',
+              content,
+              dice_rolls: [roll],
+              created_at: new Date().toISOString(),
+            },
+          })
+        )
+      },
+      { content: 'You cling to life...', roll: deathSave }
+    )
+
+    // The die renders correctly as a d20 with "Death Saving Throw" label
+    await expect(page.getByTestId('die-type-badge')).toBeVisible({ timeout: 3000 })
+    await expect(page.getByText('Death Saving Throw')).toBeVisible()
+
+    // Outcome badge shows success (roll 14 ≥ DC 10)
+    await expect(page.getByTestId('outcome-badge')).toBeVisible()
+    await expect(page.getByTestId('outcome-badge')).toContainText('Success')
+  })
+
+  test('death save tally renders when priorDeathSaves is passed (initial message with tally context)', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    // The tally is shown when the ChatLog passes priorDeathSaves to ChatMessage.
+    // In the initial loaded messages scenario, priorDeathSaves is computed from
+    // the message history. Here we test the tally is absent when priorDeathSaves
+    // is not passed (default E2E scenario) — the unit tests cover the tally display.
+    const deathSave: DiceRollEvent = {
+      type: 'dice_roll',
+      die: 'd20',
+      count: 1,
+      result: 5,
+      modifier: 0,
+      total: 5,
+      label: 'Death Saving Throw',
+      dc: 10,
+      success: false,
+    }
+
+    await setupCombatMocks(page, {
+      initialDmMessage: {
+        content: 'You falter on the edge of death...',
+        dice_rolls: [deathSave],
+      },
+    })
+
+    await gotoGame(page)
+
+    // Outcome badge shows failure
+    const badge = page.getByTestId('outcome-badge')
+    await expect(badge).toBeVisible({ timeout: 3000 })
+    await expect(badge).toContainText('Failure')
+
+    // Without prior death saves context, the tally element is not rendered
+    await expect(page.getByTestId('death-save-tally')).not.toBeVisible()
+  })
+})
+
+// ─── DIN-26: HP bar updates during combat ─────────────────────────────────────
+
+test.describe('DIN-26 — HP bar updates after combat damage', () => {
+  test('HP bar transitions to low state after combat damage via e2e-player-update', async ({
+    page,
+  }) => {
+    await setupCombatMocks(page)
+    await gotoGame(page)
+
+    // Open the character sheet
+    await page.getByTestId('sheet-button').click()
+    const sheet = page.getByRole('dialog', { name: 'Character Sheet' })
+    await expect(sheet).toBeVisible({ timeout: 3000 })
+
+    // Initial HP: 28/34 → ~82% → high
+    await expect(sheet.getByTestId('hp-bar').last()).toHaveAttribute('data-hp-state', 'high', {
+      timeout: 3000,
+    })
+
+    // Combat damage: hp drops to 7 (below 25% threshold)
+    await page.evaluate((playerId) => {
+      window.dispatchEvent(
+        new CustomEvent(`e2e-player-update-${playerId}`, {
+          detail: { hp_current: 7 },
+        })
+      )
+    }, PLAYER_ID)
+
+    await expect(sheet.getByTestId('hp-bar').last()).toHaveAttribute('data-hp-state', 'low', {
+      timeout: 2000,
+    })
+  })
+
+  test('unconscious label appears when HP reaches 0 via combat damage', async ({ page }) => {
+    await setupCombatMocks(page)
+    await gotoGame(page)
+
+    await page.getByTestId('sheet-button').click()
+    const sheet = page.getByRole('dialog', { name: 'Character Sheet' })
+    await expect(sheet).toBeVisible({ timeout: 3000 })
+
+    // Character drops to 0 HP
+    await page.evaluate((playerId) => {
+      window.dispatchEvent(
+        new CustomEvent(`e2e-player-update-${playerId}`, {
+          detail: { hp_current: 0 },
+        })
+      )
+    }, PLAYER_ID)
+
+    await expect(page.getByTestId('unconscious-label')).toBeVisible({ timeout: 2000 })
+    await expect(page.getByTestId('unconscious-label')).toContainText('Unconscious')
+  })
+})

--- a/frontend/e2e/level-up.spec.ts
+++ b/frontend/e2e/level-up.spec.ts
@@ -1,0 +1,596 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ─── DIN-28: XP awards and character level-up flow ───────────────────────────
+//
+// Verifies:
+//  1. CharacterSheetPanel level badge and XP bar display
+//  2. XP bar progress percentage and label
+//  3. Max-level XP display
+//  4. Level-up toast appears when level-up-available E2E event fires
+//  5. Toast contains correct level number and dismiss works
+//  6. Level Up button opens LevelUpModal
+//  7. LevelUpModal heading, HP options, spell-slot diff
+//  8. Confirm Level Up via "Take Average" hits the proxy API
+//  9. Modal cancel closes without API call
+// 10. Modal error state
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAME_ID = 'test-game-levelup'
+const USER_ID = 'user-1'
+const PLAYER_ID = 'player-lv1'
+
+const FIGHTER_PLAYER = {
+  id: PLAYER_ID,
+  game_id: GAME_ID,
+  profile_id: USER_ID,
+  character_name: 'Bran Ironwall',
+  character_class: 'Fighter',
+  race: 'Human',
+  level: 1,
+  hp_current: 12,
+  hp_max: 12,
+  stats: {
+    str: 16,
+    dex: 12,
+    con: 14,
+    int: 10,
+    wis: 10,
+    cha: 8,
+    spell_slots: null,
+    xp: 150,
+  },
+  status: 'active' as const,
+  joined_at: '2026-01-01T00:00:00Z',
+}
+
+const WIZARD_PLAYER = {
+  id: PLAYER_ID,
+  game_id: GAME_ID,
+  profile_id: USER_ID,
+  character_name: 'Elara Moonwhisper',
+  character_class: 'Wizard',
+  race: 'Elf',
+  level: 1,
+  hp_current: 8,
+  hp_max: 8,
+  stats: {
+    str: 8,
+    dex: 14,
+    con: 12,
+    int: 18,
+    wis: 14,
+    cha: 10,
+    spell_slots: { '1': { max: 2, used: 0 } },
+    xp: 150,
+  },
+  status: 'active' as const,
+  joined_at: '2026-01-01T00:00:00Z',
+}
+
+// ─── Setup helpers ────────────────────────────────────────────────────────────
+
+async function setupSessionMocks(
+  page: Page,
+  player: typeof FIGHTER_PLAYER | typeof WIZARD_PLAYER
+) {
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+    })
+  )
+  await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'mock-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        user: { id: USER_ID, email: 'test@example.com' },
+      }),
+    })
+  )
+
+  await page.route('**.supabase.co/rest/v1/games**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: GAME_ID,
+            name: 'The Ascent',
+            dm_persona: 'A legendary DM',
+            status: 'active',
+            created_by: USER_ID,
+            updated_at: '2026-01-01T00:00:00Z',
+            suggested_actions: null,
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/players**', (route) => {
+    if (route.request().method() === 'GET') {
+      const url = route.request().url()
+      if (url.includes(`id=eq.${PLAYER_ID}`)) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(player),
+        })
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([player]),
+        })
+      }
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+    }
+  })
+
+  const initMsg = {
+    id: 'msg-1',
+    game_id: GAME_ID,
+    profile_id: null,
+    role: 'dm',
+    content: 'A new adventure awaits.',
+    dice_rolls: null,
+    created_at: '2026-01-01T00:00:01Z',
+  }
+  await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+    if (route.request().method() === 'GET') {
+      const url = route.request().url()
+      if (url.includes('select=role')) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([{ id: initMsg.id, role: 'dm', created_at: initMsg.created_at }]),
+        })
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([initMsg]),
+        })
+      }
+    }
+  })
+}
+
+async function gotoGame(page: Page) {
+  await page.goto(`/games/${GAME_ID}`)
+  await expect(page.getByText('The Ascent')).toBeVisible({ timeout: 5000 })
+}
+
+async function openSheet(page: Page) {
+  await page.getByTestId('sheet-button').click()
+  await expect(page.getByRole('dialog', { name: 'Character Sheet' })).toBeVisible({ timeout: 3000 })
+}
+
+// ─── DIN-28: CharacterSheetPanel — level badge ───────────────────────────────
+
+test.describe('DIN-28 — Level badge in CharacterSheetPanel', () => {
+  test('level badge is visible in expanded sheet with correct level number', async ({ page }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+    await openSheet(page)
+
+    const badge = page.getByTestId('level-badge')
+    await expect(badge).toBeVisible()
+    await expect(badge).toContainText('1')
+  })
+
+  test('level badge updates when HP update also changes level via e2e-player-update', async ({
+    page,
+  }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+    await openSheet(page)
+
+    // Simulate level-up side effect — player row updates to level 2
+    await page.evaluate((playerId) => {
+      window.dispatchEvent(
+        new CustomEvent(`e2e-player-update-${playerId}`, {
+          detail: { level: 2, hp_max: 22, hp_current: 22 },
+        })
+      )
+    }, PLAYER_ID)
+
+    const badge = page.getByTestId('level-badge')
+    await expect(badge).toContainText('2', { timeout: 2000 })
+  })
+})
+
+// ─── DIN-28: XP bar ───────────────────────────────────────────────────────────
+
+test.describe('DIN-28 — XP bar in CharacterSheetPanel', () => {
+  test('XP bar is visible with correct xp-pct attribute (level 1, 150 XP / 300)', async ({
+    page,
+  }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+    await openSheet(page)
+
+    // 150 XP towards Level 2 (threshold 300), starting from Level 1 (threshold 0)
+    // pct = round((150 - 0) / (300 - 0) * 100) = 50
+    const xpBar = page.getByTestId('xp-bar')
+    await expect(xpBar).toBeVisible()
+    await expect(xpBar).toHaveAttribute('data-xp-pct', '50')
+  })
+
+  test('XP label shows "XP: 150 / 300 to Lv 2"', async ({ page }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+    await openSheet(page)
+
+    const sheet = page.getByRole('dialog', { name: 'Character Sheet' })
+    await expect(sheet.getByText(/150.*300.*Lv 2/)).toBeVisible()
+  })
+
+  test('max-level XP shows "Max level" text for level 5 character', async ({ page }) => {
+    const maxLevelPlayer = {
+      ...FIGHTER_PLAYER,
+      level: 5,
+      stats: { ...FIGHTER_PLAYER.stats, xp: 6500 },
+    }
+    await setupSessionMocks(page, maxLevelPlayer)
+    await gotoGame(page)
+    await openSheet(page)
+
+    await expect(page.getByText('Max level')).toBeVisible()
+
+    // XP bar should be at 100%
+    const xpBar = page.getByTestId('xp-bar')
+    await expect(xpBar).toHaveAttribute('data-xp-pct', '100')
+  })
+
+  test('XP bar updates in real-time after XP award via e2e-player-update', async ({ page }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+    await openSheet(page)
+
+    // Initial: 50% (150/300)
+    await expect(page.getByTestId('xp-bar')).toHaveAttribute('data-xp-pct', '50')
+
+    // XP award: 150 → 225 (75% of 300)
+    await page.evaluate((playerId) => {
+      window.dispatchEvent(
+        new CustomEvent(`e2e-player-update-${playerId}`, {
+          detail: {
+            stats: {
+              str: 16, dex: 12, con: 14, int: 10, wis: 10, cha: 8,
+              spell_slots: null,
+              xp: 225,
+            },
+          },
+        })
+      )
+    }, PLAYER_ID)
+
+    await expect(page.getByTestId('xp-bar')).toHaveAttribute('data-xp-pct', '75', {
+      timeout: 2000,
+    })
+  })
+
+  test('XP bar has data-xp-pct="0" when stats.xp is undefined (defaults to 0)', async ({
+    page,
+  }) => {
+    const noXpPlayer = {
+      ...FIGHTER_PLAYER,
+      stats: { str: 16, dex: 12, con: 14, int: 10, wis: 10, cha: 8, spell_slots: null },
+    }
+    await setupSessionMocks(page, noXpPlayer)
+    await gotoGame(page)
+    await openSheet(page)
+
+    // xp defaults to 0, threshold 0→300, pct = 0%
+    // width: 0% means the bar has no visible area — check attribute directly
+    const xpBar = page.getByTestId('xp-bar')
+    await expect(xpBar).toHaveAttribute('data-xp-pct', '0')
+    // The "Experience" label and xp text are visible even at 0%
+    await expect(page.getByText('Experience')).toBeVisible()
+  })
+})
+
+// ─── DIN-28: Level-up toast ───────────────────────────────────────────────────
+
+test.describe('DIN-28 — Level-up toast banner', () => {
+  test('toast appears when level-up-available event is dispatched', async ({ page }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+
+    // No toast initially
+    await expect(page.getByTestId('level-up-toast')).not.toBeVisible()
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('level-up-available', {
+          detail: { character_id: 'player-lv1', new_level: 2 },
+        })
+      )
+    })
+
+    await expect(page.getByTestId('level-up-toast')).toBeVisible({ timeout: 3000 })
+  })
+
+  test('toast shows the new level number', async ({ page }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('level-up-available', {
+          detail: { character_id: 'player-lv1', new_level: 3 },
+        })
+      )
+    })
+
+    const toast = page.getByTestId('level-up-toast')
+    await expect(toast).toBeVisible({ timeout: 3000 })
+    await expect(toast).toContainText('Level 3')
+  })
+
+  test('dismiss (✕) button closes the toast without opening modal', async ({ page }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('level-up-available', {
+          detail: { character_id: 'player-lv1', new_level: 2 },
+        })
+      )
+    })
+
+    const toast = page.getByTestId('level-up-toast')
+    await expect(toast).toBeVisible({ timeout: 3000 })
+
+    await page.getByRole('button', { name: /Dismiss level up/i }).click()
+
+    await expect(toast).not.toBeVisible()
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).not.toBeVisible()
+  })
+
+  test('"Level Up" button in toast opens the modal', async ({ page }) => {
+    await setupSessionMocks(page, FIGHTER_PLAYER)
+    await gotoGame(page)
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('level-up-available', {
+          detail: { character_id: 'player-lv1', new_level: 2 },
+        })
+      )
+    })
+
+    await expect(page.getByTestId('level-up-toast')).toBeVisible({ timeout: 3000 })
+
+    await page.getByRole('button', { name: /^Level Up$/i }).click()
+
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).toBeVisible({ timeout: 3000 })
+    // Toast hidden while modal is open
+    await expect(page.getByTestId('level-up-toast')).not.toBeVisible()
+  })
+})
+
+// ─── DIN-28: LevelUpModal ─────────────────────────────────────────────────────
+
+test.describe('DIN-28 — LevelUpModal content', () => {
+  async function openModal(page: Page, player = FIGHTER_PLAYER) {
+    await setupSessionMocks(page, player)
+    await gotoGame(page)
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('level-up-available', {
+          detail: { character_id: 'player-lv1', new_level: 2 },
+        })
+      )
+    })
+    await expect(page.getByTestId('level-up-toast')).toBeVisible({ timeout: 3000 })
+    await page.getByRole('button', { name: /^Level Up$/i }).click()
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).toBeVisible({ timeout: 3000 })
+  }
+
+  test('modal heading shows "You\'ve reached Level 2!"', async ({ page }) => {
+    await openModal(page)
+    const modal = page.getByRole('dialog', { name: 'Level Up' })
+    await expect(modal.getByText(/You.ve reached Level 2!/)).toBeVisible()
+  })
+
+  test('modal shows character name and class subtitle', async ({ page }) => {
+    await openModal(page)
+    const modal = page.getByRole('dialog', { name: 'Level Up' })
+    await expect(modal.getByText(/Bran Ironwall.*Fighter/)).toBeVisible()
+  })
+
+  test('modal shows level transition: 1 → 2', async ({ page }) => {
+    await openModal(page)
+    const modal = page.getByRole('dialog', { name: 'Level Up' })
+    await expect(modal.getByText(/1 → 2/)).toBeVisible()
+  })
+
+  test('"Take Average" card shows average HP value for Fighter (d10 + CON mod)', async ({
+    page,
+  }) => {
+    // Fighter: d10, CON=14 → mod=+2; avg = ceil(10/2)+2 = 7; min 1
+    await openModal(page)
+
+    const avgCard = page.getByTestId('hp-choice-average')
+    await expect(avgCard).toBeVisible()
+    await expect(avgCard).toContainText('+7')
+  })
+
+  test('selecting "Take Average" marks it as selected', async ({ page }) => {
+    await openModal(page)
+
+    const avgCard = page.getByTestId('hp-choice-average')
+    await avgCard.click()
+
+    // "Confirm Level Up" button should become enabled (was disabled without selection)
+    await expect(
+      page.getByRole('button', { name: /Confirm Level Up/i })
+    ).toBeEnabled()
+  })
+
+  test('"Roll" card appears and shows dice roller after clicking', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await openModal(page)
+
+    const rollCard = page.getByTestId('hp-choice-roll')
+    await expect(rollCard).toBeVisible()
+    await rollCard.click()
+
+    // DiceRoller is rendered inside the roll card
+    await expect(rollCard.getByTestId('die-type-badge')).toBeVisible({ timeout: 3000 })
+  })
+
+  test('cancel button closes modal and shows toast again', async ({ page }) => {
+    await openModal(page)
+
+    await page.getByRole('button', { name: /Cancel/i }).click()
+
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).not.toBeVisible({ timeout: 2000 })
+    // Toast should reappear
+    await expect(page.getByTestId('level-up-toast')).toBeVisible()
+  })
+
+  test('spell slot diff section shown for Wizard levelling up', async ({ page }) => {
+    // Wizard levels from 1→2: gains spell slots
+    await openModal(page, WIZARD_PLAYER)
+
+    const modal = page.getByRole('dialog', { name: 'Level Up' })
+    await expect(modal.getByTestId('spell-slot-diff')).toBeVisible()
+    // Wizard L1→L2: 1st level slots go from 2→3
+    await expect(modal.getByText(/1st level/)).toBeVisible()
+  })
+
+  test('spell slot diff section NOT shown for Fighter (non-spellcaster)', async ({ page }) => {
+    await openModal(page, FIGHTER_PLAYER)
+
+    const modal = page.getByRole('dialog', { name: 'Level Up' })
+    await expect(modal.getByTestId('spell-slot-diff')).not.toBeVisible()
+  })
+})
+
+// ─── DIN-28: LevelUpModal — confirm API call ──────────────────────────────────
+
+test.describe('DIN-28 — LevelUpModal confirm and API', () => {
+  async function openModal(page: Page, player = FIGHTER_PLAYER) {
+    await setupSessionMocks(page, player)
+    await gotoGame(page)
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('level-up-available', {
+          detail: { character_id: 'player-lv1', new_level: 2 },
+        })
+      )
+    })
+    await expect(page.getByTestId('level-up-toast')).toBeVisible({ timeout: 3000 })
+    await page.getByRole('button', { name: /^Level Up$/i }).click()
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).toBeVisible({ timeout: 3000 })
+  }
+
+  test('confirming "Take Average" calls POST /api/games/{gameId}/level-up', async ({ page }) => {
+    let levelUpCalled = false
+    let requestBody: unknown = null
+
+    await page.route(`**/api/games/${GAME_ID}/level-up`, (route) => {
+      if (route.request().method() === 'POST') {
+        levelUpCalled = true
+        const body = route.request().postData()
+        if (body) requestBody = JSON.parse(body)
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ level: 2, hp_max: 19, hp_gained: 7 }),
+        })
+      }
+    })
+
+    await openModal(page)
+
+    await page.getByTestId('hp-choice-average').click()
+    await page.getByRole('button', { name: /Confirm Level Up/i }).click()
+
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).not.toBeVisible({
+      timeout: 3000,
+    })
+    expect(levelUpCalled).toBe(true)
+  })
+
+  test('success: modal closes and toast is dismissed after confirm', async ({ page }) => {
+    await page.route(`**/api/games/${GAME_ID}/level-up`, (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ level: 2, hp_max: 19, hp_gained: 7 }),
+        })
+      }
+    })
+
+    await openModal(page)
+
+    await page.getByTestId('hp-choice-average').click()
+    await page.getByRole('button', { name: /Confirm Level Up/i }).click()
+
+    // Both modal and toast are gone
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).not.toBeVisible({ timeout: 3000 })
+    await expect(page.getByTestId('level-up-toast')).not.toBeVisible()
+  })
+
+  test('error state shown when API returns error', async ({ page }) => {
+    await page.route(`**/api/games/${GAME_ID}/level-up`, (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Internal server error' }),
+        })
+      }
+    })
+
+    await openModal(page)
+
+    await page.getByTestId('hp-choice-average').click()
+    await page.getByRole('button', { name: /Confirm Level Up/i }).click()
+
+    // Error banner should appear in the modal
+    await expect(page.getByTestId('level-up-error')).toBeVisible({ timeout: 3000 })
+    await expect(page.getByTestId('level-up-error')).toContainText('Internal server error')
+
+    // Modal stays open so the user can retry
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).toBeVisible()
+  })
+
+  test('confirm button is disabled until an HP choice is made', async ({ page }) => {
+    await page.route(`**/api/games/${GAME_ID}/level-up`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ level: 2, hp_max: 19, hp_gained: 7 }),
+      })
+    })
+
+    await openModal(page)
+
+    // Initially disabled (no choice selected)
+    await expect(page.getByRole('button', { name: /Confirm Level Up/i })).toBeDisabled()
+
+    // Select an option
+    await page.getByTestId('hp-choice-average').click()
+
+    await expect(page.getByRole('button', { name: /Confirm Level Up/i })).toBeEnabled()
+  })
+})

--- a/frontend/e2e/level-up.spec.ts
+++ b/frontend/e2e/level-up.spec.ts
@@ -593,4 +593,43 @@ test.describe('DIN-28 — LevelUpModal confirm and API', () => {
 
     await expect(page.getByRole('button', { name: /Confirm Level Up/i })).toBeEnabled()
   })
+
+  test('confirming "Roll" sends hp_choice: "roll" to POST /api/games/{gameId}/level-up', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    let capturedBody: Record<string, unknown> | null = null
+    await page.route(`**/api/games/${GAME_ID}/level-up`, (route) => {
+      if (route.request().method() === 'POST') {
+        const raw = route.request().postData()
+        if (raw) capturedBody = JSON.parse(raw) as Record<string, unknown>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ level: 2, hp_max: 22, hp_gained: 10 }),
+        })
+      }
+    })
+
+    await openModal(page)
+
+    // Select Roll option
+    const rollCard = page.getByTestId('hp-choice-roll')
+    await rollCard.click()
+
+    // Confirm button should become enabled
+    await expect(page.getByRole('button', { name: /Confirm Level Up/i })).toBeEnabled()
+
+    await page.getByRole('button', { name: /Confirm Level Up/i }).click()
+
+    // Modal should close
+    await expect(page.getByRole('dialog', { name: 'Level Up' })).not.toBeVisible({
+      timeout: 3000,
+    })
+
+    // Verify the API received hp_choice: 'roll'
+    expect(capturedBody).not.toBeNull()
+    expect((capturedBody as Record<string, unknown>).hp_choice).toBe('roll')
+  })
 })

--- a/frontend/e2e/lobby-theming.spec.ts
+++ b/frontend/e2e/lobby-theming.spec.ts
@@ -1,0 +1,387 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ─── DIN-58: Lobby page D&D theming ──────────────────────────────────────────
+//
+// Verifies that game lobby components (CharacterSummaryCard, CharacterLobbyPanel,
+// CharacterCreationForm, InviteSection) render correctly after migrating to
+// dnd-* CSS classes. Tests focus on user-visible behaviour and data-testid
+// queries (never CSS class names directly).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAME_ID = 'test-game-lobby'
+const HOST_ID = 'user-host'
+const GUEST_ID = 'user-guest'
+
+const MOCK_GAME_LOBBY = {
+  id: GAME_ID,
+  name: 'The Forgotten Realm',
+  dm_persona: 'A mysterious Dungeon Master',
+  status: 'lobby',
+  created_by: HOST_ID,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const MOCK_PLAYER = {
+  id: 'player-1',
+  game_id: GAME_ID,
+  profile_id: HOST_ID,
+  character_name: 'Gandalf the Grey',
+  character_class: 'Wizard',
+  race: 'Human',
+  level: 3,
+  hp_current: 18,
+  hp_max: 24,
+  stats: { str: 8, dex: 12, con: 14, int: 18, wis: 16, cha: 14 },
+  status: 'active',
+  joined_at: '2026-01-01T00:00:00Z',
+}
+
+// ─── Setup helpers ────────────────────────────────────────────────────────────
+
+async function setupAuthMocks(page: Page, userId: string) {
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: userId, email: `${userId}@example.com` }),
+    })
+  )
+  await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'mock-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        user: { id: userId, email: `${userId}@example.com` },
+      }),
+    })
+  )
+}
+
+async function setupLobbyMocks(
+  page: Page,
+  options: {
+    userId?: string
+    gameStatus?: string
+    player?: typeof MOCK_PLAYER | null
+    inventory?: { id: string; player_id: string; item_name: string; quantity: number }[]
+  } = {}
+) {
+  const {
+    userId = HOST_ID,
+    gameStatus = 'lobby',
+    player = MOCK_PLAYER,
+    inventory = [],
+  } = options
+
+  await setupAuthMocks(page, userId)
+
+  await page.route('**.supabase.co/rest/v1/games**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ ...MOCK_GAME_LOBBY, status: gameStatus }]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/players**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(player ? [player] : []),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(inventory),
+      })
+    }
+  })
+}
+
+// ─── DIN-58: CharacterSummaryCard ────────────────────────────────────────────
+
+test.describe('DIN-58 — CharacterSummaryCard in lobby', () => {
+  test('displays character name, class, race, and level', async ({ page }) => {
+    await setupLobbyMocks(page)
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+
+    await expect(page.getByText('Gandalf the Grey')).toBeVisible()
+    await expect(page.getByText(/Level 3 Human Wizard/)).toBeVisible()
+  })
+
+  test('displays HP badge with current/max HP', async ({ page }) => {
+    await setupLobbyMocks(page)
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('Gandalf the Grey')).toBeVisible({ timeout: 5000 })
+
+    // HP badge shows hp_current/hp_max
+    const hpBadge = page.locator('.dnd-hp-badge')
+    await expect(hpBadge).toBeVisible()
+    await expect(hpBadge).toContainText('18/24')
+  })
+
+  test('displays ability score grid with all six stats', async ({ page }) => {
+    await setupLobbyMocks(page)
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('Gandalf the Grey')).toBeVisible({ timeout: 5000 })
+
+    // Stat grid container and labels
+    const statGrid = page.locator('.dnd-stat-grid')
+    await expect(statGrid).toBeVisible()
+
+    for (const stat of ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA']) {
+      await expect(statGrid.getByText(stat)).toBeVisible()
+    }
+
+    // INT=18 is visible
+    await expect(statGrid.getByText('18')).toBeVisible()
+  })
+
+  test('Edit Character button is visible in lobby status', async ({ page }) => {
+    await setupLobbyMocks(page)
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('Gandalf the Grey')).toBeVisible({ timeout: 5000 })
+
+    await expect(page.getByRole('button', { name: /Edit Character/i })).toBeVisible()
+  })
+
+  test('Edit Character button is hidden when game is not in lobby', async ({ page }) => {
+    await setupLobbyMocks(page, { gameStatus: 'active' })
+    // Active game → GameSessionView; no lobby CharacterSummaryCard shown
+    await page.goto(`/games/${GAME_ID}`)
+    // The game has no messages, so it'll show game session view
+    // The CharacterSummaryCard (lobby version) should not be present
+    await expect(page.getByRole('button', { name: /Edit Character/i })).not.toBeVisible({
+      timeout: 5000,
+    })
+  })
+
+  test('clicking Edit Character switches to creation form', async ({ page }) => {
+    await setupLobbyMocks(page)
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('Gandalf the Grey')).toBeVisible({ timeout: 5000 })
+
+    await page.getByRole('button', { name: /Edit Character/i }).click()
+
+    // Form appears — name input is pre-filled with existing character name.
+    // The label is not htmlFor-linked, so we locate by placeholder.
+    const nameInput = page.getByPlaceholder('Enter character name')
+    await expect(nameInput).toBeVisible({ timeout: 3000 })
+    await expect(nameInput).toHaveValue('Gandalf the Grey')
+  })
+})
+
+// ─── DIN-58: CharacterLobbyPanel ────────────────────────────────────────────
+
+test.describe('DIN-58 — CharacterLobbyPanel', () => {
+  test('CharacterCreationForm shown directly when player has no character in lobby', async ({
+    page,
+  }) => {
+    // When initialPlayer is null, isEditing starts as true → form shows immediately
+    await setupLobbyMocks(page, { player: null })
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+
+    // Form is rendered directly — no "Create Your Character" CTA button to click
+    await expect(page.getByRole('button', { name: /Save Character/i })).toBeVisible({ timeout: 5000 })
+    // The character name input is present and empty (placeholder visible)
+    await expect(page.getByPlaceholder('Enter character name')).toBeVisible()
+  })
+
+  test('CharacterCreationForm uses dnd-label and dnd-input for name field', async ({ page }) => {
+    await setupLobbyMocks(page, { player: null })
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+
+    await expect(page.getByRole('button', { name: /Save Character/i })).toBeVisible({ timeout: 5000 })
+
+    // Label element uses dnd-label class — locate by text since label is not htmlFor-linked
+    const label = page.getByText('Character Name').first()
+    await expect(label).toHaveClass(/dnd-label/)
+
+    // Input uses dnd-input class — locate by placeholder
+    await expect(page.getByPlaceholder('Enter character name')).toHaveClass(/dnd-input/)
+  })
+
+  test('warning box shown when game has already started and user has no character', async ({
+    page,
+  }) => {
+    // CharacterLobbyPanel shows dnd-warning-box when gameStatus !== 'lobby' and
+    // isEditing is true (no existing character). We set up a lobby page with
+    // non-lobby status returned by the games endpoint.
+    await setupAuthMocks(page, HOST_ID)
+
+    await page.route('**.supabase.co/rest/v1/games**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            { ...MOCK_GAME_LOBBY, status: 'active', created_by: HOST_ID },
+          ]),
+        })
+      }
+    })
+
+    // No player exists for this user in an active game
+    await page.route('**.supabase.co/rest/v1/players**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([]),
+        })
+      }
+    })
+
+    await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+      if (route.request().method() === 'GET') {
+        const url = route.request().url()
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(url.includes('select=role') ? [] : []),
+        })
+      }
+    })
+
+    await page.goto(`/games/${GAME_ID}`)
+
+    // The active game redirects to GameSessionView which has no CharacterLobbyPanel.
+    // The lobby-panel warning scenario is fully covered by unit tests;
+    // in E2E we confirm the active session view renders (game title header).
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+    // No lobby-specific "Create Your Character" shown in active session
+    await expect(page.getByRole('button', { name: /Create Your Character/i })).not.toBeVisible()
+  })
+})
+
+// ─── DIN-58: CharacterCreationForm ───────────────────────────────────────────
+
+test.describe('DIN-58 — CharacterCreationForm', () => {
+  test('validation error appears when character name is cleared and form submitted', async ({
+    page,
+  }) => {
+    // Form is shown directly (no player) — no button click needed
+    await setupLobbyMocks(page, { player: null })
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('button', { name: /Save Character/i })).toBeVisible({ timeout: 5000 })
+
+    // Clear the character name field and submit
+    const nameInput = page.getByPlaceholder('Enter character name')
+    await nameInput.fill('')
+    await page.getByRole('button', { name: /Save Character/i }).click()
+
+    // Field error should appear (dnd-field-error class)
+    await expect(page.locator('.dnd-field-error').first()).toBeVisible()
+  })
+
+  test('server error banner appears on API failure', async ({ page }) => {
+    await setupLobbyMocks(page, { player: null })
+
+    // Mock the character creation API to return an error
+    await page.route(`**/api/games/${GAME_ID}/players`, (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 422,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Character name already taken' }),
+        })
+      }
+    })
+
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('button', { name: /Save Character/i })).toBeVisible({ timeout: 5000 })
+
+    // Fill in a name and submit
+    await page.getByPlaceholder('Enter character name').fill('Thorin')
+    await page.getByRole('button', { name: /Save Character/i }).click()
+
+    // Error banner (dnd-error-banner) should appear
+    await expect(page.locator('.dnd-error-banner')).toBeVisible({ timeout: 3000 })
+  })
+
+  test('stat grid inputs are visible in character creation form (6 stats)', async ({ page }) => {
+    // Form shows directly when no player
+    await setupLobbyMocks(page, { player: null })
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('button', { name: /Save Character/i })).toBeVisible({ timeout: 5000 })
+
+    // Stat grid uses dnd-stat-input for all 6 ability score fields
+    const statInputs = page.locator('.dnd-stat-input')
+    await expect(statInputs).toHaveCount(6)
+  })
+})
+
+// ─── DIN-58: InviteSection ───────────────────────────────────────────────────
+
+test.describe('DIN-58 — InviteSection theming', () => {
+  test('invite section renders inside a dnd-card for the game host', async ({ page }) => {
+    await setupLobbyMocks(page)
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+
+    // InviteSection should be wrapped in a dnd-card
+    await expect(page.getByTestId('generate-invite-button')).toBeVisible()
+    const card = page.getByTestId('generate-invite-button').locator('xpath=ancestor::div[contains(@class,"dnd-card")]')
+    await expect(card).toBeVisible()
+  })
+
+  test('invite section is NOT shown for a non-host player', async ({ page }) => {
+    // Log in as a guest user (different from the game creator)
+    await setupLobbyMocks(page, {
+      userId: GUEST_ID,
+      player: { ...MOCK_PLAYER, profile_id: GUEST_ID },
+    })
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+
+    // Non-host should not see the invite section
+    await expect(page.getByTestId('generate-invite-button')).not.toBeVisible()
+  })
+
+  test('invite URL input uses dnd-input class after generation', async ({ page }) => {
+    await page.context().grantPermissions(['clipboard-write'])
+    await setupLobbyMocks(page)
+
+    await page.route(`**/api/games/${GAME_ID}/invites`, (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 'abc123',
+            invite_url: 'http://localhost:3000/auth/signup?code=abc123',
+          }),
+        })
+      }
+    })
+
+    await page.goto(`/games/${GAME_ID}`)
+    await expect(page.getByText('The Forgotten Realm')).toBeVisible({ timeout: 5000 })
+
+    await page.getByTestId('generate-invite-button').click()
+
+    const inviteInput = page.getByTestId('invite-url-input')
+    await expect(inviteInput).toBeVisible()
+    // Input uses dnd-input class
+    await expect(inviteInput).toHaveClass(/dnd-input/)
+  })
+})

--- a/frontend/src/app/api/games/[gameId]/level-up/route.ts
+++ b/frontend/src/app/api/games/[gameId]/level-up/route.ts
@@ -1,0 +1,66 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ gameId: string }> }
+): Promise<NextResponse> {
+  try {
+    const cookieStore = await cookies()
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll()
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options)
+            })
+          },
+        },
+      }
+    )
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const { gameId } = await params
+
+    const backendUrl =
+      process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'
+    const response = await fetch(`${backendUrl}/games/${gameId}/level-up`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify(body),
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json()
+      return NextResponse.json(
+        { error: errorData.detail || 'Backend error' },
+        { status: response.status }
+      )
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data, { status: 200 })
+  } catch {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/app/games/[gameId]/page.tsx
+++ b/frontend/src/app/games/[gameId]/page.tsx
@@ -56,18 +56,12 @@ export default async function GamePage({ params }: GamePageProps) {
       <DashboardHeader />
       <div className="mx-auto max-w-2xl p-6">
         <div className="mb-6 space-y-2">
-          <h1
-            className="text-3xl font-bold tracking-wide"
-            style={{ fontFamily: "'Cinzel', serif", color: 'var(--dnd-parchment)' }}
-          >
+          <h1 className="dnd-heading text-2xl font-bold">
             {game.name}
           </h1>
-          <p style={{ color: 'var(--dnd-parchment-dim)' }}>
-            Status:{' '}
-            <span className="font-semibold capitalize">
-              {game.status}
-            </span>
-          </p>
+          <span className={`dnd-badge dnd-badge-${game.status}`}>
+            {game.status}
+          </span>
         </div>
 
         {game.created_by === user.id && game.status === 'lobby' && (
@@ -77,10 +71,7 @@ export default async function GamePage({ params }: GamePageProps) {
         )}
 
         <div className="dnd-card p-6">
-          <h2
-            className="mb-4 text-xl font-semibold tracking-wide"
-            style={{ fontFamily: "'Cinzel', serif", color: 'var(--dnd-parchment)' }}
-          >
+          <h2 className="dnd-heading mb-4 text-lg font-semibold">
             Your Character
           </h2>
           <CharacterLobbyPanel

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -374,3 +374,56 @@ body {
 .dnd-fade-in {
   animation: fadeInUp 0.4s ease-out;
 }
+
+/* ── Stat number input (CharacterCreationForm ability score inputs) ── */
+.dnd-stat-input {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 0.375rem;
+  color: var(--dnd-parchment);
+  padding: 0.375rem 0.5rem;
+  font-family: 'Cinzel', serif;
+  font-size: 1.1rem;
+  font-weight: 700;
+  text-align: center;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.dnd-stat-input:focus {
+  outline: none;
+  border-color: var(--dnd-gold);
+  box-shadow: 0 0 0 2px rgba(201, 168, 76, 0.15);
+}
+
+/* ── Warning / notice box (amber tint, replaces yellow-50 pattern) ── */
+.dnd-warning-box {
+  background: rgba(212, 168, 67, 0.08);
+  border: 1px solid rgba(212, 168, 67, 0.25);
+  border-radius: 0.375rem;
+  padding: 0.75rem 1rem;
+  color: var(--dnd-amber);
+  font-size: 0.875rem;
+  font-style: italic;
+  text-align: center;
+}
+
+/* ── Copy button (emerald variant — kept green for success affordance) ── */
+.dnd-btn-copy {
+  padding: 0.625rem 1rem;
+  font-family: 'Cinzel', serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dnd-black);
+  background: linear-gradient(180deg, #6fcf97 0%, #27ae60 100%);
+  border: 1px solid #27ae60;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+}
+.dnd-btn-copy:hover {
+  box-shadow: 0 0 12px rgba(111, 207, 151, 0.25);
+  transform: translateY(-1px);
+}

--- a/frontend/src/components/games/CharacterCreationForm.tsx
+++ b/frontend/src/components/games/CharacterCreationForm.tsx
@@ -130,18 +130,18 @@ export function CharacterCreationForm({
       <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         {formError && (
-          <div className="rounded bg-red-50 p-4 text-red-800">{formError}</div>
+          <div className="dnd-error-banner">{formError}</div>
         )}
 
         <div>
-          <label className="block text-sm font-medium text-gray-900">
+          <label className="dnd-label">
             Character Name
           </label>
           <div style={{ position: 'relative' }}>
             <input
               type="text"
               {...register('characterName')}
-              className="mt-2 w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="dnd-input mt-2"
               placeholder="Enter character name"
               style={{ paddingRight: '38px' }}
             />
@@ -176,19 +176,19 @@ export function CharacterCreationForm({
             </button>
           </div>
           {errors.characterName && (
-            <p className="mt-1 text-sm text-red-600">
+            <p className="dnd-field-error mt-1">
               {errors.characterName.message}
             </p>
           )}
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-900">
+          <label className="dnd-label">
             Character Class
           </label>
           <select
             {...register('characterClass')}
-            className="mt-2 w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="dnd-input mt-2"
           >
             {CHARACTER_CLASSES.map((cls) => (
               <option key={cls} value={cls}>
@@ -197,19 +197,19 @@ export function CharacterCreationForm({
             ))}
           </select>
           {errors.characterClass && (
-            <p className="mt-1 text-sm text-red-600">
+            <p className="dnd-field-error mt-1">
               {errors.characterClass.message}
             </p>
           )}
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-900">
+          <label className="dnd-label">
             Race
           </label>
           <select
             {...register('race')}
-            className="mt-2 w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="dnd-input mt-2"
           >
             {CHARACTER_RACES.map((race) => (
               <option key={race} value={race}>
@@ -218,14 +218,14 @@ export function CharacterCreationForm({
             ))}
           </select>
           {errors.race && (
-            <p className="mt-1 text-sm text-red-600">
+            <p className="dnd-field-error mt-1">
               {errors.race.message}
             </p>
           )}
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-900">
+          <label className="dnd-label">
             Level
           </label>
           <input
@@ -233,35 +233,33 @@ export function CharacterCreationForm({
             {...register('level', { valueAsNumber: true })}
             min="1"
             max="20"
-            className="mt-2 w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="dnd-input mt-2"
           />
           {errors.level && (
-            <p className="mt-1 text-sm text-red-600">
+            <p className="dnd-field-error mt-1">
               {errors.level.message}
             </p>
           )}
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-900 mb-3">
+          <label className="dnd-label mb-3">
             Ability Scores
           </label>
-          <div className="grid grid-cols-3 gap-4">
+          <div className="dnd-stat-grid">
             {STAT_NAMES.map(({ key, label }) => (
-              <div key={key}>
-                <label className="block text-xs font-medium text-gray-700 mb-1">
-                  {label}
-                </label>
+              <div key={key} className="dnd-stat-box">
+                <label className="dnd-stat-label">{label}</label>
                 <input
                   type="number"
                   {...register(`stats.${key}`, { valueAsNumber: true })}
                   min="1"
                   max="20"
-                  className="w-full rounded border border-gray-300 px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="dnd-stat-input"
                 />
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 {(errors.stats?.[key as keyof typeof errors.stats] as any)?.message && (
-                  <p className="mt-1 text-xs text-red-600">
+                  <p className="dnd-field-error mt-1 text-xs">
                     {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                     {(errors.stats?.[key as keyof typeof errors.stats] as any)?.message}
                   </p>
@@ -274,7 +272,7 @@ export function CharacterCreationForm({
         <button
           type="submit"
           disabled={loading}
-          className="w-full rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:bg-gray-400"
+          className="dnd-btn-primary"
         >
           {loading ? 'Saving...' : 'Save Character'}
         </button>

--- a/frontend/src/components/games/CharacterLobbyPanel.tsx
+++ b/frontend/src/components/games/CharacterLobbyPanel.tsx
@@ -35,8 +35,8 @@ export function CharacterLobbyPanel({
   if (isEditing) {
     if (gameStatus !== 'lobby') {
       return (
-        <div className="rounded-lg bg-yellow-50 p-4 text-center">
-          <p className="text-sm text-yellow-800">
+        <div className="dnd-warning-box">
+          <p>
             Character creation is only available when the game is in lobby status.
           </p>
         </div>
@@ -69,15 +69,12 @@ export function CharacterLobbyPanel({
       onEdit={handleEdit}
     />
   ) : gameStatus === 'lobby' ? (
-    <button
-      onClick={handleEdit}
-      className="w-full rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
-    >
+    <button onClick={handleEdit} className="dnd-btn-primary">
       Create Your Character
     </button>
   ) : (
-    <div className="rounded-lg bg-yellow-50 p-4 text-center">
-      <p className="text-sm text-yellow-800">
+    <div className="dnd-warning-box">
+      <p>
         The game has started. No new characters can be created.
       </p>
     </div>

--- a/frontend/src/components/games/CharacterSheetPanel.tsx
+++ b/frontend/src/components/games/CharacterSheetPanel.tsx
@@ -350,37 +350,54 @@ export function CharacterSheetPanel({ playerId, onClose }: CharacterSheetPanelPr
                 >
                   Level {player.level} {player.race} {player.character_class}
                 </p>
-                <span
-                  className="dnd-badge"
-                  style={{
-                    fontSize: '0.55rem',
-                    color:
-                      player.status === 'dead'
-                        ? '#e8a0a0'
-                        : player.status === 'active'
-                        ? '#6fcf97'
-                        : 'var(--dnd-parchment-dim, #8a7a60)',
-                    border: `1px solid ${
-                      player.status === 'dead'
-                        ? 'rgba(192,57,43,0.4)'
-                        : player.status === 'active'
-                        ? 'rgba(45,106,79,0.4)'
-                        : 'rgba(100,100,100,0.3)'
-                    }`,
-                    background:
-                      player.status === 'dead'
-                        ? 'rgba(139,34,50,0.12)'
-                        : player.status === 'active'
-                        ? 'rgba(45,106,79,0.12)'
-                        : 'rgba(60,60,60,0.15)',
-                    padding: '1px 6px',
-                    borderRadius: '3px',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.1em',
-                  }}
-                >
-                  {player.status}
-                </span>
+                <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                  <span
+                    className="dnd-badge"
+                    style={{
+                      fontSize: '0.55rem',
+                      color:
+                        player.status === 'dead'
+                          ? '#e8a0a0'
+                          : player.status === 'active'
+                          ? '#6fcf97'
+                          : 'var(--dnd-parchment-dim, #8a7a60)',
+                      border: `1px solid ${
+                        player.status === 'dead'
+                          ? 'rgba(192,57,43,0.4)'
+                          : player.status === 'active'
+                          ? 'rgba(45,106,79,0.4)'
+                          : 'rgba(100,100,100,0.3)'
+                      }`,
+                      background:
+                        player.status === 'dead'
+                          ? 'rgba(139,34,50,0.12)'
+                          : player.status === 'active'
+                          ? 'rgba(45,106,79,0.12)'
+                          : 'rgba(60,60,60,0.15)',
+                      padding: '1px 6px',
+                      borderRadius: '3px',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.1em',
+                    }}
+                  >
+                    {player.status}
+                  </span>
+                  <span
+                    data-testid="level-badge"
+                    style={{
+                      fontFamily: "'Cinzel', serif",
+                      fontSize: '0.55rem',
+                      color: 'var(--dnd-gold, #c9a84c)',
+                      border: '1px solid rgba(201,168,76,0.35)',
+                      background: 'rgba(201,168,76,0.08)',
+                      padding: '1px 6px',
+                      borderRadius: '3px',
+                      letterSpacing: '0.08em',
+                    }}
+                  >
+                    {player.level}
+                  </span>
+                </div>
               </div>
 
               {/* HP section */}
@@ -454,6 +471,46 @@ export function CharacterSheetPanel({ playerId, onClose }: CharacterSheetPanelPr
                   </p>
                 )}
               </div>
+
+              {/* XP bar (DIN-28) */}
+              {(() => {
+                const XP_THRESHOLDS: Record<number, number> = { 1: 0, 2: 300, 3: 900, 4: 2700, 5: 6500, 6: 14000 }
+                const MVP_MAX_LEVEL = 5
+                const xp = player.stats.xp ?? 0
+                const lvl = player.level
+                const currentThreshold = XP_THRESHOLDS[lvl] ?? 0
+                const nextThreshold = XP_THRESHOLDS[lvl + 1]
+                const isMaxLevel = lvl >= MVP_MAX_LEVEL
+                const pct = isMaxLevel || !nextThreshold
+                  ? 100
+                  : Math.round(((xp - currentThreshold) / (nextThreshold - currentThreshold)) * 100)
+                return (
+                  <div>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+                      <span style={{ fontFamily: "'Cinzel', serif", fontSize: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--dnd-parchment-dim, #8a7a60)' }}>
+                        Experience
+                      </span>
+                      <span style={{ fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: '0.65rem', color: 'var(--dnd-parchment-dim, #8a7a60)' }}>
+                        {isMaxLevel
+                          ? 'Max level'
+                          : `${xp.toLocaleString()} / ${nextThreshold?.toLocaleString()} to Lv ${lvl + 1}`}
+                      </span>
+                    </div>
+                    <div style={{ height: '5px', background: 'rgba(255,255,255,0.08)', borderRadius: '3px', overflow: 'hidden' }}>
+                      <div
+                        data-testid="xp-bar"
+                        data-xp-pct={String(pct)}
+                        style={{
+                          height: '100%',
+                          width: `${pct}%`,
+                          background: 'var(--dnd-gold, #c9a84c)',
+                          transition: 'width 0.5s ease',
+                        }}
+                      />
+                    </div>
+                  </div>
+                )
+              })()}
 
               {/* Ability Scores */}
               <div>

--- a/frontend/src/components/games/CharacterSummaryCard.tsx
+++ b/frontend/src/components/games/CharacterSummaryCard.tsx
@@ -18,51 +18,52 @@ export function CharacterSummaryCard({
   const isLobby = gameStatus === 'lobby'
 
   return (
-    <div className="space-y-6 rounded border border-gray-300 bg-white p-6">
+    <div className="dnd-card space-y-6 p-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">
+          <h2 className="dnd-heading text-2xl font-bold">
             {player.character_name}
           </h2>
-          <p className="text-lg text-gray-600">
+          <p className="dnd-subheading text-base">
             Level {player.level} {player.race} {player.character_class}
           </p>
         </div>
         {isLobby && (
           <button
             onClick={onEdit}
-            className="rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
+            className="dnd-btn-secondary"
           >
             Edit Character
           </button>
         )}
       </div>
 
-      <div className="rounded bg-gray-50 p-4">
-        <p className="text-sm font-medium text-gray-700">Hit Points</p>
-        <p className="mt-1 text-2xl font-bold text-gray-900">
-          {player.hp_current}/{player.hp_max}
-        </p>
-        <div className="mt-2 h-3 rounded-full bg-gray-200">
+      <div className="space-y-2">
+        <p className="dnd-stat-label">Hit Points</p>
+        <span className="dnd-hp-badge">
+          {'❤ '}<span>{player.hp_current}/{player.hp_max}</span>
+        </span>
+        <div className="mt-2 h-2 rounded-full" style={{ background: 'var(--input-border)' }}>
           <div
-            className="h-full rounded-full bg-green-500"
+            className="h-full rounded-full"
             style={{
-              width: `${(player.hp_current / player.hp_max) * 100}%`,
+              width: `${Math.min((player.hp_current / player.hp_max) * 100, 100)}%`,
+              background: 'var(--dnd-crimson)',
             }}
           />
         </div>
       </div>
 
       <div>
-        <p className="mb-3 text-sm font-medium text-gray-700">Ability Scores</p>
-        <div className="grid grid-cols-3 gap-3">
+        <p className="dnd-stat-label mb-3">Ability Scores</p>
+        <div className="dnd-stat-grid">
           {STAT_NAMES.map(({ key, label }) => {
             const score = player.stats[key as 'str' | 'dex' | 'con' | 'int' | 'wis' | 'cha']
             return (
-              <div key={key} className="rounded bg-gray-100 p-3 text-center">
-                <p className="text-xs font-medium text-gray-600">{label}</p>
-                <p className="mt-1 text-lg font-bold text-gray-900">{score}</p>
-                <p className="text-xs text-gray-500">
+              <div key={key} className="dnd-stat-box">
+                <p className="dnd-stat-label">{label}</p>
+                <p className="dnd-stat-value">{score}</p>
+                <p className="dnd-stat-modifier">
                   {formatModifier(score)}
                 </p>
               </div>
@@ -71,7 +72,7 @@ export function CharacterSummaryCard({
         </div>
       </div>
 
-      <div className="text-xs text-gray-500">
+      <div className="dnd-helper">
         <p>Status: {player.status}</p>
         <p>Joined: {new Date(player.joined_at).toLocaleDateString()}</p>
       </div>

--- a/frontend/src/components/games/ChatMessage.tsx
+++ b/frontend/src/components/games/ChatMessage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import React, { useState, useRef } from 'react'
 import type { DiceRollEvent } from '@/lib/types/message'
 import { DiceRoller } from '@/components/dice/DiceRoller'
 
@@ -13,6 +13,7 @@ interface ChatMessageProps {
   isLastMessage?: boolean
   isWaitingForDm?: boolean
   diceRolls?: DiceRollEvent[] | null
+  priorDeathSaves?: { successes: number; failures: number }
   onRetry?: () => void
   onDelete?: () => void
   onEdit?: (newContent: string) => void
@@ -27,6 +28,7 @@ export function ChatMessage({
   isLastMessage,
   isWaitingForDm,
   diceRolls,
+  priorDeathSaves,
   onRetry,
   onDelete,
   onEdit,
@@ -102,42 +104,84 @@ export function ChatMessage({
                 marginBottom: '12px',
               }}
             >
-              {diceRolls!.slice(0, activeDieIndex + 1).map((roll, idx) => (
-                <div key={idx} style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                  <DiceRoller
-                    dieType={roll.die}
-                    result={roll.result}
-                    modifier={roll.modifier}
-                    label={roll.label}
-                    instant={idx < activeDieIndex}
-                    onAnimationComplete={idx === activeDieIndex ? handleDieComplete : () => {}}
-                  />
-                  {/* Advantage/disadvantage pip display — shown after animation settles */}
-                  {narrationVisible && roll.advantage !== undefined && Array.isArray(roll.all_rolls) && (
-                    <div style={{ display: 'flex', gap: '10px', fontSize: '0.85rem', marginTop: '2px' }}>
-                      {roll.all_rolls.filter((r) => typeof r === 'number').map((r, ri) => {
-                        const isKept = r === roll.result
-                        return (
-                          <span
-                            key={ri}
-                            data-testid={isKept ? 'adv-kept' : 'adv-discarded'}
-                            style={{
-                              color: isKept
-                                ? 'var(--dnd-parchment)'
-                                : 'var(--dnd-parchment-dim, rgba(230,210,170,0.45))',
-                              textDecoration: isKept ? 'none' : 'line-through',
-                              fontFamily: "'Cinzel', serif",
-                              fontSize: '0.8rem',
-                            }}
-                          >
-                            {r}
-                          </span>
-                        )
-                      })}
-                    </div>
-                  )}
-                </div>
-              ))}
+              {diceRolls!.slice(0, activeDieIndex + 1).map((roll, idx) => {
+                const isCritHit = roll.ac !== undefined && roll.result === 20
+                const isCritMiss = roll.ac !== undefined && roll.result === 1
+                return (
+                  <div
+                    key={idx}
+                    data-testid={`dice-roll-card-${idx}`}
+                    data-crit={isCritHit ? 'hit' : isCritMiss ? 'miss' : undefined}
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '4px',
+                      ...(isCritHit ? {
+                        borderWidth: '2px',
+                        borderStyle: 'solid',
+                        borderColor: '#e4c65a',
+                        borderRadius: '6px',
+                        padding: '4px',
+                      } : isCritMiss ? {
+                        borderWidth: '2px',
+                        borderStyle: 'solid',
+                        borderColor: '#c0392b',
+                        borderRadius: '6px',
+                        padding: '4px',
+                        opacity: 0.75,
+                      } : {}),
+                    }}
+                  >
+                    <DiceRoller
+                      dieType={roll.die}
+                      result={roll.result}
+                      modifier={roll.modifier}
+                      label={roll.label}
+                      instant={idx < activeDieIndex}
+                      onAnimationComplete={idx === activeDieIndex ? handleDieComplete : () => {}}
+                    />
+                    {/* Advantage/disadvantage pip display — shown after animation settles */}
+                    {narrationVisible && roll.advantage !== undefined && Array.isArray(roll.all_rolls) && (
+                      <div style={{ display: 'flex', gap: '10px', fontSize: '0.85rem', marginTop: '2px' }}>
+                        {roll.all_rolls.filter((r) => typeof r === 'number').map((r, ri) => {
+                          const isKept = r === roll.result
+                          return (
+                            <span
+                              key={ri}
+                              data-testid={isKept ? 'adv-kept' : 'adv-discarded'}
+                              style={{
+                                color: isKept
+                                  ? 'var(--dnd-parchment)'
+                                  : 'var(--dnd-parchment-dim, rgba(230,210,170,0.45))',
+                                textDecoration: isKept ? 'none' : 'line-through',
+                                fontFamily: "'Cinzel', serif",
+                                fontSize: '0.8rem',
+                              }}
+                            >
+                              {r}
+                            </span>
+                          )
+                        })}
+                      </div>
+                    )}
+                    {/* Attack vs AC outcome — shown after animation settles */}
+                    {narrationVisible && roll.ac !== undefined && (
+                      <div
+                        data-testid={`attack-outcome-${idx}`}
+                        style={{
+                          fontFamily: "'Cinzel', serif",
+                          fontSize: '0.75rem',
+                          letterSpacing: '0.04em',
+                          textAlign: 'center',
+                          color: roll.success ? '#6fcf97' : 'var(--dnd-parchment-dim, #b8a98c)',
+                        }}
+                      >
+                        {roll.total} vs AC {roll.ac} — {roll.success ? 'Hit!' : 'Miss'}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           )}
 
@@ -174,24 +218,42 @@ export function ChatMessage({
                       : 'transparent'
 
                   return (
-                    <div
-                      key={idx}
-                      data-testid="outcome-badge"
-                      style={{
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        padding: '3px 10px',
-                        borderRadius: '4px',
-                        background: bg,
-                        border: `1px solid ${borderColor}`,
-                        color: textColor,
-                        fontSize: '0.78rem',
-                        fontFamily: "'Cinzel', serif",
-                        letterSpacing: '0.04em',
-                      }}
-                    >
-                      {label}
-                    </div>
+                    <React.Fragment key={idx}>
+                      <div
+                        data-testid="outcome-badge"
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          padding: '3px 10px',
+                          borderRadius: '4px',
+                          background: bg,
+                          border: `1px solid ${borderColor}`,
+                          color: textColor,
+                          fontSize: '0.78rem',
+                          fontFamily: "'Cinzel', serif",
+                          letterSpacing: '0.04em',
+                        }}
+                      >
+                        {label}
+                      </div>
+                      {/* Death save cumulative tally */}
+                      {roll.label === 'Death Saving Throw' && priorDeathSaves && (
+                        <div
+                          data-testid="death-save-tally"
+                          style={{
+                            fontFamily: "'Cinzel', serif",
+                            fontSize: '0.7rem',
+                            color: 'var(--dnd-parchment-dim, #b8a98c)',
+                            letterSpacing: '0.04em',
+                            alignSelf: 'center',
+                          }}
+                        >
+                          Successes: {priorDeathSaves.successes + (roll.success ? 1 : 0)}/3
+                          {' | '}
+                          Failures: {priorDeathSaves.failures + (!roll.success ? 1 : 0)}/3
+                        </div>
+                      )}
+                    </React.Fragment>
                   )
                 })}
             </div>

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -11,6 +11,9 @@ import { TypingIndicator } from './TypingIndicator'
 import { ConfirmModal } from './ConfirmModal'
 import { SessionStatusBanner } from './SessionStatusBanner'
 import { CharacterSheetPanel } from './CharacterSheetPanel'
+import { LevelUpModal } from './LevelUpModal'
+import type { LevelUpPayload } from './LevelUpModal'
+import type { PlayerRow } from '@/lib/types/player'
 import { CHAT_PAGE_SIZE } from '@/lib/constants/game'
 
 interface GameSessionViewProps {
@@ -43,6 +46,9 @@ export function GameSessionView({
   const [oldestCreatedAt, setOldestCreatedAt] = useState<string | null>(null)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [showCharacterSheet, setShowCharacterSheet] = useState(false)
+  const [levelUpPayload, setLevelUpPayload] = useState<LevelUpPayload | null>(null)
+  const [showLevelUpModal, setShowLevelUpModal] = useState(false)
+  const [currentPlayerRow, setCurrentPlayerRow] = useState<PlayerRow | null>(null)
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const isHost = game.created_by === userId
@@ -67,10 +73,10 @@ export function GameSessionView({
           .order('created_at', { ascending: false })
           .limit(1)
 
-        // Fetch all players for this game (include id for CharacterSheetPanel)
+        // Fetch all players for this game
         const playersPromise = supabase
           .from('players')
-          .select('id, profile_id, character_name')
+          .select('*')
           .eq('game_id', gameId)
 
         const [{ data: messagesData }, { data: latestData }, { data: playersData }] =
@@ -88,11 +94,7 @@ export function GameSessionView({
 
         // Build playerMap (profile_id -> character_name)
         const map = new Map<string, string>()
-        const players = (playersData ?? []) as Array<{
-          id: string
-          profile_id: string | null
-          character_name: string | null
-        }>
+        const players = (playersData ?? []) as PlayerRow[]
         players.forEach((p) => {
           if (p.profile_id && p.character_name) {
             map.set(p.profile_id, p.character_name)
@@ -100,9 +102,10 @@ export function GameSessionView({
         })
         setPlayerMap(map)
 
-        // Track current user's player ID for the character sheet
+        // Track current user's player ID and full row for the character sheet / level-up modal
         const myPlayer = players.find((p) => p.profile_id === userId)
         setCurrentPlayerId(myPlayer ? myPlayer.id : null)
+        setCurrentPlayerRow(myPlayer ?? null)
 
         // Check if current user has a character in this game
         setHasCharacter(map.has(userId))
@@ -219,9 +222,18 @@ export function GameSessionView({
       )
       .subscribe()
 
+    // Subscribe to level_up_available broadcast events
+    const levelUpSubscription = supabase
+      .channel(`game:${gameId}`)
+      .on('broadcast', { event: 'level_up_available' }, ({ payload }) => {
+        setLevelUpPayload(payload as LevelUpPayload)
+      })
+      .subscribe()
+
     return () => {
       messagesSubscription?.unsubscribe()
       gamesSubscription?.unsubscribe()
+      levelUpSubscription?.unsubscribe()
     }
   }, [gameId, userId])
 
@@ -518,6 +530,46 @@ export function GameSessionView({
             onResume={handleResume}
             onEnd={() => setShowEndModal(true)}
           />
+          {/* Level-up toast banner — persists until confirmed or dismissed */}
+          {levelUpPayload && !showLevelUpModal && (
+            <div
+              data-testid="level-up-toast"
+              style={{
+                flexShrink: 0,
+                borderTop: '1px solid rgba(201,168,76,0.4)',
+                background: 'rgba(201,168,76,0.12)',
+                padding: '8px 24px',
+              }}
+            >
+              <div style={{ maxWidth: '48rem', margin: '0 auto', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem' }}>
+                <div>
+                  <span style={{ fontFamily: "'Cinzel', serif", fontSize: '0.75rem', color: 'var(--dnd-gold, #c9a84c)', letterSpacing: '0.06em' }}>
+                    Level Up Available!
+                  </span>
+                  <p style={{ fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: '0.75rem', color: 'var(--dnd-parchment-dim, #8a7a60)', margin: '2px 0 0 0' }}>
+                    You&apos;ve reached Level {levelUpPayload.new_level}
+                  </p>
+                </div>
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                  <button
+                    onClick={() => setShowLevelUpModal(true)}
+                    className="dnd-btn"
+                    style={{ padding: '5px 14px', fontSize: '0.65rem' }}
+                  >
+                    Level Up
+                  </button>
+                  <button
+                    onClick={() => setLevelUpPayload(null)}
+                    className="dnd-btn-secondary"
+                    style={{ padding: '5px 10px', fontSize: '0.65rem' }}
+                    aria-label="Dismiss level up"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
           <ChatInput
             gameStatus={gameStatus}
             isWaitingForDm={isWaitingForDm}
@@ -535,6 +587,20 @@ export function GameSessionView({
           />
         )}
       </div>
+
+      {/* Level-up modal */}
+      {showLevelUpModal && levelUpPayload && currentPlayerRow && (
+        <LevelUpModal
+          gameId={gameId}
+          payload={levelUpPayload}
+          player={currentPlayerRow}
+          onClose={() => setShowLevelUpModal(false)}
+          onConfirmed={() => {
+            setShowLevelUpModal(false)
+            setLevelUpPayload(null)
+          }}
+        />
+      )}
 
       <ConfirmModal
         isOpen={showPauseModal}

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -310,6 +310,10 @@ export function GameSessionView({
     }
     const handleSessionPaused = () => setGameStatus('paused')
     const handleSessionEnded = () => setGameStatus('ended')
+    const handleLevelUpAvailable = (event: Event) => {
+      const detail = (event as CustomEvent).detail as LevelUpPayload
+      setLevelUpPayload(detail)
+    }
 
     window.addEventListener('player-message', addMessage)
     window.addEventListener('dm-message', addMessage)
@@ -317,6 +321,7 @@ export function GameSessionView({
     window.addEventListener('opening-narration', handleOpeningNarration)
     window.addEventListener('session-paused', handleSessionPaused)
     window.addEventListener('session-ended', handleSessionEnded)
+    window.addEventListener('level-up-available', handleLevelUpAvailable)
 
     return () => {
       window.removeEventListener('player-message', addMessage)
@@ -325,6 +330,7 @@ export function GameSessionView({
       window.removeEventListener('opening-narration', handleOpeningNarration)
       window.removeEventListener('session-paused', handleSessionPaused)
       window.removeEventListener('session-ended', handleSessionEnded)
+      window.removeEventListener('level-up-available', handleLevelUpAvailable)
     }
   }, [gameId])
 

--- a/frontend/src/components/games/InviteSection.tsx
+++ b/frontend/src/components/games/InviteSection.tsx
@@ -47,14 +47,12 @@ export function InviteSection({ gameId }: InviteSectionProps) {
   }
 
   return (
-    <div className="rounded-lg bg-white p-6 shadow-sm">
-      <h2 className="mb-4 text-xl font-semibold text-gray-900">
-        Invite Players
-      </h2>
+    <div className="dnd-card p-6">
+      <h2 className="dnd-heading mb-4 text-lg font-semibold">⚔ Invite Players</h2>
 
       {!inviteUrl ? (
         <div>
-          <p className="mb-4 text-sm text-gray-600">
+          <p className="dnd-subheading mb-4 text-sm">
             Generate an invite link to share with your players. Each link is
             single-use.
           </p>
@@ -62,14 +60,15 @@ export function InviteSection({ gameId }: InviteSectionProps) {
             data-testid="generate-invite-button"
             onClick={handleGenerate}
             disabled={loading}
-            className="rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:bg-gray-400"
+            className="dnd-btn-primary"
+            style={{ width: 'auto' }}
           >
             {loading ? 'Generating...' : 'Generate Invite Link'}
           </button>
         </div>
       ) : (
         <div>
-          <p className="mb-2 text-sm text-gray-600">
+          <p className="dnd-subheading mb-2 text-sm">
             Share this link with a player:
           </p>
           <div className="flex gap-2">
@@ -78,12 +77,12 @@ export function InviteSection({ gameId }: InviteSectionProps) {
               type="text"
               readOnly
               value={inviteUrl}
-              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm text-gray-700"
+              className="dnd-input flex-1 text-sm"
             />
             <button
               data-testid="copy-button"
               onClick={handleCopy}
-              className="rounded bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+              className="dnd-btn-copy"
             >
               {copied ? 'Copied!' : 'Copy'}
             </button>
@@ -94,7 +93,8 @@ export function InviteSection({ gameId }: InviteSectionProps) {
               setInviteUrl('')
               setCopied(false)
             }}
-            className="mt-3 text-sm text-blue-600 hover:text-blue-800"
+            className="dnd-link mt-3 text-sm"
+            style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
           >
             Generate another link
           </button>
@@ -104,7 +104,7 @@ export function InviteSection({ gameId }: InviteSectionProps) {
       {error && (
         <div
           data-testid="invite-error"
-          className="mt-3 rounded bg-red-50 p-3 text-sm text-red-800"
+          className="dnd-error-banner mt-3 text-sm"
         >
           {error}
         </div>

--- a/frontend/src/components/games/LevelUpModal.tsx
+++ b/frontend/src/components/games/LevelUpModal.tsx
@@ -1,0 +1,340 @@
+'use client'
+
+import { useState } from 'react'
+import type { PlayerRow } from '@/lib/types/player'
+import { DiceRoller } from '@/components/dice/DiceRoller'
+import type { DieType } from '@/components/dice/DiceRoller'
+
+export interface LevelUpPayload {
+  character_id: string
+  new_level: number
+}
+
+interface LevelUpModalProps {
+  gameId: string
+  payload: LevelUpPayload
+  player: PlayerRow
+  onClose: () => void
+  onConfirmed: () => void
+}
+
+// Frontend D&D 5e constants (mirror of backend utils/dnd.py)
+const HIT_DIE_BY_CLASS: Record<string, DieType> = {
+  sorcerer: 'd6', wizard: 'd6',
+  bard: 'd8', cleric: 'd8', druid: 'd8', monk: 'd8', rogue: 'd8', warlock: 'd8',
+  fighter: 'd10', paladin: 'd10', ranger: 'd10',
+  barbarian: 'd12',
+}
+
+const SPELL_SLOTS_BY_CLASS_LEVEL: Record<string, Record<number, Record<number, number>>> = {
+  wizard:   { 1: {1: 2}, 2: {1: 3}, 3: {1: 4, 2: 2}, 4: {1: 4, 2: 3}, 5: {1: 4, 2: 3, 3: 2} },
+  cleric:   { 1: {1: 2}, 2: {1: 3}, 3: {1: 4, 2: 2}, 4: {1: 4, 2: 3}, 5: {1: 4, 2: 3, 3: 2} },
+  druid:    { 1: {1: 2}, 2: {1: 3}, 3: {1: 4, 2: 2}, 4: {1: 4, 2: 3}, 5: {1: 4, 2: 3, 3: 2} },
+  sorcerer: { 1: {1: 2}, 2: {1: 3}, 3: {1: 4, 2: 2}, 4: {1: 4, 2: 3}, 5: {1: 4, 2: 3, 3: 2} },
+  bard:     { 1: {1: 2}, 2: {1: 3}, 3: {1: 4, 2: 2}, 4: {1: 4, 2: 3}, 5: {1: 4, 2: 3, 3: 2} },
+  paladin:  { 1: {}, 2: {1: 2}, 3: {1: 3}, 4: {1: 3}, 5: {1: 4, 2: 2} },
+  ranger:   { 1: {}, 2: {1: 2}, 3: {1: 3}, 4: {1: 3}, 5: {1: 4, 2: 2} },
+  warlock:  { 1: {1: 1}, 2: {1: 2}, 3: {2: 2}, 4: {2: 2}, 5: {3: 2} },
+}
+
+const CLASS_FEATURES_BY_LEVEL: Record<string, Record<number, string>> = {
+  barbarian: { 2: 'Reckless Attack, Danger Sense', 3: 'Primal Path feature', 4: 'Ability Score Improvement', 5: 'Extra Attack, Fast Movement' },
+  bard:      { 2: 'Jack of All Trades, Song of Rest', 3: 'Bard College feature, Expertise', 4: 'Ability Score Improvement', 5: 'Bardic Inspiration (d8), Font of Inspiration' },
+  cleric:    { 2: 'Channel Divinity, Divine Domain feature', 3: 'Divine Domain feature', 4: 'Ability Score Improvement', 5: 'Destroy Undead (CR 1/2)' },
+  druid:     { 2: 'Wild Shape, Druid Circle feature', 3: 'Druid Circle feature', 4: 'Wild Shape improvement, Ability Score Improvement', 5: 'Wild Shape (CR 1)' },
+  fighter:   { 2: 'Action Surge, Fighting Style', 3: 'Martial Archetype feature', 4: 'Ability Score Improvement', 5: 'Extra Attack' },
+  monk:      { 2: 'Ki, Unarmored Movement', 3: 'Monastic Tradition feature, Deflect Missiles', 4: 'Slow Fall, Ability Score Improvement', 5: 'Extra Attack, Stunning Strike' },
+  paladin:   { 2: 'Divine Smite, Fighting Style, Spellcasting', 3: 'Sacred Oath feature, Divine Health', 4: 'Ability Score Improvement', 5: 'Extra Attack' },
+  ranger:    { 2: 'Fighting Style, Spellcasting, Primeval Awareness', 3: 'Ranger Archetype feature', 4: 'Ability Score Improvement', 5: 'Extra Attack' },
+  rogue:     { 2: 'Cunning Action', 3: 'Roguish Archetype feature, Sneak Attack (2d6)', 4: 'Ability Score Improvement', 5: 'Uncanny Dodge, Sneak Attack (3d6)' },
+  sorcerer:  { 2: 'Font of Magic', 3: 'Sorcerous Origin feature, Metamagic', 4: 'Ability Score Improvement', 5: 'Sorcerous Origin feature' },
+  warlock:   { 2: 'Eldritch Invocations', 3: 'Pact Boon', 4: 'Ability Score Improvement', 5: 'Eldritch Invocations improvement' },
+  wizard:    { 2: 'Arcane Tradition feature', 3: 'Arcane Tradition feature', 4: 'Ability Score Improvement', 5: 'Arcane Tradition feature' },
+}
+
+const PROFICIENCY_BY_LEVEL: Record<number, number> = {
+  1: 2, 2: 2, 3: 2, 4: 2, 5: 3, 6: 3,
+}
+
+const SLOT_ORDINALS: Record<number, string> = { 1: '1st', 2: '2nd', 3: '3rd', 4: '4th', 5: '5th' }
+
+export function LevelUpModal({ gameId, payload, player, onClose, onConfirmed }: LevelUpModalProps) {
+  const [hpChoice, setHpChoice] = useState<'roll' | 'average' | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [rollKey, setRollKey] = useState(0)
+
+  const { new_level, character_id } = payload
+  const charClass = player.character_class.toLowerCase()
+  const hitDie = HIT_DIE_BY_CLASS[charClass] ?? 'd8'
+  const dieSides = parseInt(hitDie.slice(1))
+  const conMod = Math.floor((player.stats.con - 10) / 2)
+  const avgHp = Math.ceil(dieSides / 2) + conMod
+  const oldProf = PROFICIENCY_BY_LEVEL[new_level - 1] ?? 2
+  const newProf = PROFICIENCY_BY_LEVEL[new_level] ?? 2
+
+  // Spell slot diff
+  const classSlots = SPELL_SLOTS_BY_CLASS_LEVEL[charClass]
+  const isSpellcaster = classSlots !== undefined
+  const oldSlots = player.stats.spell_slots ?? {}
+  const newLevelSlots: Record<number, number> = classSlots?.[Math.min(new_level, 5)] ?? {}
+
+  // Class features
+  const classFeatures = CLASS_FEATURES_BY_LEVEL[charClass]?.[new_level]
+
+  const handleConfirm = async () => {
+    if (!hpChoice) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const resp = await fetch(`/api/games/${gameId}/level-up`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ character_id, hp_choice: hpChoice }),
+      })
+      if (!resp.ok) {
+        const data = await resp.json()
+        setError(data.detail ?? 'Something went wrong')
+        return
+      }
+      onConfirmed()
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const cardBase: React.CSSProperties = {
+    flex: 1,
+    border: '1px solid rgba(201,168,76,0.2)',
+    borderRadius: '6px',
+    padding: '12px',
+    cursor: 'pointer',
+    background: 'rgba(201,168,76,0.04)',
+    transition: 'border-color 0.15s, background 0.15s',
+  }
+
+  const cardSelected: React.CSSProperties = {
+    ...cardBase,
+    borderColor: 'rgba(201,168,76,0.6)',
+    background: 'rgba(201,168,76,0.1)',
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Level Up"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.75)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 50,
+        padding: '16px',
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--dnd-charcoal, #1c1c1e)',
+          border: '1px solid rgba(201,168,76,0.3)',
+          borderRadius: '8px',
+          padding: '24px',
+          maxWidth: '520px',
+          width: '100%',
+          maxHeight: '90vh',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '20px',
+        }}
+      >
+        {/* Header */}
+        <div>
+          <h2
+            style={{
+              fontFamily: "'Cinzel', serif",
+              color: 'var(--dnd-gold, #c9a84c)',
+              fontSize: '1.2rem',
+              margin: 0,
+            }}
+          >
+            You&apos;ve reached Level {new_level}!
+          </h2>
+          <p
+            style={{
+              fontFamily: "'Lora', serif",
+              fontStyle: 'italic',
+              fontSize: '0.85rem',
+              color: 'var(--dnd-parchment-dim, #8a7a60)',
+              margin: '4px 0 0 0',
+            }}
+          >
+            {player.character_name} — {player.character_class}
+          </p>
+        </div>
+
+        {/* Stat diff cards */}
+        <div style={{ display: 'flex', gap: '12px' }}>
+          <div style={{ flex: 1, background: 'rgba(201,168,76,0.06)', borderRadius: '6px', padding: '10px', textAlign: 'center' }}>
+            <div style={{ fontFamily: "'Cinzel', serif", fontSize: '0.55rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--dnd-parchment-dim, #8a7a60)', marginBottom: '4px' }}>Level</div>
+            <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1rem', color: 'var(--dnd-parchment, #f0e6c8)' }}>
+              {new_level - 1} → {new_level}
+            </div>
+          </div>
+          <div style={{ flex: 1, background: 'rgba(201,168,76,0.06)', borderRadius: '6px', padding: '10px', textAlign: 'center' }}>
+            <div style={{ fontFamily: "'Cinzel', serif", fontSize: '0.55rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--dnd-parchment-dim, #8a7a60)', marginBottom: '4px' }}>Proficiency</div>
+            <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1rem', color: 'var(--dnd-parchment, #f0e6c8)' }}>
+              +{oldProf} → +{newProf}
+            </div>
+            <div style={{ fontSize: '0.6rem', color: newProf > oldProf ? '#6fcf97' : 'var(--dnd-parchment-dim, #8a7a60)', fontFamily: "'Cinzel', serif" }}>
+              {newProf > oldProf ? 'Increased' : 'Unchanged'}
+            </div>
+          </div>
+        </div>
+
+        {/* HP increase */}
+        <div>
+          <p style={{ fontFamily: "'Cinzel', serif", fontSize: '0.6rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--dnd-parchment-dim, #8a7a60)', margin: '0 0 8px 0' }}>
+            HP Increase
+          </p>
+          <div style={{ display: 'flex', gap: '10px' }}>
+            {/* Roll card */}
+            <div
+              data-testid="hp-choice-roll"
+              onClick={() => setHpChoice('roll')}
+              style={hpChoice === 'roll' ? cardSelected : cardBase}
+            >
+              <div style={{ fontFamily: "'Cinzel', serif", fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--dnd-gold, #c9a84c)', marginBottom: '8px' }}>
+                Roll
+              </div>
+              {hpChoice === 'roll' && (
+                <DiceRoller
+                  key={rollKey}
+                  dieType={hitDie}
+                  autoRoll
+                  label={`${hitDie} HP Roll`}
+                  onAnimationComplete={() => {}}
+                />
+              )}
+              {conMod !== 0 && (
+                <div style={{ fontFamily: "'Cinzel', serif", fontSize: '0.7rem', color: 'var(--dnd-parchment-dim, #8a7a60)', marginTop: '6px' }}>
+                  {conMod > 0 ? '+' : ''}{conMod} CON
+                </div>
+              )}
+              {hpChoice === 'roll' && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); setRollKey((k) => k + 1) }}
+                  style={{ marginTop: '8px', background: 'none', border: '1px solid rgba(201,168,76,0.3)', borderRadius: '4px', color: 'var(--dnd-gold, #c9a84c)', fontSize: '0.6rem', cursor: 'pointer', padding: '2px 8px', fontFamily: "'Cinzel', serif" }}
+                >
+                  Re-roll
+                </button>
+              )}
+            </div>
+
+            {/* Average card */}
+            <div
+              data-testid="hp-choice-average"
+              onClick={() => setHpChoice('average')}
+              style={hpChoice === 'average' ? cardSelected : cardBase}
+            >
+              <div style={{ fontFamily: "'Cinzel', serif", fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--dnd-gold, #c9a84c)', marginBottom: '8px' }}>
+                Take Average
+              </div>
+              <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.2rem', color: 'var(--dnd-parchment, #f0e6c8)', textAlign: 'center' }}>
+                +{Math.max(1, avgHp)}
+              </div>
+              <div style={{ fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: '0.65rem', color: 'var(--dnd-parchment-dim, #8a7a60)', marginTop: '4px' }}>
+                ⌈{hitDie.slice(1)}/2⌉{conMod !== 0 ? ` ${conMod > 0 ? '+' : ''}${conMod}` : ''}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Spell slot diff (spellcasters only) */}
+        {isSpellcaster && Object.keys(newLevelSlots).length > 0 && (
+          <div data-testid="spell-slot-diff">
+            <p style={{ fontFamily: "'Cinzel', serif", fontSize: '0.6rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--dnd-parchment-dim, #8a7a60)', margin: '0 0 8px 0' }}>
+              Spell Slots
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              {Object.entries(newLevelSlots).map(([slotLvl, newCount]) => {
+                const lvlInt = parseInt(slotLvl)
+                const oldCount = oldSlots[slotLvl]?.max ?? 0
+                if (newCount === oldCount) return null
+                return (
+                  <div
+                    key={slotLvl}
+                    style={{ fontFamily: "'Cinzel', serif", fontSize: '0.75rem', color: 'var(--dnd-parchment, #f0e6c8)', display: 'flex', gap: '8px' }}
+                  >
+                    <span style={{ color: 'var(--dnd-parchment-dim, #8a7a60)', minWidth: '60px' }}>
+                      {SLOT_ORDINALS[lvlInt] ?? `${lvlInt}th`} level:
+                    </span>
+                    <span>
+                      {oldCount === 0 ? (
+                        <span style={{ color: '#6fcf97' }}>+{newCount} (new)</span>
+                      ) : (
+                        <span>{oldCount} → <span style={{ color: '#6fcf97' }}>{newCount}</span></span>
+                      )}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Class features */}
+        {classFeatures && (
+          <div>
+            <p style={{ fontFamily: "'Cinzel', serif", fontSize: '0.6rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--dnd-parchment-dim, #8a7a60)', margin: '0 0 6px 0' }}>
+              Class Features Unlocked
+            </p>
+            <p style={{ fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: '0.85rem', color: 'var(--dnd-parchment, #f0e6c8)', margin: 0 }}>
+              {classFeatures}
+            </p>
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div
+            data-testid="level-up-error"
+            style={{
+              fontFamily: "'Lora', serif",
+              fontSize: '0.8rem',
+              color: '#e8a0a0',
+              background: 'rgba(139,34,50,0.12)',
+              border: '1px solid rgba(192,57,43,0.3)',
+              borderRadius: '4px',
+              padding: '8px 12px',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Footer */}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+          <button
+            onClick={onClose}
+            className="dnd-btn-secondary"
+            style={{ padding: '6px 16px', fontSize: '0.7rem' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!hpChoice || isLoading}
+            className="dnd-btn"
+            style={{ padding: '6px 16px', fontSize: '0.7rem' }}
+          >
+            {isLoading ? 'Levelling up...' : 'Confirm Level Up'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/games/__tests__/CharacterSheetPanel.test.tsx
+++ b/frontend/src/components/games/__tests__/CharacterSheetPanel.test.tsx
@@ -222,4 +222,29 @@ describe('CharacterSheetPanel', () => {
 
     expect(screen.getByRole('dialog')).toHaveAttribute('aria-label', 'Character Sheet')
   })
+
+  describe('DIN-28: Level badge and XP bar', () => {
+    it('shows Level badge with correct level number', async () => {
+      ;(supabaseModule.createClient as jest.Mock).mockReturnValue(
+        buildMockSupabase({})  // mockPlayer has level: 3
+      )
+      render(<CharacterSheetPanel playerId="player-1" onClose={onClose} />)
+      await waitFor(() => screen.getByText('Thorin Ironforge'))
+      const badge = screen.getByTestId('level-badge')
+      expect(badge).toHaveTextContent('3')
+    })
+
+    it('XP bar renders with correct width percentage', async () => {
+      // Level 3 → 4: thresholds 900–2700. xp=1350 → (1350-900)/(2700-900) = 25%
+      ;(supabaseModule.createClient as jest.Mock).mockReturnValue(
+        buildMockSupabase({
+          playerData: { ...mockPlayer, level: 3, stats: { ...mockPlayer.stats, xp: 1350 } },
+        })
+      )
+      render(<CharacterSheetPanel playerId="player-1" onClose={onClose} />)
+      await waitFor(() => screen.getByText('Thorin Ironforge'))
+      const bar = screen.getByTestId('xp-bar')
+      expect(bar).toHaveAttribute('data-xp-pct', '25')
+    })
+  })
 })

--- a/frontend/src/components/games/__tests__/ChatMessage.test.tsx
+++ b/frontend/src/components/games/__tests__/ChatMessage.test.tsx
@@ -508,3 +508,140 @@ describe('DIN-25: ability check outcome badge and advantage display', () => {
     expect(discarded).toHaveStyle({ textDecoration: 'line-through' })
   })
 })
+
+describe('DIN-26: combat roll display', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  const critHitRoll: DiceRollEvent = {
+    type: 'dice_roll',
+    die: 'd20',
+    count: 1,
+    result: 20,
+    modifier: 4,
+    total: 24,
+    label: 'Sword Attack',
+    ac: 13,
+    success: true,
+  }
+
+  const critMissRoll: DiceRollEvent = {
+    type: 'dice_roll',
+    die: 'd20',
+    count: 1,
+    result: 1,
+    modifier: 4,
+    total: 5,
+    label: 'Sword Attack',
+    ac: 13,
+    success: false,
+  }
+
+  const normalHitRoll: DiceRollEvent = {
+    type: 'dice_roll',
+    die: 'd20',
+    count: 1,
+    result: 15,
+    modifier: 4,
+    total: 19,
+    label: 'Sword Attack',
+    ac: 13,
+    success: true,
+  }
+
+  const normalMissRoll: DiceRollEvent = {
+    type: 'dice_roll',
+    die: 'd20',
+    count: 1,
+    result: 5,
+    modifier: 2,
+    total: 7,
+    label: 'Bow Attack',
+    ac: 13,
+    success: false,
+  }
+
+  const deathSaveSuccess: DiceRollEvent = {
+    type: 'dice_roll',
+    die: 'd20',
+    count: 1,
+    result: 12,
+    modifier: 0,
+    total: 12,
+    label: 'Death Saving Throw',
+    dc: 10,
+    success: true,
+  }
+
+  it('critical hit roll card is marked with data-crit=hit (gold border)', () => {
+    render(
+      <ChatMessage
+        role="dm"
+        content="A devastating blow!"
+        diceRolls={[critHitRoll]}
+      />
+    )
+    act(() => { jest.runAllTimers() })
+    expect(screen.getByTestId('dice-roll-card-0')).toHaveAttribute('data-crit', 'hit')
+  })
+
+  it('critical miss roll card is marked with data-crit=miss (crimson border)', () => {
+    render(
+      <ChatMessage
+        role="dm"
+        content="You fumble badly!"
+        diceRolls={[critMissRoll]}
+      />
+    )
+    act(() => { jest.runAllTimers() })
+    expect(screen.getByTestId('dice-roll-card-0')).toHaveAttribute('data-crit', 'miss')
+  })
+
+  it('attack roll with ac shows hit outcome after animation', () => {
+    render(
+      <ChatMessage
+        role="dm"
+        content="Your sword connects!"
+        diceRolls={[normalHitRoll]}
+      />
+    )
+    act(() => { jest.runAllTimers() })
+    const outcome = screen.getByTestId('attack-outcome-0')
+    expect(outcome).toHaveTextContent(`vs AC ${normalHitRoll.ac}`)
+    expect(outcome).toHaveTextContent('Hit!')
+  })
+
+  it('attack roll with ac shows miss outcome after animation', () => {
+    render(
+      <ChatMessage
+        role="dm"
+        content="Your blade glances off."
+        diceRolls={[normalMissRoll]}
+      />
+    )
+    act(() => { jest.runAllTimers() })
+    const outcome = screen.getByTestId('attack-outcome-0')
+    expect(outcome).toHaveTextContent(`vs AC ${normalMissRoll.ac}`)
+    expect(outcome).toHaveTextContent('Miss')
+  })
+
+  it('death saving throw shows cumulative tally when priorDeathSaves provided', () => {
+    render(
+      <ChatMessage
+        role="dm"
+        content="Roll to survive!"
+        diceRolls={[deathSaveSuccess]}
+        priorDeathSaves={{ successes: 1, failures: 1 }}
+      />
+    )
+    act(() => { jest.runAllTimers() })
+    const tally = screen.getByTestId('death-save-tally')
+    expect(tally).toHaveTextContent('Successes: 2/3')
+    expect(tally).toHaveTextContent('Failures: 1/3')
+  })
+})

--- a/frontend/src/components/games/__tests__/GameSessionView.test.tsx
+++ b/frontend/src/components/games/__tests__/GameSessionView.test.tsx
@@ -409,11 +409,14 @@ describe('GameSessionView', () => {
     })
 
     it('retry banner disappears when isWaitingForDm goes false via Realtime', async () => {
-      let realtimeCallback: ((payload: any) => void) | null = null
+      // Capture the messages INSERT callback specifically (not just the last .on() call)
+      let insertCallback: ((payload: any) => void) | null = null
 
       const channelObj: any = {
-        on: jest.fn().mockImplementation((_event: any, _filter: any, cb: any) => {
-          realtimeCallback = cb
+        on: jest.fn().mockImplementation((event: any, filter: any, cb: any) => {
+          if (event === 'postgres_changes' && filter?.event === 'INSERT') {
+            insertCallback = cb
+          }
           return channelObj
         }),
         subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
@@ -437,7 +440,7 @@ describe('GameSessionView', () => {
 
       // Simulate DM response arriving via Realtime
       act(() => {
-        realtimeCallback?.({
+        insertCallback?.({
           new: {
             id: 'msg-dm',
             game_id: 'game-1',

--- a/frontend/src/components/games/__tests__/LevelUpModal.test.tsx
+++ b/frontend/src/components/games/__tests__/LevelUpModal.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { LevelUpModal } from '../LevelUpModal'
+import type { PlayerRow } from '@/lib/types/player'
+
+jest.mock('@/components/dice/DiceRoller', () => ({
+  DiceRoller: ({ dieType }: { dieType: string }) => (
+    <div data-testid="mock-dice-roller">{dieType}</div>
+  ),
+}))
+
+const mockWizardPlayer: PlayerRow = {
+  id: 'player-1',
+  game_id: 'game-1',
+  profile_id: 'user-1',
+  character_name: 'Elara',
+  character_class: 'Wizard',
+  race: 'Elf',
+  level: 1,
+  hp_current: 7,
+  hp_max: 7,
+  stats: {
+    str: 8,
+    dex: 14,
+    con: 12,
+    int: 18,
+    wis: 12,
+    cha: 10,
+    spell_slots: { '1': { max: 2, used: 0 } },
+    xp: 300,
+  },
+  status: 'active',
+  joined_at: '2026-01-01T00:00:00Z',
+}
+
+const mockFighterPlayer: PlayerRow = {
+  id: 'player-2',
+  game_id: 'game-1',
+  profile_id: 'user-2',
+  character_name: 'Thorin',
+  character_class: 'Fighter',
+  race: 'Dwarf',
+  level: 1,
+  hp_current: 12,
+  hp_max: 12,
+  stats: { str: 18, dex: 10, con: 16, int: 8, wis: 12, cha: 9 },
+  status: 'active',
+  joined_at: '2026-01-01T00:00:00Z',
+}
+
+describe('LevelUpModal (DIN-28)', () => {
+  const onClose = jest.fn()
+  const onConfirmed = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn()
+  })
+
+  it('renders correct level heading', () => {
+    render(
+      <LevelUpModal
+        gameId="game-1"
+        payload={{ character_id: 'player-1', new_level: 2 }}
+        player={mockWizardPlayer}
+        onClose={onClose}
+        onConfirmed={onConfirmed}
+      />
+    )
+    expect(screen.getByText(/You've reached Level 2/i)).toBeInTheDocument()
+  })
+
+  it('Confirm button is disabled until HP choice is selected', () => {
+    render(
+      <LevelUpModal
+        gameId="game-1"
+        payload={{ character_id: 'player-1', new_level: 2 }}
+        player={mockWizardPlayer}
+        onClose={onClose}
+        onConfirmed={onConfirmed}
+      />
+    )
+    const confirmBtn = screen.getByRole('button', { name: /confirm level up/i })
+    expect(confirmBtn).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId('hp-choice-roll'))
+    expect(confirmBtn).not.toBeDisabled()
+  })
+
+  it('shows spell slot diff for Wizard, not for Fighter', () => {
+    const { rerender } = render(
+      <LevelUpModal
+        gameId="game-1"
+        payload={{ character_id: 'player-1', new_level: 2 }}
+        player={mockWizardPlayer}
+        onClose={onClose}
+        onConfirmed={onConfirmed}
+      />
+    )
+    expect(screen.getByTestId('spell-slot-diff')).toBeInTheDocument()
+
+    rerender(
+      <LevelUpModal
+        gameId="game-1"
+        payload={{ character_id: 'player-2', new_level: 2 }}
+        player={mockFighterPlayer}
+        onClose={onClose}
+        onConfirmed={onConfirmed}
+      />
+    )
+    expect(screen.queryByTestId('spell-slot-diff')).not.toBeInTheDocument()
+  })
+
+  it('POSTs on confirm, shows loading state, calls onConfirmed on success', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ level: 2, hp_max: 15, hp_gained: 8 }),
+    })
+
+    render(
+      <LevelUpModal
+        gameId="game-1"
+        payload={{ character_id: 'player-1', new_level: 2 }}
+        player={mockWizardPlayer}
+        onClose={onClose}
+        onConfirmed={onConfirmed}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('hp-choice-roll'))
+    fireEvent.click(screen.getByRole('button', { name: /confirm level up/i }))
+
+    expect(screen.getByRole('button', { name: /levelling up/i })).toBeDisabled()
+
+    await waitFor(() => expect(onConfirmed).toHaveBeenCalledTimes(1))
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/games/game-1/level-up',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"hp_choice":"roll"'),
+      })
+    )
+  })
+
+  it('shows error message on API failure', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ detail: 'Something went wrong' }),
+    })
+
+    render(
+      <LevelUpModal
+        gameId="game-1"
+        payload={{ character_id: 'player-1', new_level: 2 }}
+        player={mockWizardPlayer}
+        onClose={onClose}
+        onConfirmed={onConfirmed}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('hp-choice-roll'))
+    fireEvent.click(screen.getByRole('button', { name: /confirm level up/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('level-up-error')).toBeInTheDocument()
+    )
+    expect(onConfirmed).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/types/player.ts
+++ b/frontend/src/lib/types/player.ts
@@ -17,6 +17,7 @@ export type PlayerRow = {
     cha: number
     spell_slots?: Record<string, { max: number; used: number }> | null
     cantrips?: string[]
+    xp?: number
   }
   status: 'active' | 'dead' | 'inactive'
   joined_at: string


### PR DESCRIPTION
## Summary

- **DIN-58**: Migrate 5 lobby files from plain Tailwind to `dnd-*` CSS classes; add 3 new utility classes to `globals.css`
- **DIN-26**: Add combat narration support — attack roll display, crit hit/miss styling, death saving throw tally; add COMBAT RULES instruction block to DM system prompt
- **DIN-28**: XP awards tracking, character level-up flow, CharacterSheetPanel level badge + XP bar

## DIN-58 Changes
| File | Change |
|---|---|
| `globals.css` | +3 new utility classes (`dnd-stat-input`, `dnd-warning-box`, `dnd-btn-copy`) |
| `games/[gameId]/page.tsx` | Inline styles → `dnd-heading`, `dnd-badge-{status}` |
| `CharacterSummaryCard.tsx` | Full retheme: `dnd-card`, `dnd-stat-grid`, `dnd-hp-badge` |
| `CharacterCreationForm.tsx` | All labels/inputs/errors → `dnd-*` |
| `CharacterLobbyPanel.tsx` | Buttons → `dnd-btn-primary`, warnings → `dnd-warning-box` |
| `InviteSection.tsx` | Card wrapper, heading, buttons → `dnd-*` |

## DIN-26 Changes
| File | Change |
|---|---|
| `backend/tasks/dm_tasks.py` | Rule 11 COMBAT RULES block in system prompt (attack rolls, NPC ACs, crit hit/miss, Death Saving Throw) |
| `frontend/src/components/games/ChatMessage.tsx` | `data-crit` attribute on roll cards, gold/crimson border for crit hit/miss, attack vs AC outcome display, death save cumulative tally, `priorDeathSaves` prop |
| `ChatMessage.test.tsx` | 5 new DIN-26 tests |
| `test_dm_tasks.py` | TestDin26CombatInstruction backend test |

## DIN-28 Changes
| File | Change |
|---|---|
| `backend/utils/dnd.py` | Add `XP_THRESHOLDS`, `HIT_DICE_BY_CLASS`, `CLASS_FEATURES_BY_LEVEL` constants |
| `backend/api/routes/players.py` | Initialise `xp=0` in stats on character creation |
| `backend/services/dm_service.py` | Handle `xp_awards` in `apply_state_changes`; broadcast `level_up_available` via Supabase Realtime REST when XP crosses threshold; extended signature to accept `game_id` |
| `backend/tasks/dm_tasks.py` | Pass `game_id` to `apply_state_changes`; add XP awards Rule 12 to DM system prompt |
| `backend/api/routes/level_up.py` | New `POST /{game_id}/level-up` — server-side HP roll or average choice, cascading updates to level/hp_max/hp_current/spell_slots/proficiency_bonus |
| `backend/main.py` | Register `level_up` router |
| `frontend/src/lib/types/player.ts` | Add `xp` field to stats type |
| `frontend/src/components/games/CharacterSheetPanel.tsx` | Level badge (`data-testid=level-badge`) and XP bar (`data-testid=xp-bar`, `data-xp-pct`) below HP section |
| `frontend/src/components/games/LevelUpModal.tsx` | New component — HP choice (roll/average with DiceRoller), spell slot diff, confirm POST, loading/error states |
| `frontend/src/app/api/games/[gameId]/level-up/route.ts` | Next.js proxy for level-up endpoint |
| `frontend/src/components/games/GameSessionView.tsx` | Subscribe to `level_up_available` broadcast; show toast banner; render LevelUpModal; expand players select to `'*'` |

## Test plan
- [x] All 527 frontend tests pass (49 suites) — including 5 new LevelUpModal tests, 2 new CharacterSheetPanel DIN-28 tests
- [x] 4 new backend tests in `test_level_up.py` pass; 3 new DIN-28 XP tests in `test_dm_tasks.py` pass
- [x] TypeScript type check clean (`tsc --noEmit`)
- [x] 6 pre-existing backend test failures unrelated to DIN-28 (TestDin25/TestDin27 — missing embed_text/search_rag patches)

Closes DIN-58
Closes DIN-26
Closes DIN-28

https://claude.ai/code/session_01ShjyyCcuh32Axe1BXXQj9k