### PR TITLE
Fix player-message reconciliation via client-minted UUID

### DIFF
--- a/backend/api/routes/actions.py
+++ b/backend/api/routes/actions.py
@@ -214,9 +214,18 @@ async def create_action(
             raise HTTPException(status_code=422, detail=str(e))
 
         # ---- Insert player message (fires Realtime) ---- #
-        message_id = str(uuid.uuid4())
+        if action.client_id is not None:
+            try:
+                message_id = str(uuid.UUID(action.client_id))
+            except ValueError:
+                raise HTTPException(
+                    status_code=400, detail="client_id must be a valid UUID"
+                )
+        else:
+            message_id = str(uuid.uuid4())
         supabase_client.table("game_messages").insert(
             {
+                "id": message_id,
                 "game_id": gameId,
                 "profile_id": current_user,
                 "role": MESSAGE_ROLE_PLAYER,

--- a/backend/models/action.py
+++ b/backend/models/action.py
@@ -7,6 +7,7 @@ class ActionInput(BaseModel):
     """Player action submitted to the DM."""
 
     action_text: str
+    client_id: str | None = None
 
 
 class ActionResponse(BaseModel):

--- a/backend/tests/test_actions_route.py
+++ b/backend/tests/test_actions_route.py
@@ -227,6 +227,84 @@ class TestCreateAction:
         )
         assert response.status_code == 401
 
+    def test_create_action_uses_provided_client_id(self, client):
+        """Supplied client_id UUID is used as the inserted row's id and returned."""
+        captured_inserts: list[dict] = []
+
+        mock_player_result = MagicMock(data=SAMPLE_PLAYER)
+        mock_game_result = MagicMock(data=SAMPLE_GAME)
+        mock_messages_result = MagicMock(data=[])
+        mock_players_result = MagicMock(data=[SAMPLE_PLAYER])
+        mock_inventory_result = MagicMock(data=[])
+
+        def table_side_effect(name):
+            mock = MagicMock()
+            if name == "players":
+                mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
+                    mock_player_result
+                )
+                mock.select.return_value.match.return_value.execute.return_value = (
+                    mock_players_result
+                )
+            elif name == "games":
+                mock.select.return_value.match.return_value.single.return_value.execute.return_value = (
+                    mock_game_result
+                )
+            elif name == "game_messages":
+
+                def capture_insert(row):
+                    captured_inserts.append(row)
+                    return MagicMock(execute=MagicMock(return_value=MagicMock()))
+
+                mock.insert.side_effect = capture_insert
+                mock.select.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = (
+                    mock_messages_result
+                )
+            elif name == "player_inventory":
+                mock.select.return_value.in_.return_value.execute.return_value = (
+                    mock_inventory_result
+                )
+            return mock
+
+        def _close(coro):
+            coro.close()
+            return MagicMock()
+
+        client_id = "11111111-2222-3333-4444-555555555555"
+
+        with patch("api.routes.actions.supabase_client") as mock_sb, patch(
+            "api.routes.actions.asyncio.create_task", side_effect=_close
+        ), patch("api.routes.actions.embed_text") as mock_embed, patch(
+            "api.routes.actions.search_rag"
+        ) as mock_rag:
+            mock_sb.table.side_effect = table_side_effect
+            mock_embed.return_value = [0.0] * 1536
+            mock_rag.return_value = []
+
+            response = client.post(
+                "/games/game-uuid-1/actions",
+                json={"action_text": "I attack!", "client_id": client_id},
+            )
+
+        assert response.status_code == 202
+        player_inserts = [r for r in captured_inserts if r.get("role") == "player"]
+        assert len(player_inserts) == 1
+        assert player_inserts[0]["id"] == client_id
+        assert response.json()["message_id"] == client_id
+
+    def test_create_action_rejects_invalid_client_id(self, client):
+        """Malformed client_id returns 400 with a UUID-mentioning detail."""
+        with patch("api.routes.actions.supabase_client") as mock_sb:
+            mock_sb.table.side_effect = _build_supabase_mock()
+
+            response = client.post(
+                "/games/game-uuid-1/actions",
+                json={"action_text": "I attack!", "client_id": "not-a-uuid"},
+            )
+
+        assert response.status_code == 400
+        assert "UUID" in response.json()["detail"]
+
     def test_create_action_invalid_game_state_returns_422(self, client):
         """When the game is not active, validate_action raises and returns 422."""
         mock_player_result = MagicMock()

--- a/frontend/e2e/optimistic-messages.spec.ts
+++ b/frontend/e2e/optimistic-messages.spec.ts
@@ -194,13 +194,19 @@ test.describe('DIN-64 — Optimistic player messages', () => {
     // Optimistic message appears
     await expect(page.getByText(ACTION_TEXT)).toBeVisible({ timeout: 3000 })
 
+    // Read the id the client minted so Realtime can dedupe by the same id.
+    const optimisticId = await page
+      .locator('[data-message-id]')
+      .first()
+      .getAttribute('data-message-id')
+
     // Simulate Supabase Realtime INSERT for the same player message (real DB row)
     await page.evaluate(
-      ({ gameId, userId, content }) => {
+      ({ gameId, userId, content, id }) => {
         window.dispatchEvent(
           new CustomEvent('player-message', {
             detail: {
-              id: 'msg-player-real-1',
+              id,
               game_id: gameId,
               profile_id: userId,
               role: 'player',
@@ -210,7 +216,7 @@ test.describe('DIN-64 — Optimistic player messages', () => {
           })
         )
       },
-      { gameId: GAME_ID, userId: USER_ID, content: ACTION_TEXT }
+      { gameId: GAME_ID, userId: USER_ID, content: ACTION_TEXT, id: optimisticId }
     )
 
     // Wait a tick for reconciliation to complete

--- a/frontend/src/app/api/games/[gameId]/actions/__tests__/route.test.ts
+++ b/frontend/src/app/api/games/[gameId]/actions/__tests__/route.test.ts
@@ -145,6 +145,47 @@ describe('POST /api/games/[gameId]/actions', () => {
     })
   })
 
+  it('forwards client_id when supplied', async () => {
+    mockAuthed()
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 202,
+      json: async () => ({ message_id: 'msg-1', status: 'queued' }),
+    })
+
+    await POST(
+      makeRequest({
+        action_text: 'Attack',
+        client_id: '11111111-2222-3333-4444-555555555555',
+      }),
+      { params: Promise.resolve({ gameId: 'game-1' }) }
+    )
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0]
+    const parsed = JSON.parse(init.body)
+    expect(parsed).toEqual({
+      action_text: 'Attack',
+      client_id: '11111111-2222-3333-4444-555555555555',
+    })
+  })
+
+  it('omits client_id when absent', async () => {
+    mockAuthed()
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 202,
+      json: async () => ({ message_id: 'msg-1', status: 'queued' }),
+    })
+
+    await POST(makeRequest({ action_text: 'Attack' }), {
+      params: Promise.resolve({ gameId: 'game-1' }),
+    })
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0]
+    const parsed = JSON.parse(init.body)
+    expect('client_id' in parsed).toBe(false)
+  })
+
   it('forwards backend error status and detail', async () => {
     mockAuthed()
     ;(global.fetch as jest.Mock).mockResolvedValueOnce({

--- a/frontend/src/app/api/games/[gameId]/actions/route.ts
+++ b/frontend/src/app/api/games/[gameId]/actions/route.ts
@@ -34,7 +34,7 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { action_text } = await request.json()
+    const { action_text, client_id } = await request.json()
 
     if (!action_text || typeof action_text !== 'string' || !action_text.trim()) {
       return NextResponse.json(
@@ -52,6 +52,11 @@ export async function POST(
 
     const { gameId } = await params
 
+    const forwardBody: { action_text: string; client_id?: string } = {
+      action_text: action_text.trim(),
+    }
+    if (typeof client_id === 'string') forwardBody.client_id = client_id
+
     const backendUrl =
       process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'
     const response = await fetch(`${backendUrl}/games/${gameId}/actions`, {
@@ -60,7 +65,7 @@ export async function POST(
         'Content-Type': 'application/json',
         Authorization: `Bearer ${session.access_token}`,
       },
-      body: JSON.stringify({ action_text: action_text.trim() }),
+      body: JSON.stringify(forwardBody),
     })
 
     if (!response.ok) {

--- a/frontend/src/components/games/ChatLog.tsx
+++ b/frontend/src/components/games/ChatLog.tsx
@@ -229,6 +229,7 @@ export function ChatLog({
           return messages.map((msg) => (
             <ChatMessage
               key={msg.id}
+              messageId={msg.id}
               role={msg.role}
               characterName={
                 msg.role === 'player'

--- a/frontend/src/components/games/ChatMessage.tsx
+++ b/frontend/src/components/games/ChatMessage.tsx
@@ -7,6 +7,7 @@ import { splitParagraphs } from '@/lib/utils/text'
 
 interface ChatMessageProps {
   role: 'player' | 'dm' | 'system'
+  messageId?: string
   characterName?: string
   content: string
   profileId?: string | null
@@ -22,6 +23,7 @@ interface ChatMessageProps {
 
 export function ChatMessage({
   role,
+  messageId,
   characterName,
   content,
   profileId,
@@ -79,7 +81,7 @@ export function ChatMessage({
   if (role === 'dm') {
     return (
       <>
-      <div className="mb-4 flex justify-start">
+      <div className="mb-4 flex justify-start" data-message-id={messageId}>
         <div
           className="max-w-2xl rounded-lg border px-5 py-4"
           style={{
@@ -295,7 +297,7 @@ export function ChatMessage({
 
   if (role === 'player') {
     return (
-      <div className="mb-4 flex justify-end">
+      <div className="mb-4 flex justify-end" data-message-id={messageId}>
         <div
           className="relative max-w-2xl rounded-lg border px-5 py-4"
           style={{
@@ -434,7 +436,7 @@ export function ChatMessage({
 
   // System message
   return (
-    <div className="mb-4 flex justify-center">
+    <div className="mb-4 flex justify-center" data-message-id={messageId}>
       <div
         className="max-w-2xl rounded-lg border px-5 py-4 text-center text-sm"
         style={{

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -159,8 +159,15 @@ export function GameSessionView({
 
           if (newMsg.role === 'player') {
             setMessages((prev) => {
-              if (prev.some((m) => m.id === newMsg.id)) return prev
-              return [...prev, newMsg].sort((a, b) =>
+              // Replace (not skip) on id-match so the optimistic row picks up
+              // the server's canonical fields — `created_at` (DB-generated,
+              // authoritative for ordering) and any server-normalized content.
+              // React key stays stable, so no remount.
+              const idx = prev.findIndex((m) => m.id === newMsg.id)
+              const next = idx >= 0
+                ? prev.map((m, i) => (i === idx ? newMsg : m))
+                : [...prev, newMsg]
+              return next.sort((a, b) =>
                 a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0
               )
             })
@@ -304,8 +311,11 @@ export function GameSessionView({
       }
       if (msg.role === 'player') {
         setMessages((prev) => {
-          if (prev.some((m) => m.id === msg.id)) return prev
-          return [...prev, msg].sort((a, b) =>
+          const idx = prev.findIndex((m) => m.id === msg.id)
+          const next = idx >= 0
+            ? prev.map((m, i) => (i === idx ? msg : m))
+            : [...prev, msg]
+          return next.sort((a, b) =>
             a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0
           )
         })

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -158,17 +158,11 @@ export function GameSessionView({
           const newMsg = payload.new as GameMessage
 
           if (newMsg.role === 'player') {
-            // Reconcile: replace any optimistic message matching this player+content
             setMessages((prev) => {
-              const filtered = prev.filter(
-                (m) =>
-                  !(
-                    m.id.startsWith('optimistic-') &&
-                    m.profile_id === newMsg.profile_id &&
-                    m.content === newMsg.content
-                  )
+              if (prev.some((m) => m.id === newMsg.id)) return prev
+              return [...prev, newMsg].sort((a, b) =>
+                a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0
               )
-              return [...filtered, newMsg]
             })
             // Only flip to waiting if a DIFFERENT user submitted. For our own
             // action, handleSubmit already set isWaitingForDm(true); re-setting
@@ -178,7 +172,12 @@ export function GameSessionView({
               setIsWaitingForDm(true)
             }
           } else {
-            setMessages((prev) => [...prev, newMsg])
+            setMessages((prev) => {
+              if (prev.some((m) => m.id === newMsg.id)) return prev
+              return [...prev, newMsg].sort((a, b) =>
+                a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0
+              )
+            })
             // If DM or system (error) responded, we're no longer waiting
             if (newMsg.role === 'dm' || newMsg.role === 'system') {
               setIsWaitingForDm(false)
@@ -304,22 +303,20 @@ export function GameSessionView({
         dice_rolls: detail.dice_rolls ?? null,
       }
       if (msg.role === 'player') {
-        // Reconcile: mirror the Realtime INSERT handler — remove any optimistic
-        // message with a matching profile_id + content before adding the real one.
         setMessages((prev) => {
-          const filtered = prev.filter(
-            (m) =>
-              !(
-                m.id.startsWith('optimistic-') &&
-                m.profile_id === msg.profile_id &&
-                m.content === msg.content
-              )
+          if (prev.some((m) => m.id === msg.id)) return prev
+          return [...prev, msg].sort((a, b) =>
+            a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0
           )
-          return [...filtered, msg]
         })
         setIsWaitingForDm(true)
       } else {
-        setMessages((prev) => [...prev, msg])
+        setMessages((prev) => {
+          if (prev.some((m) => m.id === msg.id)) return prev
+          return [...prev, msg].sort((a, b) =>
+            a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0
+          )
+        })
         if (msg.role === 'dm' || msg.role === 'system') {
           setIsWaitingForDm(false)
           setStreamingSegments(null)
@@ -394,9 +391,12 @@ export function GameSessionView({
   const handleSubmit = async (actionText: string) => {
     setShowRetryTimeout(false)
 
-    // 1. Optimistic player message (DIN-64) — unchanged.
+    // Client mints the message UUID so the optimistic row and the persisted
+    // row share the same id — Realtime INSERT then dedupes by id instead of
+    // remounting the bubble on reconciliation.
+    const clientMessageId = crypto.randomUUID()
     const optimisticMsg: GameMessage = {
-      id: `optimistic-${crypto.randomUUID()}`,
+      id: clientMessageId,
       game_id: gameId,
       role: 'player',
       profile_id: userId,
@@ -413,7 +413,7 @@ export function GameSessionView({
       actionResponse = await fetch(`/api/games/${gameId}/actions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action_text: actionText }),
+        body: JSON.stringify({ action_text: actionText, client_id: clientMessageId }),
       })
     } catch {
       setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id))

--- a/frontend/src/components/games/__tests__/GameSessionView.test.tsx
+++ b/frontend/src/components/games/__tests__/GameSessionView.test.tsx
@@ -558,14 +558,16 @@ describe('GameSessionView', () => {
       fireEvent.click(retryButton)
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(
-          '/api/games/game-1/actions',
-          expect.objectContaining({
-            method: 'POST',
-            body: JSON.stringify({ action_text: 'I attack the dragon!' }),
-          })
-        )
+        expect(global.fetch).toHaveBeenCalled()
       })
+      const [url, init] = (global.fetch as jest.Mock).mock.calls.find(
+        ([u]) => u === '/api/games/game-1/actions'
+      )
+      expect(url).toBe('/api/games/game-1/actions')
+      expect(init.method).toBe('POST')
+      const body = JSON.parse(init.body)
+      expect(body.action_text).toBe('I attack the dragon!')
+      expect(typeof body.client_id).toBe('string')
     })
   })
 
@@ -590,12 +592,16 @@ describe('GameSessionView', () => {
       })
     })
 
-    it('optimistic message is replaced (not duplicated) when Realtime INSERT fires with matching content', async () => {
-      let realtimeInsertCallback: ((payload: any) => void) | null = null
+    it('optimistic message is deduped (not duplicated) when Realtime INSERT fires with the same client-minted id', async () => {
+      const fixedId = '11111111-2222-3333-4444-555555555555'
+      const randomUUIDSpy = jest
+        .spyOn(crypto, 'randomUUID')
+        .mockReturnValue(fixedId)
 
+      const handlers: Record<string, (payload: any) => void> = {}
       const channelObj: any = {
-        on: jest.fn().mockImplementation((_event: any, _filter: any, cb: any) => {
-          realtimeInsertCallback = cb
+        on: jest.fn().mockImplementation((_event: any, filter: any, cb: any) => {
+          handlers[filter.event] = cb
           return channelObj
         }),
         subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
@@ -608,15 +614,13 @@ describe('GameSessionView', () => {
       render(<GameSessionView gameId="game-1" game={mockGame} userId="user-1" />)
       await waitFor(() => expect(screen.getByTestId('chat-input')).toBeInTheDocument())
 
-      // Push optimistic message
       act(() => { fireEvent.click(screen.getByTestId('submit-action')) })
       await waitFor(() => expect(screen.getByTestId('messages-count')).toHaveTextContent('1'))
 
-      // Realtime fires the real message
       act(() => {
-        realtimeInsertCallback?.({
+        handlers.INSERT?.({
           new: {
-            id: 'real-msg-1',
+            id: fixedId,
             game_id: 'game-1',
             role: 'player',
             profile_id: 'user-1',
@@ -626,10 +630,11 @@ describe('GameSessionView', () => {
         })
       })
 
-      // Still exactly 1 message — optimistic replaced, not duplicated
       await waitFor(() => {
         expect(screen.getByTestId('messages-count')).toHaveTextContent('1')
       })
+
+      randomUUIDSpy.mockRestore()
     })
 
     it('optimistic message is removed and isWaiting becomes false on fetch error', async () => {

--- a/frontend/src/components/games/__tests__/GameSessionView.test.tsx
+++ b/frontend/src/components/games/__tests__/GameSessionView.test.tsx
@@ -20,6 +20,12 @@ jest.mock('../ChatLog', () => ({
       <div data-testid="has-more">{hasMoreMessages ? 'true' : 'false'}</div>
       <div data-testid="is-loading-more">{isLoadingMore ? 'true' : 'false'}</div>
       <div data-testid="messages-count">{messages ? messages.length : 0}</div>
+      <div data-testid="first-message-created-at">
+        {messages && messages[0] ? messages[0].created_at : ''}
+      </div>
+      <div data-testid="first-message-content">
+        {messages && messages[0] ? messages[0].content : ''}
+      </div>
       <div data-testid="chat-log-user-id">{userId || ''}</div>
       <div data-testid="streaming-active">{streamingSegments === null || streamingSegments === undefined ? 'false' : 'true'}</div>
       <div data-testid="streaming-segments-count">{streamingSegments ? streamingSegments.length : 0}</div>
@@ -617,6 +623,8 @@ describe('GameSessionView', () => {
       act(() => { fireEvent.click(screen.getByTestId('submit-action')) })
       await waitFor(() => expect(screen.getByTestId('messages-count')).toHaveTextContent('1'))
 
+      const serverCreatedAt = '2099-01-01T00:00:00.000Z'
+      const serverContent = 'I attack the dragon (server-normalized)'
       act(() => {
         handlers.INSERT?.({
           new: {
@@ -624,14 +632,22 @@ describe('GameSessionView', () => {
             game_id: 'game-1',
             role: 'player',
             profile_id: 'user-1',
-            content: 'I attack the dragon',
-            created_at: new Date().toISOString(),
+            content: serverContent,
+            created_at: serverCreatedAt,
           },
         })
       })
 
+      // Same row — count stays at 1, id stays stable (no remount), but the
+      // server-canonical fields replace the optimistic placeholders.
       await waitFor(() => {
         expect(screen.getByTestId('messages-count')).toHaveTextContent('1')
+        expect(screen.getByTestId('first-message-created-at')).toHaveTextContent(
+          serverCreatedAt
+        )
+        expect(screen.getByTestId('first-message-content')).toHaveTextContent(
+          serverContent
+        )
       })
 
       randomUUIDSpy.mockRestore()


### PR DESCRIPTION
## Summary

- The optimistic player bubble used id `optimistic-<uuid>`, so the Realtime INSERT handler reconciled by filter-by-prefix + (profile_id, content) and appended. That changed the React key on reconcile (DOM flicker) and could reorder the player row past any DM message that arrived first.
- The client now mints the UUID once in `handleSubmit`, uses it as the optimistic id, and sends it as `client_id` in the POST. The backend validates it as a UUID (400 on malformed) and uses it as the explicit `game_messages.id`. Both Realtime INSERT branches (player and dm/system) dedupe by id and sort by `created_at` — no prefix, no remount, no reorder.
- `ChatMessage` renders `data-message-id` on each role's outer wrapper so the Playwright shim can read the client-minted id off the DOM and dispatch the simulated Realtime INSERT with the matching id.

## Analysis

See the design notes and file-level plan in the chat session linked below. The short version: the bug is a key-change-on-reconcile caused by two different UUIDs for the same logical row — trivially fixable by letting the client own the primary key.

## Follow-up

**PR 2 (planned, not in scope here):** move RAG search back to the Dramatiq worker so `POST /actions` returns 202 faster and the SSE stream opens with less latency. The DIN-66 stream-to-Redis path stays as-is; only the synchronous embed + vector search shifts off the request path.

## Test plan

- [x] `pytest` in `backend/` — 298 passed, including 2 new tests:
  - `test_create_action_uses_provided_client_id` — captured insert row `id` == supplied UUID; response `message_id` == supplied UUID.
  - `test_create_action_rejects_invalid_client_id` — 400 + `"UUID"` in detail.
- [x] `pnpm test` in `frontend/` — 582 passed, including:
  - Rewritten reconciliation test spies on `crypto.randomUUID`, routes mock channel `.on()` calls by `filter.event` into a handlers map, and dispatches `handlers.INSERT` with the same id → `messages-count` stays at 1.
  - Two new route tests: `forwards client_id when supplied`, `omits client_id when absent`.
- [x] `tsc --noEmit` clean on all edited files.
- [x] `eslint` clean on all edited files (pre-existing lint errors on `develop` untouched).
- [x] Grep `optimistic-` across `frontend/src`, `frontend/e2e`, `backend/` — zero hits.
- [x] Brace balance (`content.count('{') == content.count('}')`) verified on every edited `.ts`/`.tsx` file.
- [ ] Manual smoke post-merge: submit an action, confirm no flicker on the player bubble when Realtime reconciles, and confirm the player bubble stays above any in-flight streaming DM bubble rather than reordering past it.
- [ ] Playwright `optimistic-messages.spec.ts` — rerun in CI (node env) to verify the DOM-read-id path.

https://claude.ai/code/session_01Miamhi57Pnp8m87icu5QzK