### PR TITLE
DIN-66: Stream DM responses as Server-Sent Events

### DIFF
--- a/backend/api/routes/actions.py
+++ b/backend/api/routes/actions.py
@@ -1,24 +1,172 @@
 # backend/api/routes/actions.py
 """
-Actions endpoint: POST /games/{gameId}/actions
-Validates action, inserts player message, queues Dramatiq task.
-Embedding and RAG search happen inside the worker (dm_response_task).
+Actions endpoint: POST /games/{gameId}/actions (DIN-66 — SSE via Redis pub/sub).
+
+POST /actions returns 202 JSON immediately after inserting the player message
+and spawning a background coroutine. The coroutine calls Claude with stream=True
+and publishes every parsed SSE event (chunk / block / done) to the Redis
+channel `stream:{game_id}`. The acting player's browser subscribes via the
+separate GET /events endpoint (see api/routes/events.py). When the stream
+finishes, this module inserts the complete DM message to game_messages
+(firing Supabase Realtime for other connected clients) and enqueues
+`dm_bookkeeping_task` for event embedding + suggested_actions persistence.
+
+Why two endpoints?
+- The single-endpoint approach ties the stream to the acting player's HTTP
+  request. Redis pub/sub naturally fans out to N subscribers on the same
+  channel. DIN-67 (multiplayer streaming) needs only the frontend to wire
+  all players to /events — the backend is already ready.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
-import logging
-import uuid
+from __future__ import annotations
 
-from config import supabase_client
+import asyncio
+import json
+import logging
+import re
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from config import supabase_client, anthropic_async_client, redis_async_client
 from api.dependencies import get_current_user
 from models.action import ActionInput, ActionResponse
-from services.dm_service import validate_action
-from tasks.dm_tasks import dm_response_task
-from constants import MESSAGE_ROLE_PLAYER
+from services.dm_service import (
+    validate_action,
+    search_rag,
+    build_dm_system_prompt,
+)
+from services.embedding_service import embed_text
+from services.stream_parser import StreamParser
+from tasks.dm_tasks import dm_bookkeeping_task
+from constants import MESSAGE_ROLE_PLAYER, MESSAGE_ROLE_DM, MESSAGE_ROLE_SYSTEM
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+STREAM_CHANNEL_PREFIX = "stream"
+
+
+_STRIP_TAG_BLOCKS = re.compile(
+    r"<(?:suggested_actions|state_changes|dice_rolls)>.*?</(?:suggested_actions|state_changes|dice_rolls)>",
+    re.DOTALL,
+)
+_STRIP_EVENT_BLOCKS = re.compile(
+    r"<event\s+type=[\"'][^\"']+[\"']>(.*?)</event>",
+    re.DOTALL,
+)
+
+
+def _strip_all_known_tags(text: str) -> str:
+    """Remove structured blocks from a raw Claude response for display.
+
+    Preserves inner text of <event> wrappers; fully removes dice_rolls,
+    state_changes, and suggested_actions blocks.
+    """
+    text = _STRIP_TAG_BLOCKS.sub("", text)
+    text = _STRIP_EVENT_BLOCKS.sub(r"\1", text)
+    return text.strip()
+
+
+def _extract_dice_rolls_for_row(raw_response: str) -> list[dict] | None:
+    """Parse dice rolls for persistence on the DM message row. None if none."""
+    from services.dm_service import extract_dice_rolls
+
+    dice = extract_dice_rolls(raw_response)
+    return dice if dice else None
+
+
+async def _stream_to_redis(
+    game_id: str,
+    action_text: str,
+    system_prompt: str,
+) -> None:
+    """
+    Background coroutine: call Claude and publish SSE events to Redis pub/sub.
+
+    Runs concurrently via `asyncio.create_task` so the POST /actions handler
+    can return 202 immediately. All subscribers on `stream:{game_id}` receive
+    the events — native N-subscriber fan-out with no extra plumbing. A final
+    `{"type": "done"}` is always published (even on errors) so subscribers
+    can close their connections cleanly.
+    """
+    channel = f"{STREAM_CHANNEL_PREFIX}:{game_id}"
+    parser = StreamParser()
+    full_parts: list[str] = []
+
+    async def _publish(event: dict[str, Any]) -> None:
+        await redis_async_client.publish(channel, json.dumps(event))
+
+    try:
+        async with anthropic_async_client.messages.stream(
+            model="claude-sonnet-4-20250514",
+            max_tokens=1024,
+            system=system_prompt,
+            messages=[{"role": "user", "content": action_text}],
+        ) as stream:
+            async for text in stream.text_stream:
+                full_parts.append(text)
+                for evt in parser.feed(text):
+                    await _publish(evt)
+
+        for evt in parser.flush():
+            await _publish(evt)
+
+        # Persist the complete DM message (fires Supabase Realtime for
+        # other players or reconciliation of the streaming bubble).
+        raw = "".join(full_parts)
+        clean = _strip_all_known_tags(raw)
+        dice_rolls = _extract_dice_rolls_for_row(raw)
+
+        await asyncio.to_thread(
+            lambda: supabase_client.table("game_messages")
+            .insert(
+                {
+                    "game_id": game_id,
+                    "role": MESSAGE_ROLE_DM,
+                    "profile_id": None,
+                    "content": clean,
+                    "dice_rolls": dice_rolls,
+                }
+            )
+            .execute()
+        )
+
+        # Enqueue post-stream bookkeeping (event embedding, suggested_actions).
+        dm_bookkeeping_task.send(game_id=game_id, dm_response=raw)
+
+    except Exception as e:
+        logger.error(
+            f"[_stream_to_redis] Error for game={game_id}: {e}", exc_info=True
+        )
+        # Surface a user-visible system message so the retry CTA shows up.
+        try:
+            await asyncio.to_thread(
+                lambda: supabase_client.table("game_messages")
+                .insert(
+                    {
+                        "game_id": game_id,
+                        "role": MESSAGE_ROLE_SYSTEM,
+                        "profile_id": None,
+                        "content": "The Dungeon Master encountered an error. Please try your action again.",
+                    }
+                )
+                .execute()
+            )
+        except Exception:
+            logger.exception(
+                "[_stream_to_redis] failed to insert system error message"
+            )
+    finally:
+        # Subscribers wait for a done event to close cleanly.
+        try:
+            await _publish({"type": "done"})
+        except Exception:
+            logger.exception("[_stream_to_redis] failed to publish done event")
 
 
 @router.post("/{gameId}/actions", response_model=ActionResponse, status_code=202)
@@ -28,21 +176,19 @@ async def create_action(
     current_user: str = Depends(get_current_user),
 ):
     """
-    Player sends action → Backend queues DM response task
+    Player submits an action — fire-and-forget streaming (DIN-66).
 
-    Flow:
-    1. Validate action (Pydantic)
-    2. Check player is in game & valid player_id
-    3. Insert action to game_messages table
-    4. Queue Dramatiq task: dm_response_task(game_id, action_id)
-    5. Return 202 Accepted immediately
+    Synchronous preamble (runs before 202 response):
+        1. Verify player is in this game & game is active
+        2. Insert the player message to game_messages (fires Realtime)
+        3. Embed action + RAG search
+        4. Fetch party, messages, inventory in parallel
+        5. Build Claude system prompt
 
-    Embedding and RAG search happen inside the worker for lower request latency.
-    DM response happens async in worker → broadcast via Supabase Realtime
+    Then spawns `_stream_to_redis` via asyncio.create_task and returns 202.
+    The acting player's browser opens GET /events to subscribe to the stream.
     """
-
     try:
-        # Step 1: Verify player is in this game
         player = (
             supabase_client.table("players")
             .select("*")
@@ -54,7 +200,6 @@ async def create_action(
         if not player.data:
             raise HTTPException(status_code=403, detail="Player not in this game")
 
-        # Step 2: Validate action against game rules
         game = (
             supabase_client.table("games")
             .select("*")
@@ -63,26 +208,88 @@ async def create_action(
             .execute()
         )
 
-        validate_action(action, player.data, game.data)
+        try:
+            validate_action(action, player.data, game.data)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
 
-        # Step 3: Generate message_id
+        # ---- Insert player message (fires Realtime) ---- #
         message_id = str(uuid.uuid4())
+        supabase_client.table("game_messages").insert(
+            {
+                "game_id": gameId,
+                "profile_id": current_user,
+                "role": MESSAGE_ROLE_PLAYER,
+                "content": action.action_text,
+            }
+        ).execute()
 
-        # Step 4: Insert action to game_messages
-        message_row = {
-            "game_id": gameId,
-            "profile_id": current_user,
-            "role": MESSAGE_ROLE_PLAYER,
-            "content": action.action_text,
-        }
+        # ---- Embed + RAG (non-fatal) ---- #
+        try:
+            action_embedding = embed_text(action.action_text)
+            rag_context = search_rag(gameId, action_embedding, top_k=5)
+        except Exception as e:
+            logger.warning(
+                f"[create_action] RAG search failed (fallback to empty): {e}"
+            )
+            rag_context = []
 
-        supabase_client.table("game_messages").insert(message_row).execute()
+        # ---- Fetch party + messages + inventory ---- #
+        def _fetch_players():
+            return (
+                supabase_client.table("players")
+                .select("*")
+                .match({"game_id": gameId})
+                .execute()
+            )
 
-        # Step 5: Queue Dramatiq task — embedding and RAG search happen inside the worker
-        dm_response_task.send(
-            game_id=gameId,
-            message_id=message_id,
+        def _fetch_recent_messages():
+            return (
+                supabase_client.table("game_messages")
+                .select("role, profile_id, content")
+                .eq("game_id", gameId)
+                .order("created_at", desc=True)
+                .limit(20)
+                .execute()
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            f_players = executor.submit(_fetch_players)
+            f_messages = executor.submit(_fetch_recent_messages)
+            players_result = f_players.result()
+            recent_messages_result = f_messages.result()
+
+        player_ids = [p["id"] for p in (players_result.data or [])]
+        inv_by_player: dict[str, list[dict]] = {}
+        if player_ids:
+            try:
+                all_inv = (
+                    supabase_client.table("player_inventory")
+                    .select("player_id, item_name, quantity")
+                    .in_("player_id", player_ids)
+                    .execute()
+                )
+                for item in all_inv.data or []:
+                    inv_by_player.setdefault(item["player_id"], []).append(item)
+            except Exception as e:
+                logger.warning(
+                    f"[create_action] inventory fetch failed (non-fatal): {e}"
+                )
+
+        system_prompt = build_dm_system_prompt(
+            game=game.data,
+            players=players_result.data or [],
+            inv_by_player=inv_by_player,
+            recent_messages=recent_messages_result.data or [],
+            rag_context=rag_context,
             action_text=action.action_text,
+        )
+
+        # Fire-and-forget: the coroutine owns inserting the DM message on
+        # completion and enqueuing bookkeeping. Subscribers on /events see
+        # tokens in real time.
+        asyncio.create_task(
+            _stream_to_redis(gameId, action.action_text, system_prompt)
         )
 
         return ActionResponse(

--- a/backend/api/routes/events.py
+++ b/backend/api/routes/events.py
@@ -1,0 +1,84 @@
+# backend/api/routes/events.py
+"""
+GET /games/{gameId}/events — SSE stream for DM responses (DIN-66).
+
+Subscribes to the Redis pub/sub channel `stream:{gameId}` and forwards
+messages to the browser as Server-Sent Events until a `{"type": "done"}`
+message is received.
+
+In DIN-66: one subscriber — the acting player's browser.
+In DIN-67: N subscribers — all connected players. No backend changes
+needed; Redis pub/sub handles the fan-out natively.
+"""
+
+import json
+import logging
+from typing import AsyncGenerator
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+
+from api.dependencies import get_current_user
+from config import redis_async_client
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+STREAM_CHANNEL_PREFIX = "stream"
+
+
+@router.get("/{gameId}/events")
+async def game_events_stream(
+    gameId: str,
+    current_user: str = Depends(get_current_user),
+):
+    """
+    Open an SSE connection and forward pub/sub messages for this game.
+
+    Closes automatically when a `done` event is received from the backend
+    streaming coroutine (or when the client disconnects).
+    """
+    channel = f"{STREAM_CHANNEL_PREFIX}:{gameId}"
+
+    async def _subscribe() -> AsyncGenerator[str, None]:
+        pubsub = redis_async_client.pubsub()
+        await pubsub.subscribe(channel)
+        try:
+            async for message in pubsub.listen():
+                if message.get("type") != "message":
+                    continue
+                data = message["data"]
+                text = data.decode() if isinstance(data, (bytes, bytearray)) else data
+                yield f"data: {text}\n\n"
+                try:
+                    payload = json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("type") == "done":
+                    break
+        finally:
+            try:
+                await pubsub.unsubscribe(channel)
+            except Exception:
+                logger.warning(
+                    f"[events] pubsub.unsubscribe failed for {channel}",
+                    exc_info=True,
+                )
+            try:
+                await pubsub.aclose()
+            except Exception:
+                logger.warning(
+                    f"[events] pubsub.aclose failed for {channel}",
+                    exc_info=True,
+                )
+
+    return StreamingResponse(
+        _subscribe(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/config.py
+++ b/backend/config.py
@@ -54,9 +54,14 @@ supabase_client = create_client(
 )
 
 # Anthropic client
-from anthropic import Anthropic
+from anthropic import Anthropic, AsyncAnthropic
 
 anthropic_client = Anthropic(api_key=settings.ANTHROPIC_API_KEY)
+
+# Async Anthropic — used only by the SSE streaming path in actions.py.
+# Dramatiq tasks and all non-streaming narration paths keep using the sync
+# anthropic_client above.
+anthropic_async_client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
 
 # OpenAI client with connection reuse (DIN-65)
 import httpx
@@ -73,3 +78,10 @@ openai_client = OpenAI(
         timeout=httpx.Timeout(30.0),
     ),
 )
+
+# Async Redis — used only by the SSE streaming path for pub/sub
+# (publish from _stream_to_redis; subscribe from the /events endpoint).
+# The sync redis_client in redis_broker.py (Dramatiq broker) is unchanged.
+import redis.asyncio as aioredis
+
+redis_async_client = aioredis.from_url(settings.REDIS_URL)

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from dramatiq import get_broker
 from config import settings, supabase_client
 from redis_broker import redis_client
 from api.middleware import add_middleware
-from api.routes import games, players, actions, invites, messages, level_up
+from api.routes import games, players, actions, invites, messages, level_up, events
 
 
 @asynccontextmanager
@@ -56,6 +56,7 @@ app.include_router(actions.router, prefix="/games", tags=["actions"])
 app.include_router(invites.router, prefix="/games", tags=["invites"])
 app.include_router(messages.router, prefix="/games", tags=["messages"])
 app.include_router(level_up.router, prefix="/games", tags=["level-up"])
+app.include_router(events.router, prefix="/games", tags=["events"])
 
 
 @app.get("/health")

--- a/backend/services/dm_service.py
+++ b/backend/services/dm_service.py
@@ -6,6 +6,7 @@ This module handles synchronous pre-processing before enqueueing.
 
 import json
 import logging
+import math
 import os
 import re
 from typing import Any
@@ -15,6 +16,221 @@ from constants import GAME_STATUS_ACTIVE, PLAYER_STATUS_DEAD
 from utils.dnd import XP_THRESHOLDS
 
 logger = logging.getLogger(__name__)
+
+
+def _ability_mod(score: int) -> str:
+    """Format an ability score modifier with sign (e.g. +3 or -1)."""
+    m = math.floor((score - 10) / 2)
+    return f"{m:+d}"
+
+
+def _proficiency_bonus(level: int) -> int:
+    """D&D 5e proficiency bonus progression."""
+    if level >= 17:
+        return 6
+    if level >= 13:
+        return 5
+    if level >= 9:
+        return 4
+    if level >= 5:
+        return 3
+    return 2
+
+
+def build_dm_system_prompt(
+    game: dict,
+    players: list[dict],
+    inv_by_player: dict[str, list[dict]],
+    recent_messages: list[dict],
+    rag_context: list[dict],
+    action_text: str,
+) -> str:
+    """
+    Build the Claude system prompt for a player action (DIN-66).
+
+    Shared by both the streaming /actions route and `dm_response_task`
+    (non-streaming narration paths). Pure function — no I/O. `recent_messages`
+    must be in newest-first order (matches the DB ordering); this function
+    reverses it internally for chronological prompt inclusion.
+    """
+    message_history: list[str] = []
+    for msg in reversed(recent_messages or []):
+        if msg["role"] == "dm":
+            message_history.append(f"DM: {msg['content']}")
+        elif msg["role"] == "player":
+            player_name = next(
+                (
+                    p["character_name"]
+                    for p in players
+                    if p.get("profile_id") == msg.get("profile_id")
+                ),
+                "Unknown Player",
+            )
+            message_history.append(f"{player_name}: {msg['content']}")
+
+    message_history_text = (
+        "\n\n".join(message_history) if message_history else "No messages yet."
+    )
+
+    party_lines: list[str] = []
+    for p in players:
+        inv = inv_by_player.get(p["id"], [])
+        items = (
+            ", ".join(
+                (
+                    f"{i['item_name']} (x{i['quantity']})"
+                    if i["quantity"] > 1
+                    else i["item_name"]
+                )
+                for i in inv
+            )
+            or "no equipment"
+        )
+
+        stats = p.get("stats") or {}
+        str_score = stats.get("str", 10)
+        dex_score = stats.get("dex", 10)
+        con_score = stats.get("con", 10)
+        int_score = stats.get("int", 10)
+        wis_score = stats.get("wis", 10)
+        cha_score = stats.get("cha", 10)
+
+        level = p.get("level", 1)
+        prof_bonus = _proficiency_bonus(level)
+
+        party_line = (
+            f"- {p['character_name']} [ID: {p['id']}], Level {level} "
+            f"{p.get('race', 'Human')} {p['character_class']}.\n"
+            f"  HP: {p['hp_current']}/{p['hp_max']}.\n"
+            f"  STR {str_score} ({_ability_mod(str_score)}), DEX {dex_score} ({_ability_mod(dex_score)}), "
+            f"CON {con_score} ({_ability_mod(con_score)}),\n"
+            f"  INT {int_score} ({_ability_mod(int_score)}), WIS {wis_score} ({_ability_mod(wis_score)}), "
+            f"CHA {cha_score} ({_ability_mod(cha_score)})\n"
+            f"  Proficiency bonus: +{prof_bonus}\n"
+            f"  Equipment: {items}"
+        )
+
+        spell_slots = stats.get("spell_slots")
+        if spell_slots:
+            _ordinals = {1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 5: "5th"}
+            slot_parts = []
+            for lvl_key in sorted(
+                (k for k in spell_slots.keys() if isinstance(k, str) and k.isdigit()),
+                key=int,
+            ):
+                slot = spell_slots[lvl_key]
+                lvl_int = int(lvl_key)
+                if slot.get("max", 0) > 0:
+                    remaining = slot["max"] - slot.get("used", 0)
+                    ordinal = _ordinals.get(lvl_int, f"{lvl_int}th")
+                    slot_parts.append(f"{ordinal}: {remaining}/{slot['max']}")
+            if slot_parts:
+                party_line += f"\n  Spell slots: {', '.join(slot_parts)}"
+
+            cls_lower = p.get("character_class", "").lower()
+            _caster_ability = {
+                "wizard": int_score, "sorcerer": cha_score, "bard": cha_score,
+                "cleric": wis_score, "druid": wis_score, "ranger": wis_score,
+                "paladin": cha_score, "warlock": cha_score,
+            }
+            if cls_lower in _caster_ability:
+                sp_ability = _caster_ability[cls_lower]
+                sp_mod = math.floor((sp_ability - 10) / 2)
+                spell_dc = 8 + prof_bonus + sp_mod
+                spell_atk = prof_bonus + sp_mod
+                party_line += f"\n  Spell save DC: {spell_dc} | Spell attack: {spell_atk:+d}"
+
+        cantrips = stats.get("cantrips")
+        if cantrips:
+            party_line += f"\n  Cantrips (unlimited): {', '.join(cantrips)}"
+
+        party_lines.append(party_line)
+
+    return f"""You are {game['dm_persona']}. You are the Dungeon Master for a D&D 5e campaign called "{game['name']}".
+
+CURRENT PARTY:
+{chr(10).join(party_lines)}
+
+RECENT SESSION HISTORY (last 20 messages, oldest first):
+---
+{message_history_text}
+---
+
+RELEVANT PAST EVENTS (Context from RAG):
+{json.dumps(rag_context, indent=2) if rag_context else "No past events yet."}
+
+RULES:
+1. Respond in character as the DM — never break the fourth wall
+2. Be vivid and engaging but keep responses to 2–3 short paragraphs (~100 words total)
+3. Account for character abilities, equipment, and class features when narrating outcomes
+4. When a player's action requires an ability check or saving throw: determine the relevant ability and apply proficiency if the character's class would grant it for this skill, pick an appropriate DC (Very Easy 5 / Easy 10 / Medium 15 / Hard 20), generate a d20 result (1–20 — never outside this range), and embed the full roll in a <dice_rolls> block (see Rule 10). Narrate the outcome consistent with the success value. Read ability scores from the party list above — do not guess or invent modifiers.
+5. If important story events occur, mark them inline:
+   <event type="combat|discovery|dialogue|death|milestone">Brief factual description</event>
+6. End with a clear invitation for the party to act
+7. Do not list game mechanics or stat changes — narrate them naturally
+8. When your narration causes HP changes or inventory changes, emit a <state_changes> block
+   AFTER your narrative text and BEFORE the <suggested_actions> block:
+   <state_changes>
+   {{
+     "hp_changes": [{{"character_id": "<ID from party list>", "delta": -8, "reason": "goblin attack"}}],
+     "inventory_add": [{{"character_id": "<ID>", "item_name": "Gold Coin", "quantity": 50}}],
+     "inventory_remove": [{{"character_id": "<ID>", "item_name": "Torch", "quantity": 1}}]
+   }}
+   </state_changes>
+   All fields are optional — only include fields that changed. Omit the block entirely if no state changes occur.
+   character_id must be the exact UUID from the party list above (e.g. [ID: abc-123]).
+   delta is signed: negative for damage, positive for healing.
+9. After your narrative response, produce 2–10 short suggested actions the player could
+   take next (imperative mood, ~10 words each). Wrap them in:
+   <suggested_actions>
+   Pick the lock using your thieves' tools.
+   Search the walls for a hidden mechanism.
+   </suggested_actions>
+10. DICE ROLLS: When you resolve a dice roll (ability check, saving throw, attack, or damage),
+   embed the result BEFORE your narrative text using this exact format:
+   <dice_rolls>
+   [
+     {{
+       "type": "dice_roll",
+       "die": "d20",
+       "count": 1,
+       "result": <integer 1–20>,
+       "modifier": <signed integer, 0 if none>,
+       "total": <result + modifier>,
+       "label": "<human-readable label, e.g. Stealth Check>",
+       "dc": <integer, only for ability checks/saves>,
+       "ac": <integer, only for attack rolls — use instead of dc>,
+       "success": <true|false, required when dc or ac is present>,
+       "advantage": <true|false, only when relevant>,
+       "all_rolls": [<roll1>, <roll2>]
+     }}
+   ]
+   </dice_rolls>
+   Rules: result must satisfy 1 ≤ result ≤ (count × die_sides). Include one entry per distinct roll.
+   For attack rolls use "ac" (not "dc"). For ability checks/saves use "dc" (not "ac").
+11. COMBAT RULES:
+   - When a player declares a combat action, adjudicate the exchange narratively:
+     1. Roll player attack (d20 + STR/DEX mod + proficiency if proficient) vs target AC
+     2. On a hit: roll damage dice per weapon type, add modifier
+     3. Narrate enemy reaction and counterattack if applicable
+     4. Embed ALL rolls in <dice_rolls> block (attack + damage + enemy rolls as separate entries)
+     5. Emit <state_changes> with hp_changes for all HP deltas in the exchange
+   - Use SRD 5e weapon damage for player characters based on their equipment list
+   - Invent plausible NPC ACs by creature type: Goblin 13, Bandit 12, Orc 13, Guard 16
+   - Critical Hit (natural 20): double the damage dice (e.g. 2d8 instead of 1d8),
+     add modifier once, note it explicitly in narration
+   - Critical Miss (natural 1): automatic miss, narrate the fumble
+   - At 0 HP: narrate unconsciousness; prompt Death Saving Throw on next player action
+   - Death Saving Throw: d20, no modifier, dc: 10, label: "Death Saving Throw"
+12. XP AWARDS: When players defeat enemies or complete objectives, award XP via the
+   xp_awards field in <state_changes>. Use SRD 5e encounter XP values as a guide.
+   Award XP to all players present.
+   Format: "xp_awards": [{{"character_id": "<ID>", "amount": 100, "reason": "Defeated goblin"}}]
+   Typical values: Goblin 50 XP, Bandit 100 XP, Orc 100 XP, completing a minor quest 150–300 XP.
+
+The acting player's action:
+"{action_text}"
+"""
 
 
 def validate_action(action: Any, player: dict, game: dict) -> None:

--- a/backend/services/stream_parser.py
+++ b/backend/services/stream_parser.py
@@ -1,0 +1,142 @@
+# backend/services/stream_parser.py
+"""
+Streaming XML-tag parser for Claude DM responses (DIN-66).
+
+Claude emits narrative text interleaved with structured XML tags:
+    <event type="...">...</event>
+    <suggested_actions>...</suggested_actions>
+    <state_changes>...</state_changes>
+    <dice_rolls>...</dice_rolls>
+
+This parser wraps the token stream and emits SSE-ready dicts:
+    {"type": "chunk", "text": "..."}                           — plain narrative text
+    {"type": "block", "tag": "...", "attributes": {...},
+                      "content": "..."}                         — complete tag pair
+
+Plain text is held back by a ~60-char lookahead window so a tag whose leading
+`<` arrived in one chunk and whose name arrived in the next still resolves
+correctly. Incomplete tags at end-of-stream are discarded (never leaked as
+raw XML to the client).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+KNOWN_TAGS: frozenset[str] = frozenset(
+    {"event", "suggested_actions", "state_changes", "dice_rolls"}
+)
+
+# Characters held back in the buffer before emitting a chunk event. Must exceed
+# the longest known tag name + angle bracket + some attribute room. 60 ≈ 15
+# typical Claude tokens — small enough to feel live.
+_LOOKAHEAD = 60
+
+_TAG_PATTERN = re.compile(
+    r"<(" + "|".join(sorted(KNOWN_TAGS, key=len, reverse=True)) + r")[\s>]"
+)
+
+_ATTR_RE = re.compile(r"""(\w+)\s*=\s*(?:"([^"]*)"|'([^']*)')""")
+
+
+class StreamParser:
+    """Stateful parser that consumes Claude's text stream chunk-by-chunk."""
+
+    def __init__(self) -> None:
+        self.buffer: str = ""
+
+    def feed(self, chunk: str) -> list[dict[str, Any]]:
+        """Feed one raw text chunk from Claude; return list of SSE event dicts."""
+        self.buffer += chunk
+        events: list[dict[str, Any]] = []
+
+        while True:
+            m = _TAG_PATTERN.search(self.buffer)
+
+            if m is None:
+                # No known tag opening — emit everything except the lookahead.
+                safe = max(0, len(self.buffer) - _LOOKAHEAD)
+                if safe > 0:
+                    events.append({"type": "chunk", "text": self.buffer[:safe]})
+                    self.buffer = self.buffer[safe:]
+                break
+
+            # Flush any plain text before the tag.
+            if m.start() > 0:
+                events.append({"type": "chunk", "text": self.buffer[: m.start()]})
+                self.buffer = self.buffer[m.start() :]
+
+            result = self._extract_block(self.buffer)
+            if result is None:
+                # Tag is incomplete — wait for more data. The partial tag
+                # stays in the buffer and will be retried on the next feed().
+                break
+
+            events.append(result["event"])
+            self.buffer = self.buffer[result["consumed"] :]
+
+        return events
+
+    def flush(self) -> list[dict[str, Any]]:
+        """
+        Call once the upstream stream ends. Emits remaining plain text and
+        drops any incomplete tag fragment (never leaked as raw XML).
+        """
+        events: list[dict[str, Any]] = []
+        remaining = self.buffer
+        self.buffer = ""
+
+        if not remaining:
+            return events
+
+        stripped = remaining.lstrip()
+        # If remaining content starts with a `<`, assume it's an incomplete
+        # tag fragment and discard it — it's not narration-safe.
+        if stripped and not stripped.startswith("<"):
+            events.append({"type": "chunk", "text": remaining})
+        return events
+
+    # ---- internals ---------------------------------------------------- #
+
+    def _extract_block(self, text: str) -> dict[str, Any] | None:
+        """
+        Try to parse a complete `<tag [attrs]>content</tag>` at the start of
+        `text`. Returns {"event": {...}, "consumed": int} or None if the
+        block is incomplete.
+        """
+        tag_names = "|".join(re.escape(t) for t in KNOWN_TAGS)
+        open_re = re.compile(rf"^<({tag_names})((?:\s[^>]*)?)>")
+        open_m = open_re.match(text)
+        if not open_m:
+            return None
+
+        tag_name = open_m.group(1)
+        attrs_str = open_m.group(2).strip()
+
+        close_re = re.compile(rf"</{re.escape(tag_name)}>")
+        close_m = close_re.search(text, open_m.end())
+        if not close_m:
+            return None
+
+        content = text[open_m.end() : close_m.start()]
+        consumed = close_m.end()
+
+        attributes: dict[str, str] = {}
+        for attr_m in _ATTR_RE.finditer(attrs_str):
+            name = attr_m.group(1)
+            value = (
+                attr_m.group(2) if attr_m.group(2) is not None else attr_m.group(3)
+            )
+            attributes[name] = value
+
+        return {
+            "event": {
+                "type": "block",
+                "tag": tag_name,
+                "attributes": attributes,
+                "content": content,
+            },
+            "consumed": consumed,
+        }

--- a/backend/tasks/dm_tasks.py
+++ b/backend/tasks/dm_tasks.py
@@ -22,6 +22,7 @@ from services.dm_service import (
     apply_state_changes,
     extract_dice_rolls,
     search_rag,
+    build_dm_system_prompt,
 )
 from services.embedding_service import embed_text
 from constants import MESSAGE_ROLE_DM, MESSAGE_ROLE_SYSTEM, EVENT_SOURCE_CLAUDE
@@ -89,33 +90,6 @@ def dm_response_task(
             players = f_players.result()
             recent_messages = f_messages.result()
 
-        # Reverse to chronological order and format
-        message_history = []
-        for msg in reversed(recent_messages.data or []):
-            if msg["role"] == "dm":
-                message_history.append(f"DM: {msg['content']}")
-            elif msg["role"] == "player":
-                # Find character name for this profile_id
-                player_name = next(
-                    (
-                        p["character_name"]
-                        for p in players.data
-                        if p.get("profile_id") == msg.get("profile_id")
-                    ),
-                    "Unknown Player",
-                )
-                message_history.append(f"{player_name}: {msg['content']}")
-            # Skip system messages in context
-
-        message_history_text = (
-            "\n\n".join(message_history) if message_history else "No messages yet."
-        )
-
-        def _ability_mod(score: int) -> str:
-            """Format an ability score modifier with sign (e.g. +3 or -1)."""
-            m = math.floor((score - 10) / 2)
-            return f"{m:+d}"
-
         # Step 1c: Fetch player inventory in batch (DIN-65)
         player_ids = [p["id"] for p in players.data]
         inv_by_player: dict[str, list] = {}
@@ -127,178 +101,16 @@ def dm_response_task(
             for item in (all_inv.data or []):
                 inv_by_player.setdefault(item["player_id"], []).append(item)
 
-        party_lines = []
-        for p in players.data:
-            inv = inv_by_player.get(p["id"], [])
+        # Step 2: Build Claude system prompt (shared with the streaming /actions route — DIN-66)
+        system_prompt = build_dm_system_prompt(
+            game=game.data,
+            players=players.data or [],
+            inv_by_player=inv_by_player,
+            recent_messages=recent_messages.data or [],
+            rag_context=rag_context,
+            action_text=action_text,
+        )
 
-            items = (
-                ", ".join(
-                    (
-                        f"{i['item_name']} (x{i['quantity']})"
-                        if i["quantity"] > 1
-                        else i["item_name"]
-                    )
-                    for i in inv
-                )
-                or "no equipment"
-            )
-
-            stats = p.get("stats") or {}
-            str_score = stats.get("str", 10)
-            dex_score = stats.get("dex", 10)
-            con_score = stats.get("con", 10)
-            int_score = stats.get("int", 10)
-            wis_score = stats.get("wis", 10)
-            cha_score = stats.get("cha", 10)
-
-            level = p.get("level", 1)
-            if level >= 17:
-                prof_bonus = 6
-            elif level >= 13:
-                prof_bonus = 5
-            elif level >= 9:
-                prof_bonus = 4
-            elif level >= 5:
-                prof_bonus = 3
-            else:
-                prof_bonus = 2
-
-            party_line = (
-                f"- {p['character_name']} [ID: {p['id']}], Level {level} "
-                f"{p.get('race', 'Human')} {p['character_class']}.\n"
-                f"  HP: {p['hp_current']}/{p['hp_max']}.\n"
-                f"  STR {str_score} ({_ability_mod(str_score)}), DEX {dex_score} ({_ability_mod(dex_score)}), "
-                f"CON {con_score} ({_ability_mod(con_score)}),\n"
-                f"  INT {int_score} ({_ability_mod(int_score)}), WIS {wis_score} ({_ability_mod(wis_score)}), "
-                f"CHA {cha_score} ({_ability_mod(cha_score)})\n"
-                f"  Proficiency bonus: +{prof_bonus}\n"
-                f"  Equipment: {items}"
-            )
-
-            # Spell slots (DIN-27)
-            spell_slots = stats.get("spell_slots")
-            if spell_slots:
-                _ordinals = {1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 5: "5th"}
-                slot_parts = []
-                for lvl_key in sorted(
-                    (k for k in spell_slots.keys() if isinstance(k, str) and k.isdigit()),
-                    key=int,
-                ):
-                    slot = spell_slots[lvl_key]
-                    lvl_int = int(lvl_key)
-                    if slot.get("max", 0) > 0:
-                        remaining = slot["max"] - slot.get("used", 0)
-                        ordinal = _ordinals.get(lvl_int, f"{lvl_int}th")
-                        slot_parts.append(f"{ordinal}: {remaining}/{slot['max']}")
-                if slot_parts:
-                    party_line += f"\n  Spell slots: {', '.join(slot_parts)}"
-
-                # Spell save DC and spell attack bonus
-                cls_lower = p.get("character_class", "").lower()
-                _caster_ability = {
-                    "wizard": int_score, "sorcerer": cha_score, "bard": cha_score,
-                    "cleric": wis_score, "druid": wis_score, "ranger": wis_score,
-                    "paladin": cha_score, "warlock": cha_score,
-                }
-                if cls_lower in _caster_ability:
-                    sp_ability = _caster_ability[cls_lower]
-                    sp_mod = math.floor((sp_ability - 10) / 2)
-                    spell_dc = 8 + prof_bonus + sp_mod
-                    spell_atk = prof_bonus + sp_mod
-                    party_line += f"\n  Spell save DC: {spell_dc} | Spell attack: {spell_atk:+d}"
-
-            cantrips = stats.get("cantrips")
-            if cantrips:
-                party_line += f"\n  Cantrips (unlimited): {', '.join(cantrips)}"
-
-            party_lines.append(party_line)
-
-        # Step 2: Build Claude system prompt
-        system_prompt = f"""You are {game.data['dm_persona']}. You are the Dungeon Master for a D&D 5e campaign called "{game.data['name']}".
-
-CURRENT PARTY:
-{chr(10).join(party_lines)}
-
-RECENT SESSION HISTORY (last 20 messages, oldest first):
----
-{message_history_text}
----
-
-RELEVANT PAST EVENTS (Context from RAG):
-{json.dumps(rag_context, indent=2) if rag_context else "No past events yet."}
-
-RULES:
-1. Respond in character as the DM — never break the fourth wall
-2. Be vivid and engaging but keep responses to 2–3 short paragraphs (~100 words total)
-3. Account for character abilities, equipment, and class features when narrating outcomes
-4. When a player's action requires an ability check or saving throw: determine the relevant ability and apply proficiency if the character's class would grant it for this skill, pick an appropriate DC (Very Easy 5 / Easy 10 / Medium 15 / Hard 20), generate a d20 result (1–20 — never outside this range), and embed the full roll in a <dice_rolls> block (see Rule 10). Narrate the outcome consistent with the success value. Read ability scores from the party list above — do not guess or invent modifiers.
-5. If important story events occur, mark them inline:
-   <event type="combat|discovery|dialogue|death|milestone">Brief factual description</event>
-6. End with a clear invitation for the party to act
-7. Do not list game mechanics or stat changes — narrate them naturally
-8. When your narration causes HP changes or inventory changes, emit a <state_changes> block
-   AFTER your narrative text and BEFORE the <suggested_actions> block:
-   <state_changes>
-   {{
-     "hp_changes": [{{"character_id": "<ID from party list>", "delta": -8, "reason": "goblin attack"}}],
-     "inventory_add": [{{"character_id": "<ID>", "item_name": "Gold Coin", "quantity": 50}}],
-     "inventory_remove": [{{"character_id": "<ID>", "item_name": "Torch", "quantity": 1}}]
-   }}
-   </state_changes>
-   All fields are optional — only include fields that changed. Omit the block entirely if no state changes occur.
-   character_id must be the exact UUID from the party list above (e.g. [ID: abc-123]).
-   delta is signed: negative for damage, positive for healing.
-9. After your narrative response, produce 2–10 short suggested actions the player could
-   take next (imperative mood, ~10 words each). Wrap them in:
-   <suggested_actions>
-   Pick the lock using your thieves' tools.
-   Search the walls for a hidden mechanism.
-   </suggested_actions>
-10. DICE ROLLS: When you resolve a dice roll (ability check, saving throw, attack, or damage),
-   embed the result BEFORE your narrative text using this exact format:
-   <dice_rolls>
-   [
-     {{
-       "type": "dice_roll",
-       "die": "d20",
-       "count": 1,
-       "result": <integer 1–20>,
-       "modifier": <signed integer, 0 if none>,
-       "total": <result + modifier>,
-       "label": "<human-readable label, e.g. Stealth Check>",
-       "dc": <integer, only for ability checks/saves>,
-       "ac": <integer, only for attack rolls — use instead of dc>,
-       "success": <true|false, required when dc or ac is present>,
-       "advantage": <true|false, only when relevant>,
-       "all_rolls": [<roll1>, <roll2>]
-     }}
-   ]
-   </dice_rolls>
-   Rules: result must satisfy 1 ≤ result ≤ (count × die_sides). Include one entry per distinct roll.
-   For attack rolls use "ac" (not "dc"). For ability checks/saves use "dc" (not "ac").
-11. COMBAT RULES:
-   - When a player declares a combat action, adjudicate the exchange narratively:
-     1. Roll player attack (d20 + STR/DEX mod + proficiency if proficient) vs target AC
-     2. On a hit: roll damage dice per weapon type, add modifier
-     3. Narrate enemy reaction and counterattack if applicable
-     4. Embed ALL rolls in <dice_rolls> block (attack + damage + enemy rolls as separate entries)
-     5. Emit <state_changes> with hp_changes for all HP deltas in the exchange
-   - Use SRD 5e weapon damage for player characters based on their equipment list
-   - Invent plausible NPC ACs by creature type: Goblin 13, Bandit 12, Orc 13, Guard 16
-   - Critical Hit (natural 20): double the damage dice (e.g. 2d8 instead of 1d8),
-     add modifier once, note it explicitly in narration
-   - Critical Miss (natural 1): automatic miss, narrate the fumble
-   - At 0 HP: narrate unconsciousness; prompt Death Saving Throw on next player action
-   - Death Saving Throw: d20, no modifier, dc: 10, label: "Death Saving Throw"
-12. XP AWARDS: When players defeat enemies or complete objectives, award XP via the
-   xp_awards field in <state_changes>. Use SRD 5e encounter XP values as a guide.
-   Award XP to all players present.
-   Format: "xp_awards": [{{"character_id": "<ID>", "amount": 100, "reason": "Defeated goblin"}}]
-   Typical values: Goblin 50 XP, Bandit 100 XP, Orc 100 XP, completing a minor quest 150–300 XP.
-
-The acting player's action:
-"{action_text}"
-"""
 
         # Step 3: Call Claude API
         response = anthropic_client.messages.create(
@@ -831,6 +643,75 @@ Write 2–3 paragraphs."""
             ).execute()
         except Exception:
             logger.error("[generate_resume_narration] Failed to insert error message")
+        raise
+
+
+@dramatiq.actor(max_retries=DM_TASK_MAX_RETRIES, min_backoff=1000)
+def dm_bookkeeping_task(game_id: str, dm_response: str) -> None:
+    """
+    Post-stream bookkeeping for a streamed DM response (DIN-66).
+
+    Runs AFTER the complete DM message has been inserted to game_messages
+    by the SSE streaming path (see api/routes/actions.py::_stream_to_redis).
+    Handles work that doesn't need to block the player's first token:
+
+    1. Extract <event> blocks → embed each → insert to game_events (RAG)
+    2. Extract <suggested_actions> → update games.suggested_actions
+    3. Update games.updated_at
+
+    state_changes handling is intentionally deferred to Epic-7 — the
+    streaming path consumes those blocks silently for now.
+
+    Failures re-raise so Dramatiq retries the task. Because the DM message
+    is already persisted before this task runs, retries never risk a
+    duplicate DM message in the chat.
+    """
+    logger.info(f"[dm_bookkeeping_task] Starting for game={game_id}")
+
+    try:
+        events = extract_events_from_response(dm_response)
+        logger.info(f"[dm_bookkeeping_task] Extracted {len(events)} events")
+
+        event_rows = []
+        for event in events:
+            embedding = embed_text(event["description"])
+            event_rows.append(
+                {
+                    "game_id": game_id,
+                    "event_type": event["type"],
+                    "summary": event["description"],
+                    "embedding": embedding,
+                    "source": EVENT_SOURCE_CLAUDE,
+                }
+            )
+        if event_rows:
+            supabase_client.table("game_events").insert(event_rows).execute()
+            logger.info(f"[dm_bookkeeping_task] Inserted {len(event_rows)} events")
+
+        suggested_match = re.search(
+            r"<suggested_actions>(.*?)</suggested_actions>",
+            dm_response,
+            flags=re.DOTALL,
+        )
+        suggested_actions: list[str] = []
+        if suggested_match:
+            suggested_actions = [
+                line.strip()
+                for line in suggested_match.group(1).splitlines()
+                if line.strip()
+            ]
+
+        supabase_client.table("games").update(
+            {
+                "updated_at": datetime.utcnow().isoformat(),
+                "suggested_actions": suggested_actions,
+            }
+        ).match({"id": game_id}).execute()
+
+        logger.info(f"[dm_bookkeeping_task] Success for game={game_id}")
+
+    except Exception as e:
+        logger.error(f"[dm_bookkeeping_task] Error: {e}", exc_info=True)
         raise
 
 

--- a/backend/tests/test_actions_route.py
+++ b/backend/tests/test_actions_route.py
@@ -1,21 +1,122 @@
-"""Tests for the actions API route."""
+"""Tests for the actions API route (DIN-66: fire-and-forget → Redis pub/sub)."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 from tests.conftest import SAMPLE_GAME, SAMPLE_PLAYER
 
 
-class TestCreateAction:
-    """Tests for POST /games/{gameId}/actions."""
+def _build_supabase_mock():
+    """Supabase table() side-effect that responds to every call in the flow."""
+    mock_player_result = MagicMock()
+    mock_player_result.data = SAMPLE_PLAYER
+    mock_game_result = MagicMock()
+    mock_game_result.data = SAMPLE_GAME
+    mock_insert_result = MagicMock()
+    mock_insert_result.data = {"id": "msg-1"}
+    mock_messages_result = MagicMock()
+    mock_messages_result.data = []
+    mock_players_result = MagicMock()
+    mock_players_result.data = [SAMPLE_PLAYER]
+    mock_inventory_result = MagicMock()
+    mock_inventory_result.data = []
 
-    def test_create_action_success(self, client):
-        """Should accept a valid action and return 202."""
-        mock_player_result = MagicMock()
-        mock_player_result.data = SAMPLE_PLAYER
-        mock_game_result = MagicMock()
-        mock_game_result.data = SAMPLE_GAME
-        mock_insert_result = MagicMock()
-        mock_insert_result.data = {"id": "msg-1"}
+    def table_side_effect(name):
+        mock = MagicMock()
+        if name == "players":
+            mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
+                mock_player_result
+            )
+            mock.select.return_value.match.return_value.execute.return_value = (
+                mock_players_result
+            )
+        elif name == "games":
+            mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
+                mock_game_result
+            )
+        elif name == "game_messages":
+            mock.insert.return_value.execute.return_value = mock_insert_result
+            mock.select.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = (
+                mock_messages_result
+            )
+        elif name == "player_inventory":
+            mock.select.return_value.in_.return_value.execute.return_value = (
+                mock_inventory_result
+            )
+        return mock
+
+    return table_side_effect
+
+
+class TestCreateAction:
+    """Tests for POST /games/{gameId}/actions — 202 fire-and-forget (DIN-66)."""
+
+    def test_create_action_returns_202_json(self, client):
+        """Valid action returns 202 with a queued ActionResponse JSON body."""
+        captured_coros = []
+
+        def fake_create_task(coro):
+            captured_coros.append(coro)
+            coro.close()
+            return MagicMock()
+
+        with patch("api.routes.actions.supabase_client") as mock_sb, patch(
+            "api.routes.actions.asyncio.create_task", side_effect=fake_create_task
+        ), patch("api.routes.actions.embed_text") as mock_embed, patch(
+            "api.routes.actions.search_rag"
+        ) as mock_rag:
+            mock_sb.table.side_effect = _build_supabase_mock()
+            mock_embed.return_value = [0.0] * 1536
+            mock_rag.return_value = []
+
+            response = client.post(
+                "/games/game-uuid-1/actions",
+                json={"action_text": "I attack the dragon!"},
+            )
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["status"] == "queued"
+        assert body["game_id"] == "game-uuid-1"
+        assert "message_id" in body
+
+        # The streaming coroutine is spawned — not a Dramatiq task.
+        assert len(captured_coros) == 1
+
+    def test_create_action_does_not_enqueue_dm_response_task(self, client):
+        """DIN-66: dm_response_task is preserved for other paths, not used here."""
+
+        def _close(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("api.routes.actions.supabase_client") as mock_sb, patch(
+            "api.routes.actions.asyncio.create_task", side_effect=_close
+        ), patch("api.routes.actions.embed_text") as mock_embed, patch(
+            "api.routes.actions.search_rag"
+        ) as mock_rag:
+            mock_sb.table.side_effect = _build_supabase_mock()
+            mock_embed.return_value = [0.0] * 1536
+            mock_rag.return_value = []
+
+            # If actions.py accidentally imported dm_response_task, any .send
+            # invocation would show up as a call on this patched symbol.
+            with patch("tasks.dm_tasks.dm_response_task") as mock_dm_task:
+                response = client.post(
+                    "/games/game-uuid-1/actions",
+                    json={"action_text": "attack"},
+                )
+
+                assert response.status_code == 202
+                mock_dm_task.send.assert_not_called()
+
+    def test_create_action_inserts_player_message(self, client):
+        """Player message is inserted to game_messages (fires Realtime)."""
+        captured_inserts: list[dict] = []
+
+        mock_player_result = MagicMock(data=SAMPLE_PLAYER)
+        mock_game_result = MagicMock(data=SAMPLE_GAME)
+        mock_messages_result = MagicMock(data=[])
+        mock_players_result = MagicMock(data=[SAMPLE_PLAYER])
+        mock_inventory_result = MagicMock(data=[])
 
         def table_side_effect(name):
             mock = MagicMock()
@@ -23,35 +124,82 @@ class TestCreateAction:
                 mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
                     mock_player_result
                 )
+                mock.select.return_value.match.return_value.execute.return_value = (
+                    mock_players_result
+                )
             elif name == "games":
                 mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
                     mock_game_result
                 )
             elif name == "game_messages":
-                mock.insert.return_value.execute.return_value = mock_insert_result
+
+                def capture_insert(row):
+                    captured_inserts.append(row)
+                    return MagicMock(execute=MagicMock(return_value=MagicMock()))
+
+                mock.insert.side_effect = capture_insert
+                mock.select.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = (
+                    mock_messages_result
+                )
+            elif name == "player_inventory":
+                mock.select.return_value.in_.return_value.execute.return_value = (
+                    mock_inventory_result
+                )
             return mock
 
+        def _close(coro):
+            coro.close()
+            return MagicMock()
+
         with patch("api.routes.actions.supabase_client") as mock_sb, patch(
-            "api.routes.actions.dm_response_task"
-        ) as mock_task:
+            "api.routes.actions.asyncio.create_task", side_effect=_close
+        ), patch("api.routes.actions.embed_text") as mock_embed, patch(
+            "api.routes.actions.search_rag"
+        ) as mock_rag:
             mock_sb.table.side_effect = table_side_effect
+            mock_embed.return_value = [0.0] * 1536
+            mock_rag.return_value = []
 
             response = client.post(
                 "/games/game-uuid-1/actions",
-                json={
-                    "action_text": "I attack the dragon!",
-                },
+                json={"action_text": "I attack!"},
             )
 
         assert response.status_code == 202
-        data = response.json()
-        assert data["status"] == "queued"
-        assert data["game_id"] == "game-uuid-1"
-        assert "message_id" in data
-        mock_task.send.assert_called_once()
+        player_inserts = [r for r in captured_inserts if r.get("role") == "player"]
+        assert len(player_inserts) == 1
+        assert player_inserts[0]["content"] == "I attack!"
+        assert player_inserts[0]["game_id"] == "game-uuid-1"
+
+    def test_create_action_spawns_stream_task(self, client):
+        """The spawned coroutine is the streaming pub/sub task."""
+        captured_coros = []
+
+        def fake_create_task(coro):
+            captured_coros.append(coro)
+            # Close the coroutine so it doesn't produce RuntimeWarning.
+            coro.close()
+            return MagicMock()
+
+        with patch("api.routes.actions.supabase_client") as mock_sb, patch(
+            "api.routes.actions.asyncio.create_task", side_effect=fake_create_task
+        ), patch("api.routes.actions.embed_text") as mock_embed, patch(
+            "api.routes.actions.search_rag"
+        ) as mock_rag:
+            mock_sb.table.side_effect = _build_supabase_mock()
+            mock_embed.return_value = [0.0] * 1536
+            mock_rag.return_value = []
+
+            response = client.post(
+                "/games/game-uuid-1/actions",
+                json={"action_text": "I attack the dragon!"},
+            )
+
+        assert response.status_code == 202
+        assert len(captured_coros) == 1
 
     def test_create_action_player_not_in_game(self, client):
-        """Should return 403 when player is not in the game."""
+        """403 if the player is not in the game."""
         mock_player_result = MagicMock()
         mock_player_result.data = None
 
@@ -59,116 +207,28 @@ class TestCreateAction:
             mock_sb.table.return_value.select.return_value.match.return_value.single.return_value.execute.return_value = (
                 mock_player_result
             )
-
             response = client.post(
                 "/games/game-uuid-1/actions",
-                json={
-                    "action_text": "I attack!",
-                },
+                json={"action_text": "I attack!"},
             )
-
         assert response.status_code == 403
 
     def test_create_action_missing_action_text(self, client):
-        """Should return 422 when action_text is missing."""
         response = client.post(
             "/games/game-uuid-1/actions",
-            json={
-                "player_id": "player-uuid-1",
-            },
+            json={"player_id": "player-uuid-1"},
         )
         assert response.status_code == 422
 
     def test_create_action_unauthorized(self, unauthed_client):
-        """Should return 401 when no auth token is provided."""
         response = unauthed_client.post(
             "/games/game-uuid-1/actions",
-            json={
-                "player_id": "player-uuid-1",
-                "action_text": "I attack!",
-            },
+            json={"action_text": "I attack!"},
         )
         assert response.status_code == 401
 
-    def test_create_action_does_not_call_openai_embedding(self, client):
-        """DIN-64: actions endpoint must NOT call OpenAI — embedding moved to worker."""
-        mock_player_result = MagicMock()
-        mock_player_result.data = SAMPLE_PLAYER
-        mock_game_result = MagicMock()
-        mock_game_result.data = SAMPLE_GAME
-        mock_insert_result = MagicMock()
-        mock_insert_result.data = {"id": "msg-1"}
-
-        def table_side_effect(name):
-            mock = MagicMock()
-            if name == "players":
-                mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
-                    mock_player_result
-                )
-            elif name == "games":
-                mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
-                    mock_game_result
-                )
-            elif name == "game_messages":
-                mock.insert.return_value.execute.return_value = mock_insert_result
-            return mock
-
-        # Patch openai_client from config to verify it's NOT imported/used in actions.py
-        with patch("api.routes.actions.supabase_client") as mock_sb, patch(
-            "api.routes.actions.dm_response_task"
-        ) as mock_task, patch("config.openai_client") as mock_openai:
-            mock_sb.table.side_effect = table_side_effect
-
-            response = client.post(
-                "/games/game-uuid-1/actions",
-                json={"action_text": "I attack the dragon!"},
-            )
-
-        assert response.status_code == 202
-        mock_task.send.assert_called_once()
-        # OpenAI must NOT be called in the request path (DIN-64)
-        mock_openai.embeddings.create.assert_not_called()
-
-    def test_create_action_send_no_rag_context_kwarg(self, client):
-        """DIN-64: dm_response_task.send() must be called without rag_context kwarg."""
-        mock_player_result = MagicMock()
-        mock_player_result.data = SAMPLE_PLAYER
-        mock_game_result = MagicMock()
-        mock_game_result.data = SAMPLE_GAME
-        mock_insert_result = MagicMock()
-        mock_insert_result.data = {"id": "msg-1"}
-
-        def table_side_effect(name):
-            mock = MagicMock()
-            if name == "players":
-                mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
-                    mock_player_result
-                )
-            elif name == "games":
-                mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
-                    mock_game_result
-                )
-            elif name == "game_messages":
-                mock.insert.return_value.execute.return_value = mock_insert_result
-            return mock
-
-        with patch("api.routes.actions.supabase_client") as mock_sb, patch(
-            "api.routes.actions.dm_response_task"
-        ) as mock_task:
-            mock_sb.table.side_effect = table_side_effect
-
-            response = client.post(
-                "/games/game-uuid-1/actions",
-                json={"action_text": "I attack the dragon!"},
-            )
-
-        assert response.status_code == 202
-        mock_task.send.assert_called_once()
-        call_kwargs = mock_task.send.call_args[1]
-        assert "rag_context" not in call_kwargs
-
-    def test_create_action_invalid_game_state(self, client):
-        """Should return 500 when game is not active."""
+    def test_create_action_invalid_game_state_returns_422(self, client):
+        """When the game is not active, validate_action raises and returns 422."""
         mock_player_result = MagicMock()
         mock_player_result.data = SAMPLE_PLAYER
         ended_game = {**SAMPLE_GAME, "status": "ended"}
@@ -189,13 +249,10 @@ class TestCreateAction:
 
         with patch("api.routes.actions.supabase_client") as mock_sb:
             mock_sb.table.side_effect = table_side_effect
-
             response = client.post(
                 "/games/game-uuid-1/actions",
-                json={
-                    "action_text": "I attack!",
-                },
+                json={"action_text": "I attack!"},
             )
 
-        assert response.status_code == 500
+        assert response.status_code == 422
         assert "not active" in response.json()["detail"]

--- a/backend/tests/test_dm_tasks.py
+++ b/backend/tests/test_dm_tasks.py
@@ -19,6 +19,7 @@ with patch("config.supabase_client", MagicMock()), patch(
 ) as mock_embed_text:
     from tasks.dm_tasks import (
         dm_response_task,
+        dm_bookkeeping_task,
         generate_opening_narration,
         generate_pause_message,
         generate_end_message,
@@ -1960,3 +1961,123 @@ class TestDin28XpAwards:
             )
 
         mock_broadcast.assert_not_called()
+
+
+
+class TestDmBookkeepingTask:
+    """Tests for dm_bookkeeping_task (DIN-66)."""
+
+    def test_updates_suggested_actions_and_timestamp(self):
+        """Bookkeeping writes suggested_actions + updated_at to games."""
+        raw_response = (
+            "The path forks.\n<suggested_actions>\nGo left.\nGo right.\n"
+            "</suggested_actions>"
+        )
+        captured: list[dict] = []
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "games":
+                def capture_update(row):
+                    captured.append(row)
+                    return MagicMock(
+                        match=MagicMock(
+                            return_value=MagicMock(
+                                execute=MagicMock(return_value=MagicMock())
+                            )
+                        )
+                    )
+                mock.update.side_effect = capture_update
+            return mock
+
+        with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
+            "tasks.dm_tasks.embed_text"
+        ):
+            mock_sb.table.side_effect = table_side_effect
+            dm_bookkeeping_task.fn("game-1", raw_response)
+
+        assert len(captured) == 1
+        assert "updated_at" in captured[0]
+        assert captured[0]["suggested_actions"] == ["Go left.", "Go right."]
+
+    def test_embeds_events_and_inserts_to_game_events(self):
+        raw_response = (
+            'The goblin falls. <event type="combat">Goblin slain</event> '
+            'The party rests. <event type="milestone">Survived</event>'
+        )
+        captured_rows: list[list] = []
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "games":
+                mock.update.return_value.match.return_value.execute.return_value = MagicMock()
+            elif name == "game_events":
+                def capture_insert(rows):
+                    captured_rows.append(rows)
+                    return MagicMock(execute=MagicMock(return_value=MagicMock()))
+                mock.insert.side_effect = capture_insert
+            return mock
+
+        with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
+            "tasks.dm_tasks.embed_text"
+        ) as mock_embed:
+            mock_sb.table.side_effect = table_side_effect
+            mock_embed.return_value = [0.1] * 1536
+            dm_bookkeeping_task.fn("game-1", raw_response)
+
+        assert len(captured_rows) == 1
+        rows = captured_rows[0]
+        assert len(rows) == 2
+        assert rows[0]["event_type"] == "combat"
+        assert rows[0]["summary"] == "Goblin slain"
+        assert rows[0]["embedding"] == [0.1] * 1536
+        assert rows[1]["event_type"] == "milestone"
+
+    def test_no_events_skips_game_events_insert(self):
+        raw_response = (
+            "Just narration.\n<suggested_actions>\nLook around.\n"
+            "</suggested_actions>"
+        )
+        captured_updates: list[dict] = []
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "games":
+                def capture_update(row):
+                    captured_updates.append(row)
+                    return MagicMock(
+                        match=MagicMock(
+                            return_value=MagicMock(
+                                execute=MagicMock(return_value=MagicMock())
+                            )
+                        )
+                    )
+                mock.update.side_effect = capture_update
+            return mock
+
+        with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
+            "tasks.dm_tasks.embed_text"
+        ) as mock_embed:
+            mock_sb.table.side_effect = table_side_effect
+            dm_bookkeeping_task.fn("game-1", raw_response)
+            mock_embed.assert_not_called()
+
+        assert len(captured_updates) == 1
+        assert captured_updates[0]["suggested_actions"] == ["Look around."]
+
+    def test_exception_reraised_for_dramatiq_retry(self):
+        raw_response = 'Thing. <event type="combat">x</event>'
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "game_events":
+                mock.insert.side_effect = RuntimeError("db down")
+            return mock
+
+        with patch("tasks.dm_tasks.supabase_client") as mock_sb, patch(
+            "tasks.dm_tasks.embed_text"
+        ) as mock_embed:
+            mock_sb.table.side_effect = table_side_effect
+            mock_embed.return_value = [0.1] * 1536
+            with pytest.raises(RuntimeError):
+                dm_bookkeeping_task.fn("game-1", raw_response)

--- a/backend/tests/test_events_route.py
+++ b/backend/tests/test_events_route.py
@@ -1,0 +1,142 @@
+"""Tests for the events SSE route (DIN-66)."""
+
+import json
+from unittest.mock import MagicMock, patch, AsyncMock
+
+
+def _messages_iter(messages: list[dict]):
+    """Async iterator yielding a fixed sequence of pubsub messages."""
+
+    class _Iter:
+        def __init__(self, items):
+            self._items = list(items)
+            self._idx = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx >= len(self._items):
+                # Block indefinitely — real pubsub.listen() blocks forever;
+                # we reach here only if the consumer didn't break on `done`.
+                raise StopAsyncIteration
+            item = self._items[self._idx]
+            self._idx += 1
+            return item
+
+    return _Iter(messages)
+
+
+def _build_pubsub_mock(messages: list[dict]) -> MagicMock:
+    """Build a mock pubsub object matching redis.asyncio.client.PubSub's API."""
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+    pubsub.aclose = AsyncMock()
+    pubsub.listen = MagicMock(return_value=_messages_iter(messages))
+    return pubsub
+
+
+def _read_sse(body: bytes) -> list[dict]:
+    """Parse SSE body into a list of event dicts."""
+    text = body.decode() if isinstance(body, (bytes, bytearray)) else body
+    events: list[dict] = []
+    for frame in text.split("\n\n"):
+        for line in frame.split("\n"):
+            if line.startswith("data: "):
+                try:
+                    events.append(json.loads(line[6:]))
+                except json.JSONDecodeError:
+                    pass
+    return events
+
+
+class TestEventsRoute:
+    """Tests for GET /games/{gameId}/events."""
+
+    def test_success_forwards_chunks_until_done(self, client):
+        """Chunks from Redis pub/sub are proxied to the client as SSE."""
+        pub_msgs = [
+            {
+                "type": "message",
+                "data": json.dumps({"type": "chunk", "text": "Hello "}).encode(),
+            },
+            {
+                "type": "message",
+                "data": json.dumps({"type": "chunk", "text": "world."}).encode(),
+            },
+            {
+                "type": "message",
+                "data": json.dumps({"type": "done"}).encode(),
+            },
+        ]
+        pubsub = _build_pubsub_mock(pub_msgs)
+
+        with patch("api.routes.events.redis_async_client") as mock_redis:
+            # `pubsub()` is sync on redis.asyncio clients — force MagicMock
+            # (patch may auto-convert to AsyncMock for methods it infers).
+            mock_redis.pubsub = MagicMock(return_value=pubsub)
+
+            response = client.get("/games/game-1/events")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        assert response.headers.get("x-accel-buffering") == "no"
+
+        events = _read_sse(response.content)
+        assert {"type": "chunk", "text": "Hello "} in events
+        assert {"type": "chunk", "text": "world."} in events
+        assert events[-1] == {"type": "done"}
+
+        # We subscribed + unsubscribed + closed cleanly.
+        pubsub.subscribe.assert_awaited_once_with("stream:game-1")
+        pubsub.unsubscribe.assert_awaited()
+        pubsub.aclose.assert_awaited()
+
+    def test_skips_non_message_types(self, client):
+        """Non-message entries from pubsub.listen() are ignored."""
+        pub_msgs = [
+            {"type": "subscribe", "data": b""},
+            {"type": "message", "data": json.dumps({"type": "chunk", "text": "ok"}).encode()},
+            {"type": "message", "data": json.dumps({"type": "done"}).encode()},
+        ]
+        pubsub = _build_pubsub_mock(pub_msgs)
+
+        with patch("api.routes.events.redis_async_client") as mock_redis:
+            mock_redis.pubsub = MagicMock(return_value=pubsub)
+            response = client.get("/games/game-1/events")
+
+        events = _read_sse(response.content)
+        assert len(events) == 2  # chunk + done, subscribe was skipped
+
+    def test_block_events_forwarded(self, client):
+        """block events (dice_rolls etc.) are forwarded unchanged."""
+        pub_msgs = [
+            {
+                "type": "message",
+                "data": json.dumps(
+                    {
+                        "type": "block",
+                        "tag": "dice_rolls",
+                        "attributes": {},
+                        "content": '[{"die":"d20","result":15}]',
+                    }
+                ).encode(),
+            },
+            {"type": "message", "data": json.dumps({"type": "done"}).encode()},
+        ]
+        pubsub = _build_pubsub_mock(pub_msgs)
+
+        with patch("api.routes.events.redis_async_client") as mock_redis:
+            mock_redis.pubsub = MagicMock(return_value=pubsub)
+            response = client.get("/games/game-1/events")
+
+        events = _read_sse(response.content)
+        blocks = [e for e in events if e["type"] == "block"]
+        assert len(blocks) == 1
+        assert blocks[0]["tag"] == "dice_rolls"
+
+    def test_unauthorized_without_token(self, unauthed_client):
+        """401 when no bearer token is present."""
+        response = unauthed_client.get("/games/game-1/events")
+        assert response.status_code == 401

--- a/backend/tests/test_stream_parser.py
+++ b/backend/tests/test_stream_parser.py
@@ -1,0 +1,177 @@
+"""Tests for backend.services.stream_parser.StreamParser (DIN-66)."""
+
+from services.stream_parser import StreamParser, KNOWN_TAGS
+
+
+def _feed_all(parser: StreamParser, chunks: list[str]) -> list[dict]:
+    """Feed a sequence of chunks and also flush at the end, returning all events."""
+    events: list[dict] = []
+    for c in chunks:
+        events.extend(parser.feed(c))
+    events.extend(parser.flush())
+    return events
+
+
+class TestPlainText:
+    def test_single_chunk_plain_text(self):
+        parser = StreamParser()
+        events = _feed_all(parser, ["The goblin lunges forward with a snarl."])
+        assert events == [
+            {"type": "chunk", "text": "The goblin lunges forward with a snarl."}
+        ]
+
+    def test_multiple_chunks_concatenate_text(self):
+        parser = StreamParser()
+        events = _feed_all(parser, ["The goblin ", "lunges forward ", "with a snarl."])
+        combined = "".join(e["text"] for e in events if e["type"] == "chunk")
+        assert combined == "The goblin lunges forward with a snarl."
+
+    def test_empty_chunk_is_noop(self):
+        parser = StreamParser()
+        assert parser.feed("") == []
+        assert parser.flush() == []
+
+
+class TestDiceRollsBlock:
+    def test_complete_dice_rolls_block_in_one_chunk(self):
+        parser = StreamParser()
+        raw = (
+            'Rolling for stealth... <dice_rolls>[{"die":"d20","result":15}]</dice_rolls>'
+            " You sneak past."
+        )
+        events = _feed_all(parser, [raw])
+        block = next(e for e in events if e["type"] == "block")
+        assert block["tag"] == "dice_rolls"
+        assert block["content"] == '[{"die":"d20","result":15}]'
+        chunks = "".join(e["text"] for e in events if e["type"] == "chunk")
+        assert "Rolling for stealth... " in chunks
+        assert " You sneak past." in chunks
+        # Raw XML never appears in narrative chunks.
+        assert "<dice_rolls>" not in chunks
+        assert "</dice_rolls>" not in chunks
+
+    def test_dice_rolls_block_split_across_chunks(self):
+        parser = StreamParser()
+        chunks = [
+            "Rolling for stealth...",
+            " <dice_",
+            'rolls>[{"die":"d20","result":',
+            '15}]</dice_',
+            "rolls> You sneak past.",
+        ]
+        events = _feed_all(parser, chunks)
+        blocks = [e for e in events if e["type"] == "block"]
+        assert len(blocks) == 1
+        assert blocks[0]["tag"] == "dice_rolls"
+        assert "15" in blocks[0]["content"]
+
+
+class TestEventBlock:
+    def test_event_block_with_attributes(self):
+        parser = StreamParser()
+        raw = '<event type="combat">The goblin falls.</event>'
+        events = _feed_all(parser, [raw])
+        blocks = [e for e in events if e["type"] == "block"]
+        assert len(blocks) == 1
+        assert blocks[0]["tag"] == "event"
+        assert blocks[0]["attributes"] == {"type": "combat"}
+        assert blocks[0]["content"] == "The goblin falls."
+
+    def test_event_block_mixed_with_text(self):
+        parser = StreamParser()
+        raw = 'Before. <event type="discovery">Found a key</event> After.'
+        events = _feed_all(parser, [raw])
+        chunks = "".join(e.get("text", "") for e in events if e["type"] == "chunk")
+        blocks = [e for e in events if e["type"] == "block"]
+        assert "Before. " in chunks
+        assert " After." in chunks
+        assert len(blocks) == 1
+        assert blocks[0]["attributes"] == {"type": "discovery"}
+
+
+class TestSuggestedActionsBlock:
+    def test_suggested_actions_plain(self):
+        parser = StreamParser()
+        raw = (
+            "The path forks.\n<suggested_actions>\nGo left.\nGo right.\n"
+            "</suggested_actions>"
+        )
+        events = _feed_all(parser, [raw])
+        blocks = [e for e in events if e["type"] == "block"]
+        assert len(blocks) == 1
+        assert blocks[0]["tag"] == "suggested_actions"
+        assert "Go left." in blocks[0]["content"]
+        assert "Go right." in blocks[0]["content"]
+
+
+class TestStateChangesBlock:
+    def test_state_changes_block(self):
+        parser = StreamParser()
+        raw = '<state_changes>{"hp_changes":[{"character_id":"x","delta":-8}]}</state_changes>'
+        events = _feed_all(parser, [raw])
+        blocks = [e for e in events if e["type"] == "block"]
+        assert len(blocks) == 1
+        assert blocks[0]["tag"] == "state_changes"
+        assert "hp_changes" in blocks[0]["content"]
+
+
+class TestUnknownTagsPassThrough:
+    def test_unknown_tags_are_treated_as_text(self):
+        """A tag name not in KNOWN_TAGS should stay as narrative text."""
+        parser = StreamParser()
+        raw = "Hello <p>World</p>"
+        events = _feed_all(parser, [raw])
+        blocks = [e for e in events if e["type"] == "block"]
+        chunks = "".join(e["text"] for e in events if e["type"] == "chunk")
+        assert blocks == []
+        assert "<p>World</p>" in chunks
+
+
+class TestLookahead:
+    def test_plain_text_held_back_for_lookahead(self):
+        """A partial '<' at the tail of a chunk must be held back."""
+        parser = StreamParser()
+        parser.feed("The world churns. <")
+        events_2 = parser.feed("dice_rolls>[]</dice_rolls> Continue.")
+        events_3 = parser.flush()
+        all_events = events_2 + events_3
+
+        blocks = [e for e in all_events if e["type"] == "block"]
+        assert len(blocks) == 1
+        assert blocks[0]["tag"] == "dice_rolls"
+        assert blocks[0]["content"] == "[]"
+
+    def test_long_text_emits_progressively(self):
+        """A long no-tag chunk should emit everything except the lookahead."""
+        parser = StreamParser()
+        big = "A" * 300
+        events = parser.feed(big)
+        emitted = "".join(e["text"] for e in events if e["type"] == "chunk")
+        assert len(emitted) >= 300 - 60
+
+
+class TestFlushBehavior:
+    def test_flush_drops_incomplete_tag(self):
+        parser = StreamParser()
+        parser.feed('<dice_rolls>[{"die":"d20"')
+        events = parser.flush()
+        assert all(e["type"] != "block" for e in events)
+        for e in events:
+            if e["type"] == "chunk":
+                assert "<dice_rolls>" not in e["text"]
+
+    def test_flush_emits_trailing_plain_text(self):
+        parser = StreamParser()
+        parser.feed("Small tail.")
+        events = parser.flush()
+        assert events == [{"type": "chunk", "text": "Small tail."}]
+
+
+class TestKnownTags:
+    def test_known_tags_set(self):
+        assert KNOWN_TAGS == {
+            "event",
+            "suggested_actions",
+            "state_changes",
+            "dice_rolls",
+        }

--- a/frontend/e2e/streaming-dm.spec.ts
+++ b/frontend/e2e/streaming-dm.spec.ts
@@ -1,0 +1,363 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ─── DIN-66: Streaming DM responses via Redis pub/sub (two endpoints) ─────────
+//
+// Verifies the end-to-end streaming behavior:
+//  1. Empty streaming bubble (cursor) appears immediately after submit
+//  2. Text chunks from SSE render progressively in the streaming bubble
+//  3. dice_rolls blocks pop in as complete DiceRoller components, never as XML text
+//  4. event / state_changes tags are consumed silently (never appear in chat)
+//  5. Non-202 action response: bubble never opens, input re-enabled
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAME_ID = 'test-game-stream'
+const USER_ID = 'user-1'
+
+async function setupStreamMocks(page: Page) {
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+    })
+  )
+  await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'mock-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        user: { id: USER_ID, email: 'test@example.com' },
+      }),
+    })
+  )
+
+  await page.route('**.supabase.co/rest/v1/games**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: GAME_ID,
+            name: 'The Streaming Keep',
+            dm_persona: 'Grim Oracle',
+            status: 'active',
+            created_by: USER_ID,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+            suggested_actions: [],
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/players**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'player-1',
+            game_id: GAME_ID,
+            profile_id: USER_ID,
+            character_name: 'Mira',
+            character_class: 'Rogue',
+            race: 'Wood Elf',
+            level: 2,
+            hp_current: 18,
+            hp_max: 20,
+            stats: { str: 12, dex: 16, con: 12, int: 10, wis: 14, cha: 10 },
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    }
+  })
+
+  const initMsg = {
+    id: 'msg-stream-init',
+    game_id: GAME_ID,
+    profile_id: null,
+    role: 'dm',
+    content: 'The keep looms before you.',
+    dice_rolls: null,
+    created_at: '2026-01-01T00:00:01Z',
+  }
+
+  await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+    if (route.request().method() === 'GET') {
+      const url = route.request().url()
+      if (url.includes('select=role')) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            { id: initMsg.id, role: 'dm', created_at: initMsg.created_at },
+          ]),
+        })
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([initMsg]),
+        })
+      }
+    }
+  })
+}
+
+function buildSseBody(events: object[]): string {
+  return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join('')
+}
+
+/**
+ * Mock the two-endpoint streaming flow:
+ *   - POST /api/games/:id/actions → 202 JSON
+ *   - GET  /api/games/:id/events  → SSE body with the given events
+ * `eventsDelayMs` lets tests observe the empty cursor bubble before chunks arrive.
+ */
+async function mockStreamingFlow(
+  page: Page,
+  sseEvents: object[],
+  options: { eventsDelayMs?: number } = {}
+) {
+  await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message_id: 'msg-1',
+          game_id: GAME_ID,
+          status: 'queued',
+        }),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+    if (options.eventsDelayMs) {
+      await new Promise((r) => setTimeout(r, options.eventsDelayMs))
+    }
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      },
+      body: buildSseBody(sseEvents),
+    })
+  })
+}
+
+async function gotoGame(page: Page) {
+  await page.goto(`/games/${GAME_ID}`)
+  await expect(page.getByText('The Streaming Keep')).toBeVisible({ timeout: 5000 })
+}
+
+test.describe('DIN-66 — Streaming bubble appears immediately', () => {
+  test('streaming bubble with cursor appears before SSE chunks arrive', async ({ page }) => {
+    await setupStreamMocks(page)
+    await mockStreamingFlow(
+      page,
+      [
+        { type: 'chunk', text: 'The door creaks open.' },
+        { type: 'done' },
+      ],
+      { eventsDelayMs: 400 }
+    )
+
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill('I push the door open.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    await expect(page.getByTestId('streaming-dm-message')).toBeVisible({
+      timeout: 2000,
+    })
+    await expect(page.getByTestId('streaming-cursor')).toBeVisible()
+  })
+
+  test('input is disabled while streaming is active', async ({ page }) => {
+    await setupStreamMocks(page)
+    await mockStreamingFlow(
+      page,
+      [
+        { type: 'chunk', text: 'Shadows flicker.' },
+        { type: 'done' },
+      ],
+      { eventsDelayMs: 400 }
+    )
+
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill('I look around cautiously.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    await expect(textarea).toBeDisabled({ timeout: 1000 })
+  })
+})
+
+test.describe('DIN-66 — Chunk events render progressively', () => {
+  test('text chunks accumulate in the streaming bubble', async ({ page }) => {
+    await setupStreamMocks(page)
+    await mockStreamingFlow(page, [
+      { type: 'chunk', text: 'The goblin ' },
+      { type: 'chunk', text: 'lunges with a snarl.' },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I prepare to parry.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('The goblin lunges with a snarl.', {
+      timeout: 3000,
+    })
+  })
+})
+
+test.describe('DIN-66 — dice_rolls block renders as a complete component', () => {
+  test('dice_rolls block pops in as DiceRoller, never as raw XML text', async ({ page }) => {
+    await setupStreamMocks(page)
+    const diceContent = JSON.stringify([
+      {
+        type: 'dice_roll',
+        die: 'd20',
+        count: 1,
+        result: 15,
+        modifier: 2,
+        total: 17,
+        label: 'Stealth',
+      },
+    ])
+
+    await mockStreamingFlow(page, [
+      { type: 'chunk', text: 'Rolling... ' },
+      { type: 'block', tag: 'dice_rolls', attributes: {}, content: diceContent },
+      { type: 'chunk', text: ' You sneak past.' },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I sneak past.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toBeVisible({ timeout: 3000 })
+    await expect(bubble).not.toContainText('<dice_rolls>')
+    await expect(bubble).not.toContainText('</dice_rolls>')
+    await expect(page.getByTestId('streaming-dice')).toBeVisible()
+  })
+})
+
+test.describe('DIN-66 — event / state_changes tags consumed silently', () => {
+  test('event tag text does not leak into the chat', async ({ page }) => {
+    await setupStreamMocks(page)
+    await mockStreamingFlow(page, [
+      { type: 'chunk', text: 'Combat begins. ' },
+      {
+        type: 'block',
+        tag: 'event',
+        attributes: { type: 'combat' },
+        content: 'Goblin slain',
+      },
+      { type: 'chunk', text: 'The party rests.' },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I attack the goblin.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('Combat begins.', { timeout: 3000 })
+    await expect(bubble).toContainText('The party rests.')
+    await expect(bubble).not.toContainText('Goblin slain')
+    await expect(bubble).not.toContainText('<event')
+  })
+
+  test('state_changes tag does not leak into the chat', async ({ page }) => {
+    await setupStreamMocks(page)
+    await mockStreamingFlow(page, [
+      { type: 'chunk', text: 'The dragon bites. ' },
+      {
+        type: 'block',
+        tag: 'state_changes',
+        attributes: {},
+        content: '{"hp_changes":[{"character_id":"p","delta":-8}]}',
+      },
+      { type: 'chunk', text: 'You gasp.' },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I block.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('You gasp.', { timeout: 3000 })
+    await expect(bubble).not.toContainText('hp_changes')
+    await expect(bubble).not.toContainText('<state_changes>')
+  })
+})
+
+test.describe('DIN-66 — non-ok response clears streaming state', () => {
+  test('POST /actions failing keeps input enabled and no bubble opens', async ({
+    page,
+  }) => {
+    await setupStreamMocks(page)
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Backend error' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill('I do the thing.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Streaming bubble must not appear.
+    await expect(page.getByTestId('streaming-dm-message')).toHaveCount(0, {
+      timeout: 2000,
+    })
+    // Input re-enabled so the player can retry.
+    await expect(textarea).toBeEnabled()
+  })
+})

--- a/frontend/e2e/streaming-dm.spec.ts
+++ b/frontend/e2e/streaming-dm.spec.ts
@@ -361,3 +361,225 @@ test.describe('DIN-66 — non-ok response clears streaming state', () => {
     await expect(textarea).toBeEnabled()
   })
 })
+
+test.describe('DIN-66 — suggested_actions tag not visible in streaming bubble', () => {
+  test('suggested_actions block content never appears in the chat bubble', async ({ page }) => {
+    await setupStreamMocks(page)
+    const suggestionContent =
+      'Charge the goblin with your sword.\nShout for backup.\nSneak past and run.'
+
+    await mockStreamingFlow(page, [
+      { type: 'chunk', text: 'The goblin blocks the path. ' },
+      {
+        type: 'block',
+        tag: 'suggested_actions',
+        attributes: {},
+        content: suggestionContent,
+      },
+      { type: 'chunk', text: 'Decide quickly.' },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I face the goblin.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('The goblin blocks the path.', { timeout: 3000 })
+    await expect(bubble).toContainText('Decide quickly.')
+    await expect(bubble).not.toContainText('Charge the goblin')
+    await expect(bubble).not.toContainText('Shout for backup')
+    await expect(bubble).not.toContainText('<suggested_actions>')
+  })
+})
+
+test.describe('DIN-66 — suggested_actions block enables cycle UI after reconciliation', () => {
+  test('cycle button activates with new suggestions once Realtime DM INSERT fires', async ({
+    page,
+  }) => {
+    await setupStreamMocks(page)
+    const suggestions = [
+      'Draw your sword and charge.',
+      'Call out to the figure in the shadows.',
+      'Duck behind the crates for cover.',
+    ]
+
+    await mockStreamingFlow(page, [
+      { type: 'chunk', text: 'A cloaked figure emerges. ' },
+      {
+        type: 'block',
+        tag: 'suggested_actions',
+        attributes: {},
+        content: suggestions.join('\n'),
+      },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    // Starts disabled — game has no suggested_actions initially
+    await expect(cycleBtn).toBeDisabled()
+
+    await page.getByTestId('chat-textarea').fill('I peer into the shadows.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Still disabled while isWaitingForDm is true (streaming active)
+    await expect(cycleBtn).toBeDisabled({ timeout: 1000 })
+
+    // Simulate Realtime DM INSERT — triggers reconciliation
+    await page.evaluate(
+      ({ gameId }) => {
+        window.dispatchEvent(
+          new CustomEvent('dm-message', {
+            detail: {
+              id: 'msg-dm-suggest',
+              game_id: gameId,
+              profile_id: null,
+              role: 'dm',
+              content: 'A cloaked figure emerges.',
+              created_at: new Date().toISOString(),
+            },
+          })
+        )
+      },
+      { gameId: GAME_ID }
+    )
+
+    // After reconciliation isWaitingForDm=false → cycle button enabled with streamed suggestions
+    await expect(cycleBtn).toBeEnabled({ timeout: 3000 })
+
+    // Clicking populates the textarea with the first suggestion
+    await cycleBtn.click()
+    await expect(page.getByTestId('chat-textarea')).toHaveValue(suggestions[0])
+  })
+})
+
+test.describe('DIN-66 — Realtime reconciliation: no duplicate, no flash', () => {
+  test('confirmed DM INSERT clears streaming bubble and renders single message', async ({
+    page,
+  }) => {
+    await setupStreamMocks(page)
+    const streamedText = 'The orc raises his axe.'
+    const confirmedText = 'The orc raises his axe and bellows a war cry.'
+
+    await mockStreamingFlow(page, [
+      { type: 'chunk', text: streamedText },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I stand my ground.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Streaming bubble visible with the streamed text while waiting for Realtime
+    const streamBubble = page.getByTestId('streaming-dm-message')
+    await expect(streamBubble).toBeVisible({ timeout: 3000 })
+    await expect(streamBubble).toContainText(streamedText)
+
+    // Simulate Realtime DM INSERT — backend persisted the clean version
+    await page.evaluate(
+      ({ gameId, content }) => {
+        window.dispatchEvent(
+          new CustomEvent('dm-message', {
+            detail: {
+              id: 'msg-dm-confirmed',
+              game_id: gameId,
+              profile_id: null,
+              role: 'dm',
+              content,
+              created_at: new Date().toISOString(),
+            },
+          })
+        )
+      },
+      { gameId: GAME_ID, content: confirmedText }
+    )
+
+    // Streaming bubble disappears — swapped for confirmed DB message
+    await expect(streamBubble).toHaveCount(0, { timeout: 3000 })
+
+    // Confirmed message appears exactly once (no duplicate)
+    await expect(page.getByText(confirmedText)).toBeVisible({ timeout: 3000 })
+    await expect(page.getByText(confirmedText)).toHaveCount(1)
+
+    // Input re-enabled after reconciliation
+    await expect(page.getByTestId('chat-textarea')).toBeEnabled()
+  })
+})
+
+test.describe('DIN-66 — GET /events non-200 clears streaming state', () => {
+  test('events endpoint error clears bubble; system message re-enables input', async ({
+    page,
+  }) => {
+    await setupStreamMocks(page)
+
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'queued', message_id: 'msg-1' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Stream unavailable' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill('I cast fireball.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Bubble must clear after the events endpoint error
+    await expect(page.getByTestId('streaming-dm-message')).toHaveCount(0, {
+      timeout: 3000,
+    })
+
+    // isWaitingForDm stays true — input remains disabled until backend signal
+    await expect(textarea).toBeDisabled()
+
+    // Simulate backend inserting a system error message via Supabase Realtime
+    await page.evaluate(
+      ({ gameId }) => {
+        window.dispatchEvent(
+          new CustomEvent('system-message', {
+            detail: {
+              id: 'msg-system-err',
+              game_id: gameId,
+              profile_id: null,
+              role: 'system',
+              content:
+                'The Dungeon Master encountered an error. Please try your action again.',
+              created_at: new Date().toISOString(),
+            },
+          })
+        )
+      },
+      { gameId: GAME_ID }
+    )
+
+    // Error message visible in chat log
+    await expect(
+      page.getByText(/The Dungeon Master encountered an error/i)
+    ).toBeVisible({ timeout: 3000 })
+
+    // Input re-enabled after system message arrives
+    await expect(textarea).toBeEnabled({ timeout: 3000 })
+  })
+})

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,1 +1,19 @@
 import '@testing-library/jest-dom'
+
+// jsdom omits a few Web APIs we use in streaming tests (DIN-66).
+// Fall back to Node's built-in implementations so components exercising
+// TextEncoder/TextDecoder/ReadableStream work under the jsdom environment.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const nodeUtil = require('util')
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const nodeStreamWeb = require('stream/web')
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = nodeUtil.TextEncoder
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  globalThis.TextDecoder = nodeUtil.TextDecoder
+}
+if (typeof globalThis.ReadableStream === 'undefined') {
+  globalThis.ReadableStream = nodeStreamWeb.ReadableStream
+}

--- a/frontend/src/app/api/games/[gameId]/events/__tests__/route.test.ts
+++ b/frontend/src/app/api/games/[gameId]/events/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+/** @jest-environment node */
+
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+
+const mockGetSession = jest.fn()
+
+jest.mock('@supabase/ssr', () => ({
+  createServerClient: jest.fn(() => ({
+    auth: { getSession: mockGetSession },
+  })),
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest
+    .fn()
+    .mockResolvedValue({ getAll: () => [], set: jest.fn() }),
+}))
+
+function makeRequest() {
+  return new NextRequest(new URL('http://localhost/api/games/game-1/events'), {
+    method: 'GET',
+  })
+}
+
+function mockAuthed() {
+  mockGetSession.mockResolvedValueOnce({
+    data: { session: { access_token: 'tok', user: { id: 'u' } } },
+  })
+}
+
+/** Build a ReadableStream that emits the given SSE frames. */
+function streamBody(frames: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    start(controller) {
+      for (const frame of frames) {
+        controller.enqueue(encoder.encode(frame))
+      }
+      controller.close()
+    },
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://test.supabase.co'
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+  process.env.NEXT_PUBLIC_BACKEND_URL = 'http://backend.test'
+  global.fetch = jest.fn()
+})
+
+describe('GET /api/games/[gameId]/events', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { session: null } })
+
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ gameId: 'game-1' }),
+    })
+
+    expect(res.status).toBe(401)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('proxies the SSE stream through with event-stream headers', async () => {
+    mockAuthed()
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      body: streamBody([
+        'data: {"type":"chunk","text":"Hi"}\n\n',
+        'data: {"type":"done"}\n\n',
+      ]),
+    })
+
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ gameId: 'game-xyz' }),
+    })
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://backend.test/games/game-xyz/events',
+      { headers: { Authorization: 'Bearer tok' } }
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toMatch(/text\/event-stream/)
+    expect(res.headers.get('x-accel-buffering')).toBe('no')
+
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+    let all = ''
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      all += decoder.decode(value, { stream: true })
+    }
+    expect(all).toContain('{"type":"chunk","text":"Hi"}')
+    expect(all).toContain('{"type":"done"}')
+  })
+
+  it('forwards backend error status and detail', async () => {
+    mockAuthed()
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: 'Backend down' }),
+    })
+
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ gameId: 'game-1' }),
+    })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Backend down' })
+  })
+
+  it('returns 500 on an unexpected exception', async () => {
+    mockGetSession.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ gameId: 'game-1' }),
+    })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Internal server error' })
+  })
+})

--- a/frontend/src/app/api/games/[gameId]/events/route.ts
+++ b/frontend/src/app/api/games/[gameId]/events/route.ts
@@ -1,0 +1,95 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextRequest } from 'next/server'
+
+/**
+ * GET /api/games/[gameId]/events (DIN-66)
+ *
+ * SSE proxy: subscribes to the backend's Redis pub/sub channel for this game
+ * and streams events (chunk / block / done) to the browser. The acting player
+ * opens this after POST /actions returns 202; the backend streaming coroutine
+ * publishes Claude's tokens to `stream:{gameId}` as they arrive.
+ *
+ * In DIN-67 (multiplayer streaming), every connected player opens this route
+ * on mount — Redis pub/sub fans out natively, no backend changes needed.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ gameId: string }> }
+): Promise<Response> {
+  try {
+    const cookieStore = await cookies()
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll()
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options)
+            })
+          },
+        },
+      }
+    )
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+
+    if (!session) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const { gameId } = await params
+    const backendUrl =
+      process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'
+
+    const backendResponse = await fetch(`${backendUrl}/games/${gameId}/events`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    })
+
+    if (!backendResponse.ok) {
+      // Errors from the backend are JSON, not streamed — forward status + detail.
+      let detail = 'Backend error'
+      try {
+        const errorData = await backendResponse.json()
+        detail = errorData.detail || detail
+      } catch {
+        // fall through
+      }
+      return new Response(JSON.stringify({ error: detail }), {
+        status: backendResponse.status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    if (!backendResponse.body) {
+      return new Response(JSON.stringify({ error: 'Backend returned no body' }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    return new Response(backendResponse.body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    })
+  } catch {
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/frontend/src/components/games/ChatLog.tsx
+++ b/frontend/src/components/games/ChatLog.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { GameMessage } from '@/lib/types/message'
+import type { StreamSegment } from '@/lib/types/streaming'
 import { ChatMessage } from './ChatMessage'
+import { StreamingDmMessage } from './StreamingDmMessage'
 
 interface ChatLogProps {
   messages: GameMessage[]
@@ -16,6 +18,13 @@ interface ChatLogProps {
   isWaitingForDm?: boolean
   onDeleteMessage?: (messageId: string) => void
   onEditMessage?: (messageId: string, content: string) => void
+  /**
+   * When non-null, a live DM bubble is rendered at the bottom of the chat
+   * mapping each segment to streaming text (with blinking cursor on the
+   * last text segment) or a complete dice_rolls display. Cleared to null
+   * once the real Realtime DM INSERT reconciles (DIN-66).
+   */
+  streamingSegments?: StreamSegment[] | null
 }
 
 export function ChatLog({
@@ -30,6 +39,7 @@ export function ChatLog({
   isWaitingForDm,
   onDeleteMessage,
   onEditMessage,
+  streamingSegments,
 }: ChatLogProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const topSentinelRef = useRef<HTMLDivElement>(null)
@@ -89,7 +99,7 @@ export function ChatLog({
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setHasNewMessages(true)
     }
-  }, [messages])
+  }, [messages, streamingSegments])
 
   // Handle scroll to detect if at bottom
   const handleScroll = () => {
@@ -245,6 +255,10 @@ export function ChatLog({
             />
           ))
         })()}
+
+        {streamingSegments !== null && streamingSegments !== undefined && (
+          <StreamingDmMessage segments={streamingSegments} />
+        )}
       </div>
 
       <div ref={bottomSentinelRef} />

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -3,6 +3,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { GameMessage } from '@/lib/types/message'
+import {
+  type StreamSegment,
+  type SseEvent,
+  appendTextChunk,
+} from '@/lib/types/streaming'
 import { Game } from '@/lib/supabase/games'
 import { GameHeader } from './GameHeader'
 import { ChatLog } from './ChatLog'
@@ -49,6 +54,10 @@ export function GameSessionView({
   const [levelUpPayload, setLevelUpPayload] = useState<LevelUpPayload | null>(null)
   const [showLevelUpModal, setShowLevelUpModal] = useState(false)
   const [currentPlayerRow, setCurrentPlayerRow] = useState<PlayerRow | null>(null)
+  // DIN-66 live DM bubble. null = no active stream; non-null = bubble rendered
+  // below the chat list until Realtime DM INSERT reconciles (clears to null).
+  const [streamingSegments, setStreamingSegments] =
+    useState<StreamSegment[] | null>(null)
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const isHost = game.created_by === userId
@@ -167,6 +176,9 @@ export function GameSessionView({
             // If DM or system (error) responded, we're no longer waiting
             if (newMsg.role === 'dm' || newMsg.role === 'system') {
               setIsWaitingForDm(false)
+              // DIN-66: reconcile — swap the live streaming bubble for the
+              // persisted DM message in a single render (no flash).
+              setStreamingSegments(null)
             }
           }
         }
@@ -301,6 +313,7 @@ export function GameSessionView({
         setMessages((prev) => [...prev, msg])
         if (msg.role === 'dm' || msg.role === 'system') {
           setIsWaitingForDm(false)
+          setStreamingSegments(null)
         }
       }
     }
@@ -360,7 +373,7 @@ export function GameSessionView({
   const handleSubmit = async (actionText: string) => {
     setShowRetryTimeout(false)
 
-    // Push optimistic message immediately so the player sees their action right away
+    // 1. Optimistic player message (DIN-64) — unchanged.
     const optimisticMsg: GameMessage = {
       id: `optimistic-${crypto.randomUUID()}`,
       game_id: gameId,
@@ -372,25 +385,104 @@ export function GameSessionView({
     setMessages((prev) => [...prev, optimisticMsg])
     setIsWaitingForDm(true)
 
+    // 2. Submit action — backend returns 202 quickly and spawns the
+    //    background streaming coroutine that publishes to Redis pub/sub.
+    let actionResponse: Response
     try {
-      const response = await fetch(`/api/games/${gameId}/actions`, {
+      actionResponse = await fetch(`/api/games/${gameId}/actions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action_text: actionText }),
       })
-
-      if (!response.ok) {
-        const errorData = await response.json()
-        // On error, remove the optimistic message and re-enable input
-        setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id))
-        setIsWaitingForDm(false)
-        console.error('Action failed:', errorData.error)
-      }
-      // On success, the real player message will arrive via Realtime and reconcile
-      // the optimistic message. DM response will also arrive via Realtime.
     } catch {
       setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id))
       setIsWaitingForDm(false)
+      return
+    }
+
+    if (!actionResponse.ok) {
+      let errorDetail: string | undefined
+      try {
+        errorDetail = (await actionResponse.json()).error
+      } catch {
+        // fall through
+      }
+      setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id))
+      setIsWaitingForDm(false)
+      if (errorDetail) console.error('Action failed:', errorDetail)
+      return
+    }
+
+    // 3. Open SSE stream — bubble appears; tokens will stream in.
+    setStreamingSegments([])
+
+    let eventsResponse: Response
+    try {
+      eventsResponse = await fetch(`/api/games/${gameId}/events`)
+    } catch {
+      setStreamingSegments(null)
+      return
+    }
+
+    if (!eventsResponse.ok || !eventsResponse.body) {
+      setStreamingSegments(null)
+      return
+    }
+
+    const reader = eventsResponse.body.getReader()
+    const decoder = new TextDecoder()
+    let sseBuffer = ''
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        sseBuffer += decoder.decode(value, { stream: true })
+
+        // SSE events are delimited by \n\n. Buffer partial frames across reads.
+        let sepIdx: number
+        while ((sepIdx = sseBuffer.indexOf('\n\n')) !== -1) {
+          const frame = sseBuffer.slice(0, sepIdx)
+          sseBuffer = sseBuffer.slice(sepIdx + 2)
+
+          for (const line of frame.split('\n')) {
+            if (!line.startsWith('data: ')) continue
+            let event: SseEvent
+            try {
+              event = JSON.parse(line.slice(6)) as SseEvent
+            } catch {
+              continue
+            }
+
+            if (event.type === 'chunk') {
+              setStreamingSegments((prev) =>
+                appendTextChunk(prev ?? [], event.text)
+              )
+            } else if (event.type === 'block') {
+              if (event.tag === 'dice_rolls') {
+                setStreamingSegments((prev) => [
+                  ...(prev ?? []),
+                  { kind: 'dice_rolls', content: event.content },
+                ])
+              } else if (event.tag === 'suggested_actions') {
+                const lines = event.content
+                  .trim()
+                  .split('\n')
+                  .map((line) => line.trim())
+                  .filter(Boolean)
+                setSuggestedActions(lines)
+              }
+              // 'event' and 'state_changes' consumed silently.
+            }
+            // 'done': keep streamingSegments until Realtime INSERT reconciles.
+          }
+        }
+      }
+    } catch {
+      // Network hiccup mid-stream: clear the bubble. The Realtime system
+      // message inserted by the backend (on stream failure) surfaces retry.
+      setStreamingSegments(null)
     }
   }
 
@@ -516,8 +608,11 @@ export function GameSessionView({
             isWaitingForDm={isWaitingForDm}
             onDeleteMessage={handleDeleteMessage}
             onEditMessage={handleEditMessage}
+            streamingSegments={streamingSegments}
           />
-          {isWaitingForDm && gameStatus === 'active' && <TypingIndicator />}
+          {isWaitingForDm &&
+            gameStatus === 'active' &&
+            streamingSegments === null && <TypingIndicator />}
           {showRetryTimeout && isWaitingForDm && gameStatus === 'active' && (
             <div style={{ flexShrink: 0, borderTop: '1px solid var(--dnd-brown)', background: 'var(--dnd-charcoal)', padding: '8px 24px' }}>
               <div style={{ maxWidth: '48rem', margin: '0 auto', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', borderRadius: '6px', border: '1px solid rgba(192,57,43,0.3)', background: 'rgba(139,34,50,0.12)', padding: '8px 14px' }}>

--- a/frontend/src/components/games/StreamingDmMessage.tsx
+++ b/frontend/src/components/games/StreamingDmMessage.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import type { StreamSegment } from '@/lib/types/streaming'
+import type { DiceRollEvent } from '@/lib/types/message'
+import { DiceRoller } from '@/components/dice/DiceRoller'
+
+interface StreamingDmMessageProps {
+  segments: StreamSegment[]
+}
+
+/** Parse the JSON content of a dice_rolls block. [] on any failure. */
+function parseDiceRolls(content: string): DiceRollEvent[] {
+  try {
+    const parsed = JSON.parse(content.trim())
+    if (Array.isArray(parsed)) return parsed as DiceRollEvent[]
+  } catch {
+    // Non-fatal — malformed content just renders as no dice.
+  }
+  return []
+}
+
+/**
+ * Live DM response bubble rendered while a stream is in flight (DIN-66).
+ *
+ * Interleaves plain text with complete dice_rolls blocks. The last text
+ * segment gets a blinking cursor. Unmounts as soon as the real Realtime
+ * DM INSERT arrives and the parent clears `streamingSegments` to null.
+ */
+export function StreamingDmMessage({ segments }: StreamingDmMessageProps) {
+  // Find the last text segment so the cursor anchors to it.
+  let lastTextIdx = -1
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (segments[i].kind === 'text') {
+      lastTextIdx = i
+      break
+    }
+  }
+
+  const showEmptyCursor = segments.length === 0
+
+  return (
+    <div className="mb-4 flex justify-start" data-testid="streaming-dm-message">
+      <div
+        className="max-w-2xl rounded-lg border px-5 py-4"
+        style={{
+          background: 'rgba(45, 106, 79, 0.12)',
+          borderColor: 'rgba(45, 106, 79, 0.25)',
+        }}
+      >
+        <div
+          className="mb-2 text-xs font-semibold uppercase tracking-widest"
+          style={{ color: '#6fcf97' }}
+        >
+          Dungeon Master
+        </div>
+
+        {segments.map((segment, idx) => {
+          if (segment.kind === 'dice_rolls') {
+            const rolls = parseDiceRolls(segment.content)
+            return (
+              <div
+                key={`dice-${idx}`}
+                data-testid="streaming-dice"
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: '8px',
+                  marginBottom: '12px',
+                }}
+              >
+                {rolls.map((roll, ri) => (
+                  <DiceRoller
+                    key={ri}
+                    dieType={roll.die}
+                    result={roll.result}
+                    modifier={roll.modifier}
+                    label={roll.label}
+                    instant
+                    onAnimationComplete={() => {}}
+                  />
+                ))}
+              </div>
+            )
+          }
+
+          const isLastText = idx === lastTextIdx
+          return (
+            <p
+              key={`text-${idx}`}
+              className="font-serif italic"
+              style={{ color: 'var(--dnd-parchment)', whiteSpace: 'pre-wrap' }}
+            >
+              {segment.content}
+              {isLastText && (
+                <span
+                  aria-hidden="true"
+                  data-testid="streaming-cursor"
+                  className="streaming-cursor"
+                >
+                  |
+                </span>
+              )}
+            </p>
+          )
+        })}
+
+        {showEmptyCursor && (
+          <p
+            className="font-serif italic"
+            style={{ color: 'var(--dnd-parchment)' }}
+          >
+            <span
+              aria-hidden="true"
+              data-testid="streaming-cursor"
+              className="streaming-cursor"
+            >
+              |
+            </span>
+          </p>
+        )}
+      </div>
+
+      <style jsx>{`
+        :global(.streaming-cursor) {
+          display: inline-block;
+          margin-left: 1px;
+          animation: dnd-stream-cursor 0.7s ease-in-out infinite;
+        }
+        @keyframes dnd-stream-cursor {
+          0%,
+          100% {
+            opacity: 1;
+          }
+          50% {
+            opacity: 0;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/frontend/src/components/games/__tests__/GameSessionView.test.tsx
+++ b/frontend/src/components/games/__tests__/GameSessionView.test.tsx
@@ -14,13 +14,28 @@ jest.mock('../GameHeader', () => ({
 }))
 
 jest.mock('../ChatLog', () => ({
-  ChatLog: ({ onLoadMore, hasMoreMessages, isLoadingMore, messages, userId, onDeleteMessage, onEditMessage }: any) => (
+  ChatLog: ({ onLoadMore, hasMoreMessages, isLoadingMore, messages, userId, onDeleteMessage, onEditMessage, streamingSegments }: any) => (
     <div data-testid="chat-log">
       <button data-testid="load-more" onClick={onLoadMore}>Load more</button>
       <div data-testid="has-more">{hasMoreMessages ? 'true' : 'false'}</div>
       <div data-testid="is-loading-more">{isLoadingMore ? 'true' : 'false'}</div>
       <div data-testid="messages-count">{messages ? messages.length : 0}</div>
       <div data-testid="chat-log-user-id">{userId || ''}</div>
+      <div data-testid="streaming-active">{streamingSegments === null || streamingSegments === undefined ? 'false' : 'true'}</div>
+      <div data-testid="streaming-segments-count">{streamingSegments ? streamingSegments.length : 0}</div>
+      <div data-testid="streaming-text">
+        {streamingSegments
+          ? streamingSegments
+              .filter((s: any) => s.kind === 'text')
+              .map((s: any) => s.content)
+              .join('')
+          : ''}
+      </div>
+      <div data-testid="streaming-dice-count">
+        {streamingSegments
+          ? streamingSegments.filter((s: any) => s.kind === 'dice_rolls').length
+          : 0}
+      </div>
       <button data-testid="trigger-delete" onClick={() => onDeleteMessage?.('msg-1')}>Delete</button>
       <button data-testid="trigger-edit" onClick={() => onEditMessage?.('msg-1', 'new content')}>Edit</button>
     </div>
@@ -626,6 +641,291 @@ describe('GameSessionView', () => {
         expect(screen.getByTestId('messages-count')).toHaveTextContent('0')
         expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
       })
+    })
+  })
+
+  describe('DIN-66: streaming DM responses', () => {
+    /** Build a fetch mock that returns a ReadableStream of SSE frames. */
+    function buildStreamResponse(frames: string[]) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { TextEncoder: NodeTextEncoder } = require('util')
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { ReadableStream: NodeReadableStream } = require('stream/web')
+      const encoder = new NodeTextEncoder()
+      const stream = new NodeReadableStream({
+        start(controller: ReadableStreamDefaultController<Uint8Array>) {
+          for (const frame of frames) {
+            controller.enqueue(encoder.encode(frame))
+          }
+          controller.close()
+        },
+      })
+      return { ok: true, status: 200, body: stream }
+    }
+
+    /** Queue action POST (202 JSON) + events GET (SSE stream) fetch responses. */
+    function mockTwoFetches(frames: string[]) {
+      ;(global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 202,
+          json: async () => ({ message_id: 'msg-1', status: 'queued' }),
+        })
+        .mockResolvedValueOnce(buildStreamResponse(frames))
+    }
+
+    it('opens an empty streaming bubble after the 202 response', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      // POST /actions resolves; GET /events never resolves so we can observe
+      // the empty bubble before any chunks arrive.
+      ;(global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 202,
+          json: async () => ({ message_id: 'msg-1', status: 'queued' }),
+        })
+        .mockReturnValueOnce(new Promise(() => {}))
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      })
+      expect(screen.getByTestId('streaming-segments-count')).toHaveTextContent(
+        '0'
+      )
+    })
+
+    it('appends chunk events to the streaming bubble text', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      mockTwoFetches([
+        'data: {"type":"chunk","text":"The goblin "}\n\n',
+        'data: {"type":"chunk","text":"lunges."}\n\n',
+      ])
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+          'The goblin lunges.'
+        )
+      })
+    })
+
+    it('dice_rolls block produces a dice segment', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      const diceContent = JSON.stringify([
+        {
+          type: 'dice_roll',
+          die: 'd20',
+          count: 1,
+          result: 15,
+          modifier: 2,
+          total: 17,
+          label: 'Stealth',
+        },
+      ])
+
+      mockTwoFetches([
+        'data: {"type":"chunk","text":"Rolling... "}\n\n',
+        `data: ${JSON.stringify({ type: 'block', tag: 'dice_rolls', attributes: {}, content: diceContent })}\n\n`,
+        'data: {"type":"chunk","text":" You sneak."}\n\n',
+        'data: {"type":"done"}\n\n',
+      ])
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-dice-count')).toHaveTextContent('1')
+      })
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+          /Rolling\.\.\.\s*You sneak\./
+        )
+      })
+    })
+
+    it('suggested_actions block mid-stream updates ChatInput suggestions', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      mockTwoFetches([
+        'data: {"type":"chunk","text":"You wake up."}\n\n',
+        `data: ${JSON.stringify({
+          type: 'block',
+          tag: 'suggested_actions',
+          attributes: {},
+          content: '\nLook around.\nStand up.\n',
+        })}\n\n`,
+        'data: {"type":"done"}\n\n',
+      ])
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('suggested-actions-count')).toHaveTextContent(
+          '2'
+        )
+      })
+    })
+
+    it('event and state_changes blocks are consumed silently', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      mockTwoFetches([
+        'data: {"type":"chunk","text":"Start. "}\n\n',
+        `data: ${JSON.stringify({
+          type: 'block',
+          tag: 'event',
+          attributes: { type: 'combat' },
+          content: 'Goblin slain',
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          type: 'block',
+          tag: 'state_changes',
+          attributes: {},
+          content: '{"hp_changes":[]}',
+        })}\n\n`,
+        'data: {"type":"chunk","text":"End."}\n\n',
+        'data: {"type":"done"}\n\n',
+      ])
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+          /Start\.\s*End\./
+        )
+      })
+      expect(screen.getByTestId('streaming-dice-count')).toHaveTextContent('0')
+      expect(screen.getByTestId('streaming-text').textContent).not.toContain(
+        'Goblin slain'
+      )
+    })
+
+    it('Realtime DM INSERT clears the streaming bubble (reconciliation)', async () => {
+      const realtimeCallbacks: Array<{ event: string; cb: (payload: any) => void }> = []
+      const channelObj: any = {
+        on: jest
+          .fn()
+          .mockImplementation((_event: any, filter: any, cb: any) => {
+            realtimeCallbacks.push({ event: filter?.event, cb })
+            return channelObj
+          }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+      }
+      mockSupabaseClient.channel.mockReturnValue(channelObj)
+
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      mockTwoFetches([
+        'data: {"type":"chunk","text":"Streaming text"}\n\n',
+        'data: {"type":"done"}\n\n',
+      ])
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      })
+
+      const insertCb = realtimeCallbacks.find((c) => c.event === 'INSERT')?.cb
+      expect(insertCb).toBeDefined()
+      act(() => {
+        insertCb?.({
+          new: {
+            id: 'dm-msg-1',
+            game_id: 'game-1',
+            role: 'dm',
+            profile_id: null,
+            content: 'Streaming text',
+            created_at: new Date().toISOString(),
+          },
+        })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent('false')
+      })
+      expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+    })
+
+    it('non-ok action response removes optimistic and does not open stream', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'boom' }),
+      })
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('messages-count')).toHaveTextContent('0')
+        expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent('false')
+      })
+      // Only the /actions POST was called — no /events fetch.
+      expect(global.fetch).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/frontend/src/components/games/__tests__/StreamingDmMessage.test.tsx
+++ b/frontend/src/components/games/__tests__/StreamingDmMessage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { StreamingDmMessage } from '../StreamingDmMessage'
+import type { StreamSegment } from '@/lib/types/streaming'
+
+jest.mock('@/components/dice/DiceRoller', () => ({
+  DiceRoller: ({ dieType, result, label }: { dieType: string; result?: number; label: string }) => (
+    <div data-testid={`dice-${dieType}`}>
+      {label}: {result ?? ''}
+    </div>
+  ),
+}))
+
+describe('StreamingDmMessage', () => {
+  it('renders a blinking cursor when the segment list is empty', () => {
+    render(<StreamingDmMessage segments={[]} />)
+    expect(screen.getByTestId('streaming-cursor')).toBeInTheDocument()
+    expect(screen.getByText('Dungeon Master')).toBeInTheDocument()
+  })
+
+  it('renders a text segment with a trailing cursor', () => {
+    const segments: StreamSegment[] = [
+      { kind: 'text', content: 'The goblin lunges.' },
+    ]
+    render(<StreamingDmMessage segments={segments} />)
+    expect(screen.getByText(/The goblin lunges\./)).toBeInTheDocument()
+    expect(screen.getByTestId('streaming-cursor')).toBeInTheDocument()
+  })
+
+  it('renders dice_rolls as complete DiceRoller components (never partial XML)', () => {
+    const diceContent = JSON.stringify([
+      {
+        type: 'dice_roll',
+        die: 'd20',
+        count: 1,
+        result: 15,
+        modifier: 2,
+        total: 17,
+        label: 'Stealth',
+      },
+    ])
+
+    const segments: StreamSegment[] = [
+      { kind: 'text', content: 'Rolling for stealth... ' },
+      { kind: 'dice_rolls', content: diceContent },
+      { kind: 'text', content: 'You sneak past.' },
+    ]
+    render(<StreamingDmMessage segments={segments} />)
+
+    expect(screen.getByTestId('streaming-dice')).toBeInTheDocument()
+    expect(screen.getByTestId('dice-d20')).toHaveTextContent(/Stealth/)
+    expect(screen.getByText(/Rolling for stealth/)).toBeInTheDocument()
+    expect(screen.getByText(/You sneak past\./)).toBeInTheDocument()
+  })
+
+  it('places cursor on the last text segment, not on dice segments', () => {
+    const segments: StreamSegment[] = [
+      { kind: 'text', content: 'First. ' },
+      {
+        kind: 'dice_rolls',
+        content:
+          '[{"type":"dice_roll","die":"d20","count":1,"result":10,"modifier":0,"total":10,"label":"Roll"}]',
+      },
+      { kind: 'text', content: 'Last.' },
+    ]
+    render(<StreamingDmMessage segments={segments} />)
+    const cursors = screen.getAllByTestId('streaming-cursor')
+    expect(cursors).toHaveLength(1)
+  })
+
+  it('gracefully handles malformed dice_rolls content', () => {
+    const segments: StreamSegment[] = [
+      { kind: 'dice_rolls', content: 'not-json' },
+    ]
+    render(<StreamingDmMessage segments={segments} />)
+    expect(screen.getByTestId('streaming-dice')).toBeInTheDocument()
+    expect(screen.queryByTestId('dice-d20')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/lib/types/__tests__/streaming.test.ts
+++ b/frontend/src/lib/types/__tests__/streaming.test.ts
@@ -1,0 +1,38 @@
+import { appendTextChunk, type StreamSegment } from '../streaming'
+
+describe('appendTextChunk', () => {
+  it('creates a new text segment from an empty list', () => {
+    expect(appendTextChunk([], 'Hello')).toEqual([
+      { kind: 'text', content: 'Hello' },
+    ])
+  })
+
+  it('appends to the existing trailing text segment', () => {
+    const segs: StreamSegment[] = [{ kind: 'text', content: 'Hello' }]
+    expect(appendTextChunk(segs, ' world')).toEqual([
+      { kind: 'text', content: 'Hello world' },
+    ])
+  })
+
+  it('starts a new text segment after a non-text segment', () => {
+    const segs: StreamSegment[] = [
+      { kind: 'text', content: 'Rolling... ' },
+      { kind: 'dice_rolls', content: '[]' },
+    ]
+    const result = appendTextChunk(segs, 'You pass.')
+    expect(result).toHaveLength(3)
+    expect(result[2]).toEqual({ kind: 'text', content: 'You pass.' })
+  })
+
+  it('is a no-op for empty text', () => {
+    const segs: StreamSegment[] = [{ kind: 'text', content: 'Hi' }]
+    expect(appendTextChunk(segs, '')).toBe(segs)
+  })
+
+  it('does not mutate the input array', () => {
+    const segs: StreamSegment[] = [{ kind: 'text', content: 'A' }]
+    const result = appendTextChunk(segs, 'B')
+    expect(segs).toEqual([{ kind: 'text', content: 'A' }])
+    expect(result).not.toBe(segs)
+  })
+})

--- a/frontend/src/lib/types/streaming.ts
+++ b/frontend/src/lib/types/streaming.ts
@@ -1,0 +1,44 @@
+// Streaming DM response types (DIN-66)
+//
+// The backend streams SSE events in three shapes:
+//   - chunk: narrative text fragment to append
+//   - block: complete structured XML tag (dice_rolls, event, suggested_actions,
+//            state_changes)
+//   - done:  terminal marker — subscribers close the stream
+//
+// The frontend builds a list of StreamSegments from chunk/block events so the
+// live DM bubble can interleave plain text with complete dice_rolls blocks.
+
+export type StreamSegment =
+  | { kind: 'text'; content: string }
+  | { kind: 'dice_rolls'; content: string }
+
+export type SseEvent =
+  | { type: 'chunk'; text: string }
+  | {
+      type: 'block'
+      tag: string
+      attributes: Record<string, string>
+      content: string
+    }
+  | { type: 'done' }
+
+/**
+ * Append a text chunk to a segment list. If the last segment is text,
+ * append to its content; otherwise start a new text segment. Pure function —
+ * never mutates the input array.
+ */
+export function appendTextChunk(
+  segments: StreamSegment[],
+  text: string
+): StreamSegment[] {
+  if (!text) return segments
+  const last = segments[segments.length - 1]
+  if (last && last.kind === 'text') {
+    return [
+      ...segments.slice(0, -1),
+      { kind: 'text', content: last.content + text },
+    ]
+  }
+  return [...segments, { kind: 'text', content: text }]
+}


### PR DESCRIPTION
## Summary

Stream the DM response token-by-token as Server-Sent Events using a
**two-endpoint architecture over Redis pub/sub**. `POST /actions` fires-and-forgets (returns 202 JSON), a background async task calls Claude and publishes each SSE event to a Redis channel. `GET /events` subscribes to that channel and streams to the browser. This design is ready for DIN-67 multiplayer fan-out with zero backend changes — Redis pub/sub handles N subscribers natively.

Rebased onto latest `develop` (conflicts resolved).

## Architecture

```
Player submits action
  → Next.js proxy → POST /games/{id}/actions (backend)
    - validate + insert player message + embed + RAG + build prompt
    - spawn asyncio.create_task(_stream_to_redis(...))
    - return 202 JSON immediately
  → browser opens GET /games/{id}/events (backend)
    - subscribe to Redis channel `stream:{id}`
    - forward SSE events to the browser until `done`
  → background coroutine:
    - call Claude with stream=True via AsyncAnthropic
    - publish chunk / block events to `stream:{id}`
    - on completion: insert DM message (fires Realtime),
      enqueue `dm_bookkeeping_task`, publish `done`
```

## Backend

- **`config.py`**: add `anthropic_async_client` (AsyncAnthropic) and `redis_async_client` (`redis.asyncio`). Sync clients preserved unchanged for Dramatiq tasks.
- **`services/stream_parser.py`** (new): stateful XML-tag parser with 60-char lookahead; emits `chunk` / `block` events; drops incomplete tags on flush.
- **`services/dm_service.py`**: extract `build_dm_system_prompt` shared by the streaming route and `dm_response_task` (unchanged behavior).
- **`api/routes/actions.py`**: rewrite to fire-and-forget 202 + `_stream_to_redis` coroutine. Strips all known tags from the persisted DM message.
- **`api/routes/events.py`** (new): SSE subscriber endpoint forwarding pub/sub messages until `done`.
- **`tasks/dm_tasks.py`**: add `dm_bookkeeping_task` (embed events, update `suggested_actions`, bump `updated_at`). `dm_response_task` preserved for opening/resume/pause/end narration paths.
- **`main.py`**: register events router.

## Frontend

- **`lib/types/streaming.ts`** (new): `StreamSegment` / `SseEvent` types + `appendTextChunk` helper.
- **`app/api/games/[gameId]/events/route.ts`** (new): Next.js SSE proxy with Supabase auth.
- **`components/games/GameSessionView.tsx`**: handleSubmit now does two fetches — POST `/actions` (202), then GET `/events` (SSE). Reads the stream, maps chunk/block events to StreamSegments. Realtime DM INSERT clears `streamingSegments` for flash-free reconciliation.
- **`components/games/StreamingDmMessage.tsx`** (new): live DM bubble with blinking cursor on the last text segment and complete DiceRoller components for `dice_rolls` blocks.
- **`components/games/ChatLog.tsx`**: new optional `streamingSegments` prop.

## SSE event protocol

```json
{"type": "chunk", "text": "The goblin lunges..."}
{"type": "block", "tag": "dice_rolls",        "attributes": {},                 "content": "..."}
{"type": "block", "tag": "event",             "attributes": {"type": "combat"}, "content": "..."}
{"type": "block", "tag": "state_changes",     "attributes": {},                 "content": "..."}
{"type": "block", "tag": "suggested_actions", "attributes": {},                 "content": "..."}
{"type": "done"}
```

Frontend per tag: `dice_rolls` → rendered as `DiceRoller`; `suggested_actions` → updates suggestion UI; `event` / `state_changes` → consumed silently.

## Tests

- Backend: 241 pass (new: `test_stream_parser.py`, `test_events_route.py`, `TestDmBookkeepingTask`; updated `test_actions_route.py` asserts 202 JSON + `asyncio.create_task` spawn, `dm_response_task` NOT enqueued).
- Frontend: 548 pass (new: streaming types tests, events proxy tests, `StreamingDmMessage` tests, GameSessionView streaming scenarios).
- E2E: new `streaming-dm.spec.ts` covering cursor bubble, chunk progression, dice block, silent `event`/`state_changes` tags, error path. Uses the two-endpoint mock pattern.
- `tsc --noEmit` clean; no new lint warnings.

## Out of Scope

- Multiplayer simultaneous streaming — the Redis pub/sub channel supports it natively; DIN-67 will wire all players to `/events` on mount.
- Streaming for opening/resume/pause/end narrations.
- `state_changes` rendering in chat (Epic-7 concern — consumed silently).

## Test plan

- [x] 241 backend pytest + 548 frontend jest green locally
- [x] TypeScript typecheck clean
- [x] Lint clean (no new warnings)
- [ ] Playwright e2e `streaming-dm.spec.ts` passes in CI
- [ ] CI green on develop-base rebase

https://claude.ai/code/session_01GCA8RLYW4pUCiMtHhCckEo