### PR TITLE
DIN-66: Fix SSE/Realtime race conditions in streaming reconciliation

### DIFF
--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -59,12 +59,6 @@ export function GameSessionView({
   const [streamingSegments, setStreamingSegments] =
     useState<StreamSegment[] | null>(null)
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // DIN-66 fallback: if Supabase Realtime INSERT is delayed after stream
-  // completion, force-clear streaming state after 3s to unblock the input.
-  const realtimeFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Tracks whether the Realtime DM INSERT already arrived for the current action.
-  // Prevents the fallback timer from firing when Realtime arrives before `done`.
-  const realtimeReceivedRef = useRef(false)
 
   const isHost = game.created_by === userId
 
@@ -191,13 +185,6 @@ export function GameSessionView({
               // DIN-66: reconcile — swap the live streaming bubble for the
               // persisted DM message in a single render (no flash).
               setStreamingSegments(null)
-              // Mark Realtime as received — prevents the fallback timer from
-              // firing if `done` arrives after this (the common case).
-              realtimeReceivedRef.current = true
-              if (realtimeFallbackRef.current) {
-                clearTimeout(realtimeFallbackRef.current)
-                realtimeFallbackRef.current = null
-              }
             }
           }
         }
@@ -265,7 +252,6 @@ export function GameSessionView({
       messagesSubscription?.unsubscribe()
       gamesSubscription?.unsubscribe()
       levelUpSubscription?.unsubscribe()
-      if (realtimeFallbackRef.current) clearTimeout(realtimeFallbackRef.current)
     }
   }, [gameId, userId])
 
@@ -392,8 +378,6 @@ export function GameSessionView({
 
   const handleSubmit = async (actionText: string) => {
     setShowRetryTimeout(false)
-    // Reset Realtime-received flag for this new action.
-    realtimeReceivedRef.current = false
 
     // 1. Optimistic player message (DIN-64) — unchanged.
     const optimisticMsg: GameMessage = {
@@ -497,13 +481,18 @@ export function GameSessionView({
               }
               // 'event' and 'state_changes' consumed silently.
             } else if (event.type === 'done') {
-              // `done` is the authoritative signal from the backend that streaming
-              // has completed (either successfully or via error — it's always
-              // published in the finally block). Clear the streaming bubble and
-              // re-enable the input immediately. The persisted DM (or system error)
-              // message arrives separately via Realtime and appears in the chat log
-              // a moment later — if it's already arrived, this is a harmless no-op.
-              setStreamingSegments(null)
+              // `done` means the backend has finished streaming (success or error —
+              // it is always published in the finally block). Re-enable the chat
+              // input, but INTENTIONALLY keep `streamingSegments` in place so the
+              // user retains the content they already saw stream in.
+              //
+              // Reconciliation path: when the Supabase Realtime INSERT for the
+              // persisted DM message arrives, its handler clears `streamingSegments`
+              // and the real message is rendered from the `messages` array — no
+              // duplicate appears. If Realtime never arrives (WebSocket drop, RLS,
+              // auth drift), the streamed text stays on screen as a best-effort
+              // rendering, and the next `handleSubmit` resets `streamingSegments`
+              // to [] before the next action starts.
               setIsWaitingForDm(false)
             }
           }

--- a/frontend/src/components/games/__tests__/GameSessionView.test.tsx
+++ b/frontend/src/components/games/__tests__/GameSessionView.test.tsx
@@ -36,6 +36,14 @@ jest.mock('../ChatLog', () => ({
           ? streamingSegments.filter((s: any) => s.kind === 'dice_rolls').length
           : 0}
       </div>
+      <div data-testid="last-dm-content">
+        {messages
+          ? [...messages]
+              .reverse()
+              .find((m: any) => m.role === 'dm' || m.role === 'system')
+              ?.content ?? ''
+          : ''}
+      </div>
       <button data-testid="trigger-delete" onClick={() => onDeleteMessage?.('msg-1')}>Delete</button>
       <button data-testid="trigger-edit" onClick={() => onEditMessage?.('msg-1', 'new content')}>Edit</button>
     </div>
@@ -926,6 +934,391 @@ describe('GameSessionView', () => {
       })
       // Only the /actions POST was called — no /events fetch.
       expect(global.fetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('DIN-66: SSE ↔ Realtime race conditions', () => {
+    /** Controllable SSE stream — lets the test enqueue frames across ticks. */
+    function buildControllableStream() {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { TextEncoder: NodeTextEncoder } = require('util')
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { ReadableStream: NodeReadableStream } = require('stream/web')
+      const encoder = new NodeTextEncoder()
+      let ctrl: ReadableStreamDefaultController<Uint8Array>
+      const stream = new NodeReadableStream({
+        start(c: ReadableStreamDefaultController<Uint8Array>) {
+          ctrl = c
+        },
+      })
+      return {
+        response: { ok: true, status: 200, body: stream },
+        enqueue: (frame: string) => ctrl.enqueue(encoder.encode(frame)),
+        close: () => ctrl.close(),
+      }
+    }
+
+    /** Capture Supabase Realtime subscription callbacks so tests can fire them. */
+    function captureChannelCallbacks() {
+      const cbs: Array<{ event: string; cb: (payload: any) => void }> = []
+      const channelObj: any = {
+        on: jest.fn((_evt: any, filter: any, cb: any) => {
+          cbs.push({ event: filter?.event, cb })
+          return channelObj
+        }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+      }
+      mockSupabaseClient.channel.mockReturnValue(channelObj)
+      return {
+        getInsertCb: () => cbs.find((c) => c.event === 'INSERT')?.cb,
+      }
+    }
+
+    /** Queue the POST /actions 202 and the GET /events stream response. */
+    function mockActionThenEvents(eventsResponse: any) {
+      ;(global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 202,
+          json: async () => ({ message_id: 'msg-1', status: 'queued' }),
+        })
+        .mockResolvedValueOnce(eventsResponse)
+    }
+
+    it('Realtime DM INSERT before SSE done: streaming clears on Realtime, done becomes a no-op', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      const { getInsertCb } = captureChannelCallbacks()
+      const stream = buildControllableStream()
+      mockActionThenEvents(stream.response)
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      stream.enqueue('data: {"type":"chunk","text":"Streaming text"}\n\n')
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+          'Streaming text'
+        )
+      })
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+
+      const insertCb = getInsertCb()
+      expect(insertCb).toBeDefined()
+      act(() => {
+        insertCb?.({
+          new: {
+            id: 'dm-1',
+            game_id: 'game-1',
+            role: 'dm',
+            profile_id: null,
+            content: 'Streaming text',
+            created_at: new Date().toISOString(),
+          },
+        })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent(
+          'false'
+        )
+      })
+      // Optimistic player (never reconciled — we did not fire the player echo)
+      // + the freshly inserted DM message.
+      expect(screen.getByTestId('messages-count')).toHaveTextContent('2')
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent(
+        'Streaming text'
+      )
+      expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+
+      // `done` arrives after Realtime — must be a no-op. Nothing changes.
+      stream.enqueue('data: {"type":"done"}\n\n')
+      stream.close()
+      await new Promise((r) => setTimeout(r, 20))
+
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('false')
+      expect(screen.getByTestId('messages-count')).toHaveTextContent('2')
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent(
+        'Streaming text'
+      )
+      expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+    })
+
+    it('SSE done before Realtime DM (consistent content): streaming persists, Realtime swaps to persisted message', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      const { getInsertCb } = captureChannelCallbacks()
+      const stream = buildControllableStream()
+      mockActionThenEvents(stream.response)
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      stream.enqueue('data: {"type":"chunk","text":"The goblin lunges."}\n\n')
+      stream.enqueue('data: {"type":"done"}\n\n')
+      stream.close()
+
+      // done processed — is-waiting false — streaming bubble persists with
+      // the streamed content (new post-persist-streamed-content behavior).
+      await waitFor(() => {
+        expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+      })
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+        'The goblin lunges.'
+      )
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent('')
+
+      // Realtime INSERT arrives with matching content — reconciliation
+      // swaps streaming bubble for persisted DM message.
+      act(() => {
+        getInsertCb()?.({
+          new: {
+            id: 'dm-1',
+            game_id: 'game-1',
+            role: 'dm',
+            profile_id: null,
+            content: 'The goblin lunges.',
+            created_at: new Date().toISOString(),
+          },
+        })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent(
+          'false'
+        )
+      })
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent(
+        'The goblin lunges.'
+      )
+      expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+    })
+
+    it('SSE done before Realtime DM (inconsistent content): persisted content overrides streamed content', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      const { getInsertCb } = captureChannelCallbacks()
+      const stream = buildControllableStream()
+      mockActionThenEvents(stream.response)
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      stream.enqueue('data: {"type":"chunk","text":"The goblin lunges."}\n\n')
+      stream.enqueue('data: {"type":"done"}\n\n')
+      stream.close()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+      })
+      // Pre-reconciliation: streamed text visible, no persisted DM yet.
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+        'The goblin lunges.'
+      )
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent('')
+
+      // Authoritative Realtime DM differs — must replace the streamed version.
+      act(() => {
+        getInsertCb()?.({
+          new: {
+            id: 'dm-1',
+            game_id: 'game-1',
+            role: 'dm',
+            profile_id: null,
+            content: 'The goblin lunges and misses.',
+            created_at: new Date().toISOString(),
+          },
+        })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent(
+          'false'
+        )
+      })
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent(
+        'The goblin lunges and misses.'
+      )
+    })
+
+    it('SSE done with no Realtime: streamed content stays on screen, chat input re-enabled', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      // Capture callbacks but never fire them.
+      captureChannelCallbacks()
+      const stream = buildControllableStream()
+      mockActionThenEvents(stream.response)
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      stream.enqueue('data: {"type":"chunk","text":"Streamed result."}\n\n')
+      stream.enqueue('data: {"type":"done"}\n\n')
+      stream.close()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+      })
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+        'Streamed result.'
+      )
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent('')
+
+      // Give any stray microtasks a chance to run — state must remain stable.
+      await new Promise((r) => setTimeout(r, 30))
+
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+        'Streamed result.'
+      )
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent('')
+      expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+    })
+
+    it('SSE done then late Realtime DM: streamed content shown until Realtime arrives, then reconciled', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      const { getInsertCb } = captureChannelCallbacks()
+      const stream = buildControllableStream()
+      mockActionThenEvents(stream.response)
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      stream.enqueue('data: {"type":"chunk","text":"Streamed result."}\n\n')
+      stream.enqueue('data: {"type":"done"}\n\n')
+      stream.close()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+      })
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+        'Streamed result.'
+      )
+
+      // Simulate Realtime arriving LATE (well after `done`).
+      await new Promise((r) => setTimeout(r, 75))
+      // Streamed content still on screen — no fallback timer clears it.
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+        'Streamed result.'
+      )
+
+      act(() => {
+        getInsertCb()?.({
+          new: {
+            id: 'dm-1',
+            game_id: 'game-1',
+            role: 'dm',
+            profile_id: null,
+            content: 'Streamed result.',
+            created_at: new Date().toISOString(),
+          },
+        })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent(
+          'false'
+        )
+      })
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent(
+        'Streamed result.'
+      )
+    })
+
+    it('Realtime DM without SSE done: streaming bubble clears, persisted DM renders', async () => {
+      testContext.playersData = [
+        { id: 'player-1', profile_id: 'user-1', character_name: 'Thorin' },
+      ]
+      const { getInsertCb } = captureChannelCallbacks()
+      const stream = buildControllableStream()
+      mockActionThenEvents(stream.response)
+
+      render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+      )
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('submit-action'))
+      })
+
+      // A chunk streams in, but the backend never emits `done` (worker crash,
+      // stream drop mid-flight). Realtime is the ONLY reconciliation signal.
+      stream.enqueue('data: {"type":"chunk","text":"Streaming text"}\n\n')
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-text')).toHaveTextContent(
+          'Streaming text'
+        )
+      })
+      expect(screen.getByTestId('streaming-active')).toHaveTextContent('true')
+      expect(screen.getByTestId('is-waiting')).toHaveTextContent('true')
+
+      act(() => {
+        getInsertCb()?.({
+          new: {
+            id: 'dm-1',
+            game_id: 'game-1',
+            role: 'dm',
+            profile_id: null,
+            content: 'Streaming text',
+            created_at: new Date().toISOString(),
+          },
+        })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-active')).toHaveTextContent(
+          'false'
+        )
+      })
+      expect(screen.getByTestId('last-dm-content')).toHaveTextContent(
+        'Streaming text'
+      )
+      expect(screen.getByTestId('is-waiting')).toHaveTextContent('false')
+
+      // Close the stream so the reader loop can terminate cleanly.
+      stream.close()
     })
   })
 


### PR DESCRIPTION
## Summary
Fixes race conditions between Server-Sent Events (SSE) streaming completion and Supabase Realtime message persistence in the game session view. The previous implementation used a fallback timer to clear streaming state, which could cause duplicate messages or lost content. This change implements a more robust reconciliation strategy that keeps streamed content visible until the authoritative persisted message arrives via Realtime.

## Key Changes

- **Removed fallback timer mechanism**: Eliminated `realtimeFallbackRef` and `realtimeReceivedRef` that attempted to force-clear streaming state after 3 seconds. This approach was fragile and could cause race conditions.

- **Changed `done` event handling**: Instead of immediately clearing `streamingSegments` when the SSE `done` event arrives, the streamed content now persists on screen. This allows the user to see the content they already watched stream in, while waiting for the authoritative persisted message.

- **Improved reconciliation logic**: When the Realtime INSERT callback fires for a DM message, it now clears `streamingSegments` in a single render, swapping the streaming bubble for the persisted message without flashing or duplicates.

- **Added fallback behavior**: If Realtime never arrives (WebSocket drop, RLS issues, auth drift), the streamed text remains visible as a best-effort rendering. The next action submission resets `streamingSegments` to `[]` before starting a new request.

- **Enhanced test coverage**: Added comprehensive test suite covering five race condition scenarios:
  - Realtime INSERT before SSE done
  - SSE done before Realtime (consistent content)
  - SSE done before Realtime (inconsistent content)
  - SSE done with no Realtime
  - Realtime DM without SSE done

## Implementation Details

- The mock chat component now includes a `last-dm-content` test element to verify the final persisted message content
- Tests use a controllable SSE stream builder and captured Realtime callbacks to simulate various timing scenarios
- The reconciliation now treats the Realtime INSERT as the authoritative signal, allowing it to override streamed content if the backend made corrections
- Streaming state cleanup is now driven by Realtime arrival rather than timers, making the behavior more predictable and testable

https://claude.ai/code/session_01FAzxQoWtvNgvSqBc373VXg