### PR TITLE
Add typewriter effect to streaming DM messages with paragraph support

### DIFF
--- a/frontend/src/components/games/ChatMessage.tsx
+++ b/frontend/src/components/games/ChatMessage.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useRef } from 'react'
 import type { DiceRollEvent } from '@/lib/types/message'
 import { DiceRoller } from '@/components/dice/DiceRoller'
+import { splitParagraphs } from '@/lib/utils/text'
 
 interface ChatMessageProps {
   role: 'player' | 'dm' | 'system'
@@ -261,15 +262,25 @@ export function ChatMessage({
             </div>
           )}
 
-          <p
-            className="font-serif italic"
+          <div
             style={{
-              color: 'var(--dnd-parchment)',
               visibility: narrationVisible ? 'visible' : 'hidden',
             }}
           >
-            {content}
-          </p>
+            {splitParagraphs(content).map((para, pIdx, arr) => (
+              <p
+                key={pIdx}
+                className="font-serif italic"
+                style={{
+                  color: 'var(--dnd-parchment)',
+                  margin: 0,
+                  marginBottom: pIdx < arr.length - 1 ? '0.4em' : 0,
+                }}
+              >
+                {para}
+              </p>
+            ))}
+          </div>
         </div>
       </div>
       <style jsx>{`
@@ -400,12 +411,21 @@ export function ChatMessage({
               </div>
             </div>
           ) : (
-            <p
-              className="font-serif"
-              style={{ color: 'var(--dnd-parchment)' }}
-            >
-              {content}
-            </p>
+            <div>
+              {splitParagraphs(content).map((para, pIdx, arr) => (
+                <p
+                  key={pIdx}
+                  className="font-serif"
+                  style={{
+                    color: 'var(--dnd-parchment)',
+                    margin: 0,
+                    marginBottom: pIdx < arr.length - 1 ? '0.4em' : 0,
+                  }}
+                >
+                  {para}
+                </p>
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/components/games/StreamingDmMessage.tsx
+++ b/frontend/src/components/games/StreamingDmMessage.tsx
@@ -4,10 +4,16 @@ import { Fragment, useRef, useState } from 'react'
 import type { StreamSegment } from '@/lib/types/streaming'
 import type { DiceRollEvent } from '@/lib/types/message'
 import { DiceRoller } from '@/components/dice/DiceRoller'
+import { useTypewriter } from '@/lib/hooks/useTypewriter'
+import { splitParagraphs } from '@/lib/utils/text'
 
 interface StreamingDmMessageProps {
   segments: StreamSegment[]
 }
+
+type PlanItem =
+  | { kind: 'text'; content: string; isCurrent: boolean }
+  | { kind: 'dice_rolls'; content: string }
 
 /** Parse the JSON content of a dice_rolls block. [] on any failure. */
 function parseDiceRolls(content: string): DiceRollEvent[] {
@@ -183,23 +189,65 @@ function StreamingDiceBlock({ rolls }: { rolls: DiceRollEvent[] }) {
 /**
  * Live DM response bubble rendered while a stream is in flight (DIN-66).
  *
- * Interleaves plain text with animated dice_rolls blocks. Dice animate
- * sequentially (same as ChatMessage) and the outcome badge appears once all
- * dice in a block settle. The last text segment gets a blinking cursor.
- * Unmounts as soon as the real Realtime DM INSERT arrives and the parent
- * clears `streamingSegments` to null.
+ * Interleaves plain text with animated dice_rolls blocks. A requestAnimationFrame-
+ * driven typewriter reveals text at ~100 cps (with a 1.5s catch-up clamp) so the
+ * reveal stays smooth even when the backend bursts large chunks. Dice blocks are
+ * gated behind any still-typing preceding text so they never animate ahead of
+ * their narration. The last rendered text segment gets a blinking cursor.
  */
 export function StreamingDmMessage({ segments }: StreamingDmMessageProps) {
-  // Find the last text segment so the cursor anchors to it.
-  let lastTextIdx = -1
-  for (let i = segments.length - 1; i >= 0; i--) {
-    if (segments[i].kind === 'text') {
-      lastTextIdx = i
-      break
+  const targetChars = segments.reduce(
+    (n, s) => n + (s.kind === 'text' ? s.content.length : 0),
+    0
+  )
+  const revealed = useTypewriter(targetChars, 100)
+
+  const plan: PlanItem[] = []
+  let budget = revealed
+  let halted = false
+  for (const seg of segments) {
+    if (halted) break
+    if (seg.kind === 'text') {
+      const take = Math.min(seg.content.length, Math.max(0, budget))
+      const isCurrent = take < seg.content.length
+      plan.push({
+        kind: 'text',
+        content: seg.content.slice(0, take),
+        isCurrent,
+      })
+      budget -= seg.content.length
+      if (isCurrent) halted = true
+    } else {
+      plan.push({ kind: 'dice_rolls', content: seg.content })
     }
   }
 
-  const showEmptyCursor = segments.length === 0
+  // Cursor anchors to the current (still-typing) text item if present,
+  // otherwise to the last rendered text item.
+  let cursorPlanIdx = -1
+  for (let i = plan.length - 1; i >= 0; i--) {
+    const item = plan[i]
+    if (item.kind === 'text' && item.isCurrent) {
+      cursorPlanIdx = i
+      break
+    }
+  }
+  if (cursorPlanIdx === -1) {
+    for (let i = plan.length - 1; i >= 0; i--) {
+      if (plan[i].kind === 'text') {
+        cursorPlanIdx = i
+        break
+      }
+    }
+  }
+
+  // Fall back to the empty-cursor paragraph when the plan has no renderable
+  // text yet (plan empty, dice-only, or the cursor host's slice is still empty).
+  const cursorHost = cursorPlanIdx >= 0 ? plan[cursorPlanIdx] : null
+  const showEmptyCursor =
+    !cursorHost ||
+    cursorHost.kind !== 'text' ||
+    cursorHost.content.length === 0
 
   return (
     <div className="mb-4 flex justify-start" data-testid="streaming-dm-message">
@@ -217,20 +265,19 @@ export function StreamingDmMessage({ segments }: StreamingDmMessageProps) {
           Dungeon Master
         </div>
 
-        {segments.map((segment, idx) => {
-          if (segment.kind === 'dice_rolls') {
-            const rolls = parseDiceRolls(segment.content)
+        {plan.map((item, idx) => {
+          if (item.kind === 'dice_rolls') {
+            const rolls = parseDiceRolls(item.content)
             return <StreamingDiceBlock key={`dice-${idx}`} rolls={rolls} />
           }
 
-          const isLastText = idx === lastTextIdx
-          // Split on double-newlines so paragraph breaks render as tight
-          // spacing (~0.4em) rather than a full blank line from pre-wrap.
-          const paragraphs = segment.content.split('\n\n').filter((p) => p.length > 0)
+          const isCursorHost = idx === cursorPlanIdx
+          const paragraphs = splitParagraphs(item.content)
           return (
             <Fragment key={`text-${idx}`}>
               {paragraphs.map((para, pIdx) => {
-                const isVeryLast = isLastText && pIdx === paragraphs.length - 1
+                const isLastPara = pIdx === paragraphs.length - 1
+                const isVeryLast = isCursorHost && isLastPara
                 return (
                   <p
                     key={`text-${idx}-p${pIdx}`}
@@ -238,7 +285,7 @@ export function StreamingDmMessage({ segments }: StreamingDmMessageProps) {
                     style={{
                       color: 'var(--dnd-parchment)',
                       margin: 0,
-                      marginBottom: pIdx < paragraphs.length - 1 ? '0.4em' : 0,
+                      marginBottom: isLastPara ? 0 : '0.4em',
                     }}
                   >
                     {para}

--- a/frontend/src/components/games/StreamingDmMessage.tsx
+++ b/frontend/src/components/games/StreamingDmMessage.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { Fragment, useRef, useState } from 'react'
+import { Fragment, useMemo, useRef, useState } from 'react'
 import type { StreamSegment } from '@/lib/types/streaming'
 import type { DiceRollEvent } from '@/lib/types/message'
 import { DiceRoller } from '@/components/dice/DiceRoller'
 import { useTypewriter } from '@/lib/hooks/useTypewriter'
-import { splitParagraphs } from '@/lib/utils/text'
+import { graphemesOf, splitParagraphs } from '@/lib/utils/text'
 
 interface StreamingDmMessageProps {
   segments: StreamSegment[]
@@ -13,6 +13,10 @@ interface StreamingDmMessageProps {
 
 type PlanItem =
   | { kind: 'text'; content: string; isCurrent: boolean }
+  | { kind: 'dice_rolls'; content: string }
+
+type SegmentedItem =
+  | { kind: 'text'; graphemes: string[] }
   | { kind: 'dice_rolls'; content: string }
 
 /** Parse the JSON content of a dice_rolls block. [] on any failure. */
@@ -196,8 +200,22 @@ function StreamingDiceBlock({ rolls }: { rolls: DiceRollEvent[] }) {
  * their narration. The last rendered text segment gets a blinking cursor.
  */
 export function StreamingDmMessage({ segments }: StreamingDmMessageProps) {
-  const targetChars = segments.reduce(
-    (n, s) => n + (s.kind === 'text' ? s.content.length : 0),
+  // Pre-segment text into grapheme clusters so the typewriter reveal never
+  // slices through an emoji / combining mark mid-character. Memoized on the
+  // segments array identity — the rAF loop re-renders on every frame, so
+  // re-segmenting each tick would be wasted work.
+  const segmented = useMemo<SegmentedItem[]>(
+    () =>
+      segments.map((seg) =>
+        seg.kind === 'text'
+          ? { kind: 'text', graphemes: graphemesOf(seg.content) }
+          : { kind: 'dice_rolls', content: seg.content }
+      ),
+    [segments]
+  )
+
+  const targetChars = segmented.reduce(
+    (n, s) => n + (s.kind === 'text' ? s.graphemes.length : 0),
     0
   )
   const revealed = useTypewriter(targetChars, 100)
@@ -205,17 +223,17 @@ export function StreamingDmMessage({ segments }: StreamingDmMessageProps) {
   const plan: PlanItem[] = []
   let budget = revealed
   let halted = false
-  for (const seg of segments) {
+  for (const seg of segmented) {
     if (halted) break
     if (seg.kind === 'text') {
-      const take = Math.min(seg.content.length, Math.max(0, budget))
-      const isCurrent = take < seg.content.length
+      const take = Math.min(seg.graphemes.length, Math.max(0, budget))
+      const isCurrent = take < seg.graphemes.length
       plan.push({
         kind: 'text',
-        content: seg.content.slice(0, take),
+        content: seg.graphemes.slice(0, take).join(''),
         isCurrent,
       })
-      budget -= seg.content.length
+      budget -= seg.graphemes.length
       if (isCurrent) halted = true
     } else {
       plan.push({ kind: 'dice_rolls', content: seg.content })

--- a/frontend/src/components/games/__tests__/ChatMessage.test.tsx
+++ b/frontend/src/components/games/__tests__/ChatMessage.test.tsx
@@ -73,6 +73,95 @@ describe('ChatMessage', () => {
   })
 })
 
+describe('paragraph rendering on reconcile', () => {
+  it('DM message with \\n\\n renders multiple <p> elements', () => {
+    const { container } = render(
+      <ChatMessage
+        role="dm"
+        content={'First paragraph.\n\nSecond paragraph.\n\nThird paragraph.'}
+      />
+    )
+    const paragraphs = container.querySelectorAll('p')
+    expect(paragraphs.length).toBe(3)
+    expect(paragraphs[0]).toHaveTextContent('First paragraph.')
+    expect(paragraphs[1]).toHaveTextContent('Second paragraph.')
+    expect(paragraphs[2]).toHaveTextContent('Third paragraph.')
+  })
+
+  it('DM message without newlines renders a single <p>', () => {
+    const { container } = render(
+      <ChatMessage role="dm" content="A single line of narration." />
+    )
+    const paragraphs = container.querySelectorAll('p')
+    expect(paragraphs.length).toBe(1)
+    expect(paragraphs[0]).toHaveTextContent('A single line of narration.')
+  })
+
+  it('player message with \\n\\n renders multiple <p> elements', () => {
+    const { container } = render(
+      <ChatMessage
+        role="player"
+        characterName="Elara"
+        content={'I approach the door.\n\nI listen for voices inside.'}
+      />
+    )
+    const paragraphs = container.querySelectorAll('p')
+    expect(paragraphs.length).toBe(2)
+    expect(paragraphs[0]).toHaveTextContent('I approach the door.')
+    expect(paragraphs[1]).toHaveTextContent('I listen for voices inside.')
+  })
+
+  it('player single-line still renders one <p>', () => {
+    const { container } = render(
+      <ChatMessage role="player" characterName="Elara" content="I cast Fireball." />
+    )
+    const paragraphs = container.querySelectorAll('p')
+    expect(paragraphs.length).toBe(1)
+    expect(paragraphs[0]).toHaveTextContent('I cast Fireball.')
+  })
+
+  it('DM with dice + multi-paragraph narration: narration hidden until dice settle, then multiple <p>', () => {
+    jest.useFakeTimers()
+    try {
+      const roll: DiceRollEvent = {
+        type: 'dice_roll',
+        die: 'd20',
+        count: 1,
+        result: 14,
+        modifier: 3,
+        total: 17,
+        label: 'Stealth Check',
+        dc: 15,
+        success: true,
+      }
+      const { container } = render(
+        <ChatMessage
+          role="dm"
+          content={'You slip past the guard.\n\nThe corridor stretches ahead.'}
+          diceRolls={[roll]}
+        />
+      )
+
+      // Narration wrapper is initially hidden via visibility.
+      const paraOne = screen.getByText('You slip past the guard.')
+      expect(paraOne).not.toBeVisible()
+
+      act(() => {
+        jest.runAllTimers()
+      })
+
+      expect(screen.getByText('You slip past the guard.')).toBeVisible()
+      expect(screen.getByText('The corridor stretches ahead.')).toBeVisible()
+
+      // Two paragraphs rendered inside the narration wrapper.
+      const paragraphs = container.querySelectorAll('p')
+      expect(paragraphs.length).toBe(2)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+})
+
 describe('✏ edit/delete controls (DIN-61)', () => {
   it('shows edit and delete buttons when hovering the last owned player message', () => {
     render(

--- a/frontend/src/components/games/__tests__/StreamingDmMessage.test.tsx
+++ b/frontend/src/components/games/__tests__/StreamingDmMessage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { StreamingDmMessage } from '../StreamingDmMessage'
 import type { StreamSegment } from '@/lib/types/streaming'
 
@@ -9,6 +9,47 @@ jest.mock('@/components/dice/DiceRoller', () => ({
     </div>
   ),
 }))
+
+type RafCallback = (t: number) => void
+
+let rafCallbacks: RafCallback[] = []
+let currentTime = 0
+
+const flush = (dtMs: number): void => {
+  currentTime += dtMs
+  const toRun = rafCallbacks
+  rafCallbacks = []
+  act(() => {
+    for (const cb of toRun) cb(currentTime)
+  })
+}
+
+const flushFrames = (count: number, dtMs = 16): void => {
+  for (let i = 0; i < count; i++) flush(dtMs)
+}
+
+/** Advance enough simulated frames to fully reveal any plausible stream. */
+const flushToComplete = (): void => {
+  // 3 simulated seconds at 16ms/frame = 188 frames — more than enough at
+  // 100cps + 1.5s catch-up clamp for anything the unit tests throw at us.
+  flushFrames(200)
+}
+
+beforeEach(() => {
+  rafCallbacks = []
+  currentTime = 0
+  jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((cb: RafCallback): number => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+  jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
 
 describe('StreamingDmMessage', () => {
   it('renders a blinking cursor when the segment list is empty', () => {
@@ -22,6 +63,7 @@ describe('StreamingDmMessage', () => {
       { kind: 'text', content: 'The goblin lunges.' },
     ]
     render(<StreamingDmMessage segments={segments} />)
+    flushToComplete()
     expect(screen.getByText(/The goblin lunges\./)).toBeInTheDocument()
     expect(screen.getByTestId('streaming-cursor')).toBeInTheDocument()
   })
@@ -45,6 +87,7 @@ describe('StreamingDmMessage', () => {
       { kind: 'text', content: 'You sneak past.' },
     ]
     render(<StreamingDmMessage segments={segments} />)
+    flushToComplete()
 
     expect(screen.getByTestId('streaming-dice')).toBeInTheDocument()
     expect(screen.getByTestId('dice-d20')).toHaveTextContent(/Stealth/)
@@ -63,6 +106,7 @@ describe('StreamingDmMessage', () => {
       { kind: 'text', content: 'Last.' },
     ]
     render(<StreamingDmMessage segments={segments} />)
+    flushToComplete()
     const cursors = screen.getAllByTestId('streaming-cursor')
     expect(cursors).toHaveLength(1)
   })
@@ -74,5 +118,64 @@ describe('StreamingDmMessage', () => {
     render(<StreamingDmMessage segments={segments} />)
     expect(screen.getByTestId('streaming-dice')).toBeInTheDocument()
     expect(screen.queryByTestId('dice-d20')).not.toBeInTheDocument()
+  })
+
+  it('reveals text progressively via the typewriter (not all at once)', () => {
+    const long = 'A'.repeat(500)
+    const segments: StreamSegment[] = [{ kind: 'text', content: long }]
+    render(<StreamingDmMessage segments={segments} />)
+
+    // After one frame (~16ms at 100cps) only ~1-2 chars are revealed.
+    flushFrames(2)
+    const partial = screen.getByTestId('streaming-dm-message').textContent ?? ''
+    // Remove the "Dungeon Master" label prefix before measuring.
+    const rendered = partial.replace('Dungeon Master', '')
+    expect(rendered.length).toBeLessThan(long.length)
+  })
+
+  it('gates dice blocks behind still-typing preceding text', () => {
+    const diceContent =
+      '[{"type":"dice_roll","die":"d20","count":1,"result":10,"modifier":0,"total":10,"label":"Roll"}]'
+    const segments: StreamSegment[] = [
+      { kind: 'text', content: 'Hello' },
+      { kind: 'dice_rolls', content: diceContent },
+    ]
+    render(<StreamingDmMessage segments={segments} />)
+
+    // Before the text is fully revealed, the dice block must not render.
+    flushFrames(1)
+    expect(screen.queryByTestId('streaming-dice')).not.toBeInTheDocument()
+
+    // After the reveal completes, the dice block appears.
+    flushToComplete()
+    expect(screen.getByTestId('streaming-dice')).toBeInTheDocument()
+  })
+
+  it('preserves paragraph breaks on \\n\\n within a single text segment', () => {
+    const segments: StreamSegment[] = [
+      { kind: 'text', content: 'Paragraph one.\n\nParagraph two.' },
+    ]
+    const { container } = render(<StreamingDmMessage segments={segments} />)
+    flushToComplete()
+
+    const paragraphs = container.querySelectorAll('p')
+    // Two <p>s for the two paragraphs; no extra empty-cursor <p>.
+    expect(paragraphs.length).toBe(2)
+    expect(paragraphs[0].textContent).toContain('Paragraph one.')
+    expect(paragraphs[1].textContent).toContain('Paragraph two.')
+  })
+
+  it('keeps the cursor on the final paragraph once the stream fully reveals', () => {
+    const segments: StreamSegment[] = [
+      { kind: 'text', content: 'Alpha.\n\nBeta.' },
+    ]
+    const { container } = render(<StreamingDmMessage segments={segments} />)
+    flushToComplete()
+
+    const paragraphs = container.querySelectorAll('p')
+    expect(paragraphs.length).toBe(2)
+    // Cursor should be within the last paragraph.
+    expect(paragraphs[1].querySelector('[data-testid="streaming-cursor"]')).toBeTruthy()
+    expect(paragraphs[0].querySelector('[data-testid="streaming-cursor"]')).toBeFalsy()
   })
 })

--- a/frontend/src/components/games/__tests__/StreamingDmMessage.test.tsx
+++ b/frontend/src/components/games/__tests__/StreamingDmMessage.test.tsx
@@ -165,6 +165,23 @@ describe('StreamingDmMessage', () => {
     expect(paragraphs[1].textContent).toContain('Paragraph two.')
   })
 
+  it('never slices an emoji mid-character during the typewriter reveal', () => {
+    // Mix ASCII + multi-code-unit glyphs. A naive UTF-16 slice would
+    // produce a lone surrogate (rendered as U+FFFD) at certain frames;
+    // grapheme-safe slicing guarantees every intermediate string is valid.
+    const content = 'a🐉b🦄c'
+    const segments: StreamSegment[] = [{ kind: 'text', content }]
+    const { container } = render(<StreamingDmMessage segments={segments} />)
+
+    // Sample the DOM text at several intermediate frames — no replacement
+    // character should ever appear.
+    for (let i = 0; i < 40; i++) {
+      flush(16)
+      const bubble = container.querySelector('[data-testid="streaming-dm-message"]')
+      expect(bubble?.textContent ?? '').not.toContain('�')
+    }
+  })
+
   it('keeps the cursor on the final paragraph once the stream fully reveals', () => {
     const segments: StreamSegment[] = [
       { kind: 'text', content: 'Alpha.\n\nBeta.' },

--- a/frontend/src/lib/hooks/__tests__/useTypewriter.test.ts
+++ b/frontend/src/lib/hooks/__tests__/useTypewriter.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react'
+import { useTypewriter } from '../useTypewriter'
+
+type RafCallback = (t: number) => void
+
+let rafCallbacks: RafCallback[] = []
+let currentTime = 0
+
+const flush = (dtMs: number): void => {
+  currentTime += dtMs
+  const toRun = rafCallbacks
+  rafCallbacks = []
+  act(() => {
+    for (const cb of toRun) cb(currentTime)
+  })
+}
+
+const flushFrames = (count: number, dtMs = 16): void => {
+  for (let i = 0; i < count; i++) flush(dtMs)
+}
+
+beforeEach(() => {
+  rafCallbacks = []
+  currentTime = 0
+  jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((cb: RafCallback): number => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+  jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('useTypewriter', () => {
+  it('stays at 0 when target is 0', () => {
+    const { result } = renderHook(() => useTypewriter(0, 100))
+    flushFrames(60)
+    expect(result.current).toBe(0)
+  })
+
+  it('reaches target at roughly cps over time', () => {
+    const { result } = renderHook(() => useTypewriter(100, 100))
+    // 1.05s of simulated ticks (~65 frames at 16ms) — 100 chars @ 100cps = 1s.
+    flushFrames(70)
+    expect(result.current).toBe(100)
+  })
+
+  it('catches up faster than the steady rate when a large backlog exists', () => {
+    // At pure cps=100 for 1.5s we would only reveal 150 chars. With the
+    // deficit/1.5 catch-up clamp active, revealed should comfortably exceed
+    // that bound for a target of 300.
+    const { result } = renderHook(() => useTypewriter(300, 100))
+    flushFrames(94) // ~1.5s of simulated ticks at 16ms
+    expect(result.current).toBeGreaterThan(150)
+  })
+
+  it('continues climbing when target grows mid-animation', () => {
+    const { result, rerender } = renderHook(
+      ({ target }: { target: number }) => useTypewriter(target, 100),
+      { initialProps: { target: 50 } }
+    )
+    flushFrames(35) // ~0.56s, should reach 50
+    expect(result.current).toBe(50)
+
+    rerender({ target: 150 })
+    flushFrames(70) // another ~1.1s, plenty to close the 100-char gap
+    expect(result.current).toBe(150)
+  })
+
+  it('clamps revealed down when target shrinks below it', () => {
+    const { result, rerender } = renderHook(
+      ({ target }: { target: number }) => useTypewriter(target, 100),
+      { initialProps: { target: 100 } }
+    )
+    flushFrames(70)
+    expect(result.current).toBe(100)
+
+    rerender({ target: 30 })
+    // target-shrink clamp runs in a useEffect; flush a frame so the state
+    // update is observable.
+    flushFrames(1)
+    expect(result.current).toBe(30)
+  })
+})

--- a/frontend/src/lib/hooks/useTypewriter.ts
+++ b/frontend/src/lib/hooks/useTypewriter.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react'
+
+const MAX_LATENCY_SECONDS = 1.5
+
+/**
+ * Drives a character-by-character reveal of `target` characters at roughly
+ * `cps` characters per second. Uses a single long-lived requestAnimationFrame
+ * loop and clamps up to MAX_LATENCY_SECONDS of backlog so bursty backend
+ * chunks still land within ~1.5s without sacrificing the steady reveal feel.
+ */
+export function useTypewriter(target: number, cps: number): number {
+  const [revealedInt, setRevealedInt] = useState<number>(0)
+  const revealedRef = useRef<number>(0)
+  const targetRef = useRef<number>(target)
+  const cpsRef = useRef<number>(cps)
+
+  useEffect(() => {
+    targetRef.current = target
+  }, [target])
+
+  useEffect(() => {
+    cpsRef.current = cps
+  }, [cps])
+
+  useEffect(() => {
+    let rafId = 0
+    let lastTime: number | null = null
+
+    const tick = (now: number): void => {
+      if (lastTime === null) lastTime = now
+      const dt = (now - lastTime) / 1000
+      lastTime = now
+
+      const tgt = targetRef.current
+      if (revealedRef.current > tgt) revealedRef.current = tgt
+      const deficit = tgt - revealedRef.current
+      const effectiveCps = Math.max(cpsRef.current, deficit / MAX_LATENCY_SECONDS)
+      revealedRef.current = Math.min(tgt, revealedRef.current + dt * effectiveCps)
+
+      const floored = Math.floor(revealedRef.current)
+      setRevealedInt((prev) => (prev !== floored ? floored : prev))
+
+      rafId = requestAnimationFrame(tick)
+    }
+
+    rafId = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(rafId)
+  }, [])
+
+  // Derive the clamp from `target` during render so a shrinking target is
+  // reflected immediately (the rAF loop catches up the ref on its next tick).
+  return Math.min(revealedInt, target)
+}

--- a/frontend/src/lib/utils/__tests__/text.test.ts
+++ b/frontend/src/lib/utils/__tests__/text.test.ts
@@ -1,4 +1,4 @@
-import { splitParagraphs } from '../text'
+import { graphemesOf, splitParagraphs } from '../text'
 
 describe('splitParagraphs', () => {
   it('returns an empty array for an empty string', () => {
@@ -23,5 +23,30 @@ describe('splitParagraphs', () => {
 
   it('preserves single newlines within a paragraph', () => {
     expect(splitParagraphs('line1\nline2\n\nline3')).toEqual(['line1\nline2', 'line3'])
+  })
+})
+
+describe('graphemesOf', () => {
+  it('returns an empty array for an empty string', () => {
+    expect(graphemesOf('')).toEqual([])
+  })
+
+  it('returns one entry per ASCII character', () => {
+    expect(graphemesOf('hello')).toEqual(['h', 'e', 'l', 'l', 'o'])
+  })
+
+  it('keeps a basic-plane emoji as a single entry', () => {
+    // The dragon emoji is a single code point but occupies 2 UTF-16 units.
+    expect(graphemesOf('🐉')).toEqual(['🐉'])
+  })
+
+  it('keeps a ZWJ emoji sequence as a single entry', () => {
+    // Family emoji: man + ZWJ + woman + ZWJ + boy
+    const family = '\u{1F468}‍\u{1F469}‍\u{1F466}'
+    expect(graphemesOf(family)).toEqual([family])
+  })
+
+  it('splits mixed text correctly', () => {
+    expect(graphemesOf('a🐉b')).toEqual(['a', '🐉', 'b'])
   })
 })

--- a/frontend/src/lib/utils/__tests__/text.test.ts
+++ b/frontend/src/lib/utils/__tests__/text.test.ts
@@ -1,0 +1,27 @@
+import { splitParagraphs } from '../text'
+
+describe('splitParagraphs', () => {
+  it('returns an empty array for an empty string', () => {
+    expect(splitParagraphs('')).toEqual([])
+  })
+
+  it('returns a single-element array for a single paragraph', () => {
+    expect(splitParagraphs('a')).toEqual(['a'])
+  })
+
+  it('splits on double newlines', () => {
+    expect(splitParagraphs('a\n\nb')).toEqual(['a', 'b'])
+  })
+
+  it('treats multiple paragraphs separated by double newlines', () => {
+    expect(splitParagraphs('one\n\ntwo\n\nthree')).toEqual(['one', 'two', 'three'])
+  })
+
+  it('filters out empty paragraphs from consecutive double newlines', () => {
+    expect(splitParagraphs('a\n\n\n\nb')).toEqual(['a', 'b'])
+  })
+
+  it('preserves single newlines within a paragraph', () => {
+    expect(splitParagraphs('line1\nline2\n\nline3')).toEqual(['line1\nline2', 'line3'])
+  })
+})

--- a/frontend/src/lib/utils/text.ts
+++ b/frontend/src/lib/utils/text.ts
@@ -1,0 +1,4 @@
+/** Split content into display paragraphs using the same rule as the streaming bubble. */
+export function splitParagraphs(text: string): string[] {
+  return text.split('\n\n').filter((p) => p.length > 0)
+}

--- a/frontend/src/lib/utils/text.ts
+++ b/frontend/src/lib/utils/text.ts
@@ -2,3 +2,31 @@
 export function splitParagraphs(text: string): string[] {
   return text.split('\n\n').filter((p) => p.length > 0)
 }
+
+let cachedSegmenter: Intl.Segmenter | null = null
+
+function getGraphemeSegmenter(): Intl.Segmenter | null {
+  if (cachedSegmenter) return cachedSegmenter
+  if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
+    cachedSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    return cachedSegmenter
+  }
+  return null
+}
+
+/**
+ * Split `text` into grapheme clusters so emoji, combining marks, and other
+ * multi-code-unit glyphs aren't torn mid-character when we slice for the
+ * typewriter reveal. Falls back to code-point iteration when
+ * `Intl.Segmenter` is unavailable — still better than UTF-16 `.length`/`.slice`.
+ */
+export function graphemesOf(text: string): string[] {
+  if (text.length === 0) return []
+  const segmenter = getGraphemeSegmenter()
+  if (segmenter) {
+    const out: string[] = []
+    for (const { segment } of segmenter.segment(text)) out.push(segment)
+    return out
+  }
+  return Array.from(text)
+}


### PR DESCRIPTION
## Summary
Implements a smooth character-by-character reveal animation for streaming DM messages using a requestAnimationFrame-driven typewriter hook. Text now reveals at ~100 characters per second with intelligent catch-up logic, while dice blocks are gated behind still-typing text. Adds paragraph break support (`\n\n`) to both streaming and regular chat messages for better visual formatting.

## Key Changes

- **New `useTypewriter` hook** (`lib/hooks/useTypewriter.ts`): Drives character reveal at configurable cps with a 1.5s catch-up clamp to handle bursty backend chunks smoothly without sacrificing the steady reveal feel
  
- **Streaming message refactor** (`StreamingDmMessage.tsx`): 
  - Integrates typewriter hook to progressively reveal text instead of rendering all at once
  - Implements "plan" system to gate dice blocks behind still-typing preceding text
  - Cursor now anchors to the currently-typing text segment or the last rendered text
  - Adds paragraph break support via new `splitParagraphs` utility

- **Chat message paragraph support** (`ChatMessage.tsx`):
  - Both DM and player messages now split on `\n\n` to render multiple `<p>` elements with proper spacing
  - Maintains visibility gating for narration when dice are present

- **New `splitParagraphs` utility** (`lib/utils/text.ts`): Shared logic for splitting content on double newlines and filtering empty paragraphs

- **Comprehensive test coverage**:
  - `useTypewriter.test.ts`: Tests reveal rate, catch-up clamping, and target changes
  - `StreamingDmMessage.test.ts`: Tests progressive reveal, dice gating, paragraph rendering, and cursor placement
  - `ChatMessage.test.ts`: Tests paragraph rendering in both DM and player messages with and without dice
  - `text.test.ts`: Tests paragraph splitting edge cases

## Implementation Details

The typewriter effect uses a single long-lived rAF loop that calculates an effective cps based on the deficit between revealed and target characters. When a large backlog exists (e.g., backend burst), the effective rate scales up to `deficit / 1.5s` to catch up within 1.5 seconds, then settles back to the steady rate. This prevents the reveal from feeling sluggish on bursty data while maintaining smooth character-by-character animation.

Dice blocks only render once all preceding text has been fully revealed, preventing them from appearing ahead of their narration context.

https://claude.ai/code/session_0186qn86QLrRYimDMACQMUPU