### PR TITLE
fix(DIN-73): scene overlay no longer blocks header/chat input

### DIFF
--- a/frontend/e2e/scene-overlay.spec.ts
+++ b/frontend/e2e/scene-overlay.spec.ts
@@ -1,0 +1,425 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ─── DIN-73: Scene overlay must not block game UI ─────────────────────────────
+//
+// Regression suite for the production bug where SceneBackground's fixed overlay
+// painted on top of the header and chat, making them unclickable and causing the
+// IntersectionObserver top sentinel to fire onLoadMore in an infinite loop.
+//
+// Fix: SceneBackground root uses z-index:-1 + pointer-events:none, and
+// .scene-bg-active isolates its stacking context via position:relative +
+// isolation:isolate, keeping the overlay strictly behind in-flow UI siblings.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAME_ID = 'test-game-din73'
+const USER_ID = 'user-1'
+
+interface GameMessage {
+  id: string
+  game_id: string
+  profile_id: string | null
+  role: 'player' | 'dm' | 'system'
+  content: string
+  scene_type?: string | null
+  scene_mood?: string | null
+  dice_rolls?: null
+  created_at: string
+}
+
+// ─── Setup helper ─────────────────────────────────────────────────────────────
+//
+// Registers auth, game, player, inventory, and message mocks.
+// `messages` must be in DESC created_at order (newest first) — matching
+// the Supabase `.order('created_at', { ascending: false })` response.
+// The game is always set to status='active' so the scene overlay renders.
+async function setupSceneMocks(page: Page, messages: GameMessage[]) {
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+    })
+  )
+
+  await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'mock-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        user: { id: USER_ID, email: 'test@example.com' },
+      }),
+    })
+  )
+
+  await page.route('**.supabase.co/rest/v1/games**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: GAME_ID,
+            name: 'The Shadow Vault',
+            dm_persona: 'A grim, theatrical Dungeon Master',
+            status: 'active',
+            created_by: USER_ID,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+            suggested_actions: [],
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/players**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'player-1',
+            game_id: GAME_ID,
+            profile_id: USER_ID,
+            character_name: 'Aldric',
+            character_class: 'Paladin',
+            race: 'Half-Elf',
+            level: 4,
+            hp_current: 36,
+            hp_max: 36,
+            stats: { str: 16, dex: 10, con: 14, int: 10, wis: 12, cha: 14 },
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+    if (route.request().method() === 'GET') {
+      const url = route.request().url()
+      if (url.includes('select=role')) {
+        // latestMessagePromise (limit=1): newest message
+        const latest = messages[0]
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(latest ? [latest] : []),
+        })
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(messages),
+        })
+      }
+    }
+  })
+}
+
+// A single DM message with scene_type set — activates the scene overlay.
+const dmSceneMsg: GameMessage = {
+  id: 'msg-scene',
+  game_id: GAME_ID,
+  profile_id: null,
+  role: 'dm',
+  content: 'The dungeon yawns before you, torchlight catching the carved stone walls.',
+  scene_type: 'dungeon',
+  scene_mood: 'tense',
+  dice_rolls: null,
+  created_at: '2026-01-01T00:00:01Z',
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('DIN-73 — Scene overlay does not block game UI', () => {
+  // ── 1. CSS guard: root element must pass through all pointer events ──────────
+  test('scene-background-root has pointer-events:none', async ({ page }) => {
+    await setupSceneMocks(page, [dmSceneMsg])
+    await page.goto(`/games/${GAME_ID}`)
+
+    // Wait for the game page to settle — game name in header signals mount
+    await expect(page.getByText('The Shadow Vault')).toBeVisible({ timeout: 8000 })
+
+    const root = page.locator('[data-testid="scene-background-root"]')
+    await expect(root).toBeVisible({ timeout: 5000 })
+
+    const pointerEvents = await root.evaluate(
+      (el) => window.getComputedStyle(el).pointerEvents
+    )
+    expect(pointerEvents).toBe('none')
+  })
+
+  // ── 2. Header button clickable with scene overlay in the DOM ─────────────────
+  //
+  // Regression: the fixed SceneBackground at z-index:0 intercepted all clicks
+  // in the header area. Verify the character sheet opens normally.
+  test('header sheet button is clickable when scene overlay is active', async ({
+    page,
+  }) => {
+    await setupSceneMocks(page, [dmSceneMsg])
+    await page.goto(`/games/${GAME_ID}`)
+
+    await expect(page.getByText('The Shadow Vault')).toBeVisible({ timeout: 8000 })
+
+    // Confirm the scene-bg-active class is present — overlay IS in the DOM
+    const container = page.locator('.dnd-page-bg')
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 5000 })
+
+    // Click the character sheet toggle
+    const sheetButton = page.getByTestId('sheet-button')
+    await expect(sheetButton).toBeVisible({ timeout: 5000 })
+    await sheetButton.click()
+
+    // The character sheet panel must open — its close button is the clearest signal
+    await expect(page.getByTestId('character-sheet-close')).toBeVisible({
+      timeout: 5000,
+    })
+  })
+
+  // ── 3. Chat textarea is interactive with scene overlay active ────────────────
+  //
+  // Regression: the root overlay container swallowed clicks in the chat area.
+  // Verify the textarea is focusable, accepts text, and the form submits.
+  test('chat textarea accepts input and submits when scene overlay is active', async ({
+    page,
+  }) => {
+    let actionCallCount = 0
+    await page.route(`**/api/games/${GAME_ID}/actions`, (route) => {
+      if (route.request().method() === 'POST') {
+        actionCallCount++
+        route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-new', status: 'queued' }),
+        })
+      }
+    })
+
+    await setupSceneMocks(page, [dmSceneMsg])
+    await page.goto(`/games/${GAME_ID}`)
+
+    await expect(page.getByText('The Shadow Vault')).toBeVisible({ timeout: 8000 })
+
+    const textarea = page.getByTestId('chat-textarea')
+    await expect(textarea).toBeEnabled({ timeout: 8000 })
+    await textarea.click()
+    await textarea.fill('I examine the carved runes on the wall.')
+
+    // Submit via Enter
+    await textarea.press('Enter')
+
+    // The actions proxy route must have been hit
+    await expect
+      .poll(() => actionCallCount, { timeout: 5000 })
+      .toBeGreaterThan(0)
+  })
+
+  // ── 4. Scroll-to-bottom button appears when scrolled away from bottom ─────────
+  //
+  // Regression: the infinite load-more loop kept the scroll container at the top,
+  // which meant the scroll-to-bottom button was always visible.  After the fix the
+  // page auto-scrolls to the latest message and the button is hidden until the user
+  // manually scrolls up.
+  test('scroll-to-bottom button is hidden on load, appears after scrolling up', async ({
+    page,
+  }) => {
+    // Small viewport guarantees the chat log overflows with few messages
+    await page.setViewportSize({ width: 1280, height: 400 })
+
+    // 8 DM messages (< page size 10 → hasMoreMessages=false, no load-more) in DESC.
+    // All DM so latestMessagePromise returns role='dm' → isWaitingForDm=false.
+    const msgs: GameMessage[] = Array.from({ length: 8 }, (_, i) => {
+      const n = 8 - i // 8 down to 1 (DESC newest-first)
+      return {
+        id: `msg-scroll-${n}`,
+        game_id: GAME_ID,
+        profile_id: null,
+        role: 'dm',
+        content: `The DM narrates scroll scene ${n} with vivid detail.`,
+        scene_type: n === 8 ? 'dungeon' : null,
+        dice_rolls: null,
+        created_at: `2026-01-01T00:${String(n).padStart(2, '0')}:00Z`,
+      }
+    })
+
+    await setupSceneMocks(page, msgs)
+    await page.goto(`/games/${GAME_ID}`)
+
+    // Wait for the newest message to render (the page auto-scrolls here)
+    await expect(
+      page.getByText('The DM narrates scroll scene 8 with vivid detail.')
+    ).toBeVisible({ timeout: 8000 })
+
+    // Scroll-to-bottom button must NOT be shown when already at the bottom
+    const scrollBtn = page.getByRole('button', { name: /latest message/i })
+    await expect(scrollBtn).not.toBeVisible()
+
+    // Scroll the chat log back to the top — simulates user reading history
+    await page.evaluate(() => {
+      const el = document.querySelector('.dnd-chat-log')
+      if (el) {
+        el.scrollTop = 0
+        el.dispatchEvent(new Event('scroll'))
+      }
+    })
+
+    // Button must now appear
+    await expect(scrollBtn).toBeVisible({ timeout: 5000 })
+
+    // Click it — user returns to bottom
+    await scrollBtn.click()
+
+    // Button disappears once back at the bottom
+    await expect(scrollBtn).not.toBeVisible({ timeout: 5000 })
+  })
+
+  // ── 5. Pagination does not loop infinitely when scene overlay is active ───────
+  //
+  // Regression: the fixed overlay at z-index:0 obscured the scroll container,
+  // causing the IntersectionObserver on the top sentinel to fire onLoadMore
+  // continuously.  The load-more query URL contains `created_at=lt.` (cursor).
+  // After the fix, that path should be called at most once per genuine scroll-to-top.
+  test('game_messages pagination is not triggered in an infinite loop', async ({
+    page,
+  }) => {
+    let loadMoreCallCount = 0
+
+    // Override the messages route BEFORE setupSceneMocks so ours wins (routes
+    // registered first match first in Playwright).
+    await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+      if (route.request().method() === 'GET') {
+        const url = route.request().url()
+        if (url.includes('select=role')) {
+          // latestMessagePromise — return the newest dm message
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([dmSceneMsg]),
+          })
+        } else if (url.includes('created_at=lt.')) {
+          // load-more cursor query
+          loadMoreCallCount++
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([]),
+          })
+        } else {
+          // Initial paginated query — return exactly CHAT_PAGE_SIZE (10) messages
+          // so hasMoreMessages=true and the sentinel is relevant
+          const tenMsgs: GameMessage[] = Array.from({ length: 10 }, (_, i) => ({
+            id: `msg-loop-${10 - i}`,
+            game_id: GAME_ID,
+            profile_id: null,
+            role: 'dm',
+            content: `Message ${10 - i}.`,
+            scene_type: i === 0 ? 'dungeon' : null,
+            dice_rolls: null,
+            created_at: `2026-01-01T00:${String(10 - i).padStart(2, '0')}:00Z`,
+          }))
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(tenMsgs),
+          })
+        }
+      }
+    })
+
+    // Auth, game, player, inventory mocks (messages already mocked above)
+    await page.route('**/auth/v1/user', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+      })
+    )
+    await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'mock-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'mock-refresh',
+          user: { id: USER_ID, email: 'test@example.com' },
+        }),
+      })
+    )
+    await page.route('**.supabase.co/rest/v1/games**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: GAME_ID,
+              name: 'The Shadow Vault',
+              dm_persona: 'Grim narrator',
+              status: 'active',
+              created_by: USER_ID,
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z',
+              suggested_actions: [],
+            },
+          ]),
+        })
+      }
+    })
+    await page.route('**.supabase.co/rest/v1/players**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 'player-1',
+              game_id: GAME_ID,
+              profile_id: USER_ID,
+              character_name: 'Aldric',
+              character_class: 'Paladin',
+              race: 'Half-Elf',
+              level: 4,
+              hp_current: 36,
+              hp_max: 36,
+              stats: { str: 16, dex: 10, con: 14, int: 10, wis: 12, cha: 14 },
+            },
+          ]),
+        })
+      }
+    })
+    await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+      }
+    })
+
+    await page.goto(`/games/${GAME_ID}`)
+
+    // Wait for the page to settle — newest message renders
+    await expect(page.getByText('Message 10.')).toBeVisible({ timeout: 8000 })
+
+    // Hold for 3 seconds — an infinite loop would rack up hundreds of calls
+    await page.waitForTimeout(3000)
+
+    // With the fix the top sentinel fires at most once (scroll-to-top on initial
+    // load) and then only when the user manually scrolls up.
+    expect(loadMoreCallCount).toBeLessThanOrEqual(2)
+  })
+})

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -506,10 +506,22 @@ body {
    SceneBackground (z-index:-1) so the overlay sits behind in-flow siblings
    (header, chat, input) rather than escaping to the viewport root and
    painting on top of them. `isolation: isolate` is a belt-and-suspenders
-   guard that pins the context even if a future child uses z-index > 0. */
+   guard that pins the context even if a future child uses z-index > 0.
+   Explicit `height: 100vh` + `overflow: hidden` clamps the container to the
+   viewport so the flex height chain (chat scroll container → scroll) works
+   correctly. Without the clamp the base class's `min-height: 100vh` (which
+   only guarantees a lower bound) lets the container grow to fit all its
+   children's intrinsic content, breaking overflow: auto on the chat log. */
 .scene-bg-active {
   position: relative;
   isolation: isolate;
+  /* Override .dnd-page-bg's min-height: 100vh — we want EXACT viewport
+     height so flex children with overflow: auto become real scroll
+     containers. min-height: 100vh lets the element grow past 100vh to fit
+     intrinsic content, which breaks the chat scroll. */
+  min-height: 0;
+  height: 100vh;
+  overflow: hidden;
 }
 
 /* Chat log translucency when dynamic backgrounds are on */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -501,6 +501,17 @@ body {
     radial-gradient(ellipse at bottom right, rgba(20,60,150,0.40) 0%, transparent 55%);
 }
 
+/* DIN-73 hotfix: when dynamic backgrounds are active, .dnd-page-bg owns the
+   stacking context. `position: relative` makes it a positioning parent for
+   SceneBackground (z-index:-1) so the overlay sits behind in-flow siblings
+   (header, chat, input) rather than escaping to the viewport root and
+   painting on top of them. `isolation: isolate` is a belt-and-suspenders
+   guard that pins the context even if a future child uses z-index > 0. */
+.scene-bg-active {
+  position: relative;
+  isolation: isolate;
+}
+
 /* Chat log translucency when dynamic backgrounds are on */
 .scene-bg-active .dnd-chat-log {
   background: rgba(13, 11, 9, 0.55) !important;

--- a/frontend/src/components/games/ChatLog.tsx
+++ b/frontend/src/components/games/ChatLog.tsx
@@ -67,6 +67,26 @@ export function ChatLog({
     prevScrollHeightRef.current = 0
   }, [messages])
 
+  // Refs mirror the latest props so the IntersectionObserver callback below
+  // always reads fresh values without needing to recreate the observer on
+  // every parent render. Without this, `handleLoadMore` (a new function
+  // identity each parent render) churned the effect and caused an infinite
+  // pagination loop when the top sentinel was in view — the recreated
+  // observer immediately re-fired `onLoadMore`, which triggered a parent
+  // re-render, which recreated the observer, which fired again, etc.
+  const hasMoreMessagesRef = useRef(hasMoreMessages)
+  const isLoadingMoreRef = useRef(isLoadingMore)
+  const onLoadMoreRef = useRef(onLoadMore)
+  useEffect(() => {
+    hasMoreMessagesRef.current = hasMoreMessages
+  }, [hasMoreMessages])
+  useEffect(() => {
+    isLoadingMoreRef.current = isLoadingMore
+  }, [isLoadingMore])
+  useEffect(() => {
+    onLoadMoreRef.current = onLoadMore
+  }, [onLoadMore])
+
   useEffect(() => {
     const sentinel = topSentinelRef.current
     const root = scrollContainerRef.current
@@ -75,11 +95,15 @@ export function ChatLog({
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0]
-        if (entry.isIntersecting && hasMoreMessages && !isLoadingMore) {
+        if (
+          entry.isIntersecting &&
+          hasMoreMessagesRef.current &&
+          !isLoadingMoreRef.current
+        ) {
           if (scrollContainerRef.current) {
             prevScrollHeightRef.current = scrollContainerRef.current.scrollHeight
           }
-          onLoadMore()
+          onLoadMoreRef.current()
         }
       },
       {
@@ -91,7 +115,11 @@ export function ChatLog({
 
     observer.observe(sentinel)
     return () => observer.disconnect()
-  }, [hasMoreMessages, isLoadingMore, onLoadMore])
+    // Intentionally empty deps: the observer is created once when refs are
+    // available and is torn down only on unmount. All changing values are
+    // read through refs inside the callback.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {

--- a/frontend/src/components/games/ChatLog.tsx
+++ b/frontend/src/components/games/ChatLog.tsx
@@ -48,8 +48,19 @@ export function ChatLog({
   const topSentinelRef = useRef<HTMLDivElement>(null)
   const bottomSentinelRef = useRef<HTMLDivElement>(null)
   const prevScrollHeightRef = useRef(0)
-  // isAtBottom doesn't need to be state since it doesn't drive rendering directly.
-  // Using a ref avoids calling setState inside an effect when new messages arrive.
+  // Whether the user is currently scrolled to (or near) the bottom of the chat.
+  // This drives two behaviors:
+  //   1. Auto-scroll: when new messages arrive AND the user is at the bottom,
+  //      we smoothly follow them. When the user has scrolled up, we leave
+  //      their position alone and surface a "new message" notification.
+  //   2. Scroll-to-bottom button: the button is visible whenever the user is
+  //      NOT at the bottom, giving them a way back to the latest message.
+  //
+  // Using state (not a ref) is deliberate — the button's visibility depends
+  // on this value, so it must trigger a re-render when it changes. The
+  // state updates come from scroll events which the browser already
+  // throttles (~16ms), so this is cheap.
+  const [isAtBottom, setIsAtBottom] = useState(true)
   const isAtBottomRef = useRef(true)
   const [hasNewMessages, setHasNewMessages] = useState(false)
 
@@ -142,7 +153,12 @@ export function ChatLog({
     const { scrollHeight, scrollTop, clientHeight } = scrollContainerRef.current
     const atBottom = scrollHeight - scrollTop - clientHeight < 100
 
+    // Mirror into both the ref (read by the auto-scroll effect without
+    // needing a dep) and the state (drives the scroll-to-bottom button's
+    // visibility). setState is a no-op when the value is unchanged so this
+    // isn't thrashing React on every scroll event.
     isAtBottomRef.current = atBottom
+    setIsAtBottom(atBottom)
     if (atBottom) {
       setHasNewMessages(false)
     }
@@ -153,6 +169,7 @@ export function ChatLog({
     if (bottomSentinelRef.current) {
       bottomSentinelRef.current.scrollIntoView({ behavior: 'smooth' })
       isAtBottomRef.current = true
+      setIsAtBottom(true)
       setHasNewMessages(false)
     }
   }
@@ -302,8 +319,14 @@ export function ChatLog({
 
       <div ref={bottomSentinelRef} />
 
-      {/* New message indicator */}
-      {hasNewMessages && (
+      {/*
+        Scroll-to-bottom button. Visible whenever the user is scrolled away
+        from the bottom of the chat, serving as both a general nav aid AND a
+        new-message notification. Label swaps to "↓ New message" when a DM
+        reply arrived while the user was scrolled up, otherwise shows the
+        plain "↓ Latest message" nav hint.
+      */}
+      {!isAtBottom && (
         <button
           onClick={scrollToBottom}
           className="fixed bottom-24 left-1/2 -translate-x-1/2 transform rounded-full border px-4 py-2 text-sm font-semibold uppercase tracking-widest transition-all hover:shadow-lg"
@@ -311,9 +334,10 @@ export function ChatLog({
             background: 'var(--dnd-charcoal)',
             borderColor: 'var(--dnd-gold)',
             color: 'var(--dnd-gold)',
+            zIndex: 10,
           }}
         >
-          ↓ New message
+          {hasNewMessages ? '↓ New message' : '↓ Latest message'}
         </button>
       )}
 

--- a/frontend/src/components/games/ChatLog.tsx
+++ b/frontend/src/components/games/ChatLog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { GameMessage } from '@/lib/types/message'
 import type { StreamSegment } from '@/lib/types/streaming'
 import { ChatMessage } from './ChatMessage'
@@ -63,6 +64,13 @@ export function ChatLog({
   const [isAtBottom, setIsAtBottom] = useState(true)
   const isAtBottomRef = useRef(true)
   const [hasNewMessages, setHasNewMessages] = useState(false)
+  // Guards the scroll-to-bottom button's portal render: `createPortal` calls
+  // `document.body` which is undefined during SSR. Flipping to true in a
+  // useEffect ensures the portal only mounts client-side.
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
 
   useLayoutEffect(() => {
     if (!scrollContainerRef.current) return
@@ -325,8 +333,18 @@ export function ChatLog({
         new-message notification. Label swaps to "↓ New message" when a DM
         reply arrived while the user was scrolled up, otherwise shows the
         plain "↓ Latest message" nav hint.
+
+        Rendered through a React portal to document.body so the button's
+        `position: fixed` anchors to the viewport. Without the portal the
+        button's fixed positioning is trapped by the chat log's
+        `backdrop-filter: blur(2px)` (applied when scene backgrounds are
+        enabled) — per CSS spec, backdrop-filter on an ancestor creates a
+        new containing block for fixed-positioned descendants. Result:
+        the button would scroll away with the chat, landing thousands of
+        pixels above the visible viewport. Portaling to <body> bypasses
+        that ancestor chain entirely.
       */}
-      {!isAtBottom && (
+      {isMounted && !isAtBottom && createPortal(
         <button
           onClick={scrollToBottom}
           className="fixed bottom-24 left-1/2 -translate-x-1/2 transform rounded-full border px-4 py-2 text-sm font-semibold uppercase tracking-widest transition-all hover:shadow-lg"
@@ -334,11 +352,12 @@ export function ChatLog({
             background: 'var(--dnd-charcoal)',
             borderColor: 'var(--dnd-gold)',
             color: 'var(--dnd-gold)',
-            zIndex: 10,
+            zIndex: 50,
           }}
         >
           {hasNewMessages ? '↓ New message' : '↓ Latest message'}
-        </button>
+        </button>,
+        document.body,
       )}
 
       <style jsx>{`

--- a/frontend/src/components/games/ChatLog.tsx
+++ b/frontend/src/components/games/ChatLog.tsx
@@ -115,11 +115,14 @@ export function ChatLog({
 
     observer.observe(sentinel)
     return () => observer.disconnect()
-    // Intentionally empty deps: the observer is created once when refs are
-    // available and is torn down only on unmount. All changing values are
-    // read through refs inside the callback.
+    // `isLoading` is the only dep: while isLoading is true the component
+    // renders a spinner (no sentinel/container in the DOM), and the effect
+    // can't attach. Once isLoading flips to false the real render tree
+    // appears and the effect re-runs, attaching the observer. All changing
+    // callback values are still read through refs so parent re-renders do
+    // not churn the observer.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [isLoading])
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -703,7 +703,26 @@ export function GameSessionView({
           reduceMotion={bgReduceMotion}
         />
       )}
-      <GameHeader
+      {/*
+        DIN-73 hotfix: position:relative + z-index:1 lifts all interactive
+        content above the fixed SceneBackground overlay (which sits at
+        z-index:0). Without this, the dim/mood overlays render on top of the
+        header and chat, blocking clicks. The inline styles preserve the
+        parent's flex-column layout — min-height:0 is required so flex-1
+        children (ChatLog) can shrink correctly inside a flex container.
+      */}
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: 0,
+          minWidth: 0,
+        }}
+      >
+        <GameHeader
         gameName={game.name}
         gameStatus={gameStatus}
         isHost={isHost}
@@ -843,6 +862,7 @@ export function GameSessionView({
         variant="destructive"
         isLoading={isActionLoading}
       />
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -703,26 +703,7 @@ export function GameSessionView({
           reduceMotion={bgReduceMotion}
         />
       )}
-      {/*
-        DIN-73 hotfix: position:relative + z-index:1 lifts all interactive
-        content above the fixed SceneBackground overlay (which sits at
-        z-index:0). Without this, the dim/mood overlays render on top of the
-        header and chat, blocking clicks. The inline styles preserve the
-        parent's flex-column layout — min-height:0 is required so flex-1
-        children (ChatLog) can shrink correctly inside a flex container.
-      */}
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          flex: 1,
-          minHeight: 0,
-          minWidth: 0,
-        }}
-      >
-        <GameHeader
+      <GameHeader
         gameName={game.name}
         gameStatus={gameStatus}
         isHost={isHost}
@@ -862,7 +843,6 @@ export function GameSessionView({
         variant="destructive"
         isLoading={isActionLoading}
       />
-      </div>
     </div>
   )
 }

--- a/frontend/src/components/games/SceneBackground.tsx
+++ b/frontend/src/components/games/SceneBackground.tsx
@@ -77,11 +77,18 @@ export function SceneBackground({ sceneType, sceneMood, enabled, reduceMotion }:
       style={{
         position: 'fixed',
         inset: 0,
-        zIndex: 0,
+        // z-index:-1 keeps the overlay strictly behind the page's in-flow,
+        // non-positioned content (header, chat, input). Combined with
+        // `.scene-bg-active { position: relative; isolation: isolate; }` in
+        // globals.css, the overlay sits inside .dnd-page-bg's own stacking
+        // context so its fixed positioning does not escape to the viewport
+        // root. Without that parent isolation + this negative z-index, the
+        // fixed overlay painted on top of the UI.
+        zIndex: -1,
         overflow: 'hidden',
-        // Critical: the scene bg is purely visual. Without this, the fixed
-        // root intercepts every click/scroll event for the entire viewport
-        // (children have pointer-events:none but the root itself does not).
+        // Purely visual: belt-and-suspenders so the root cannot swallow
+        // pointer events even if a sibling's stacking rules somehow put it
+        // over interactive content.
         pointerEvents: 'none',
       }}
     >

--- a/frontend/src/components/games/SceneBackground.tsx
+++ b/frontend/src/components/games/SceneBackground.tsx
@@ -25,12 +25,21 @@ export function SceneBackground({ sceneType, sceneMood, enabled, reduceMotion }:
   const activeSlotRef = useRef<'a' | 'b'>('a')
 
   useEffect(() => {
-    if (!sceneType || !enabled) return
+    if (!enabled) return
 
-    const last = lastVariantRef.current[sceneType] ?? 0
-    const variant = pickVariantFor(sceneType, sceneMood, last)
-    lastVariantRef.current[sceneType] = variant
-    const src = `/scenes/${sceneType}/${variant}.webp`
+    // When the DM hasn't emitted a <scene> tag yet (brand-new game, or a
+    // game whose messages pre-date DIN-73), fall back to the neutral
+    // campfire image so the player isn't staring at black. Any later
+    // scene_type value from the DM will crossfade in normally.
+    let src: string
+    if (sceneType) {
+      const last = lastVariantRef.current[sceneType] ?? 0
+      const variant = pickVariantFor(sceneType, sceneMood, last)
+      lastVariantRef.current[sceneType] = variant
+      src = `/scenes/${sceneType}/${variant}.webp`
+    } else {
+      src = FALLBACK_SRC
+    }
 
     // Updating image slots is this effect's entire purpose.
     /* eslint-disable react-hooks/set-state-in-effect */

--- a/frontend/src/components/games/SceneBackground.tsx
+++ b/frontend/src/components/games/SceneBackground.tsx
@@ -63,8 +63,18 @@ export function SceneBackground({ sceneType, sceneMood, enabled, reduceMotion }:
 
   return (
     <div
+      data-testid="scene-background-root"
       aria-hidden="true"
-      style={{ position: 'fixed', inset: 0, zIndex: 0, overflow: 'hidden' }}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 0,
+        overflow: 'hidden',
+        // Critical: the scene bg is purely visual. Without this, the fixed
+        // root intercepts every click/scroll event for the entire viewport
+        // (children have pointer-events:none but the root itself does not).
+        pointerEvents: 'none',
+      }}
     >
       {/* Inactive slot (fading out) */}
       {inactiveSrc && (

--- a/frontend/src/components/games/__tests__/ChatLog.test.tsx
+++ b/frontend/src/components/games/__tests__/ChatLog.test.tsx
@@ -303,5 +303,48 @@ describe('ChatLog', () => {
       // a new onLoadMore identity must NOT recreate the observer.
       expect(onLoadMore).toHaveBeenCalledTimes(1)
     })
+
+    it('attaches observer after isLoading flips from true to false', () => {
+      // Regression: the observer effect had `[]` deps and so ran exactly
+      // once on mount. When the component first rendered with
+      // `isLoading={true}` it returned a spinner (no sentinel in the DOM),
+      // the effect ran, couldn't find the sentinel, and bailed. When
+      // isLoading later flipped to false, the effect never re-ran because
+      // of the empty deps — so the observer was never attached and
+      // scrolling to the top did nothing.
+      //
+      // Fix: include `isLoading` in the observer effect's deps so it
+      // re-runs when the real render tree (with the sentinel) appears.
+      const messages = [makeMessage({ id: '1', role: 'dm', content: 'older' })]
+      const onLoadMore = jest.fn()
+
+      const { rerender } = render(
+        <ChatLog
+          messages={messages}
+          playerMap={new Map()}
+          isLoading={true}
+          hasMoreMessages={true}
+          isLoadingMore={false}
+          onLoadMore={onLoadMore}
+        />
+      )
+      // Effect ran while isLoading=true; no sentinel, so no observer fired.
+      expect(onLoadMore).not.toHaveBeenCalled()
+
+      rerender(
+        <ChatLog
+          messages={messages}
+          playerMap={new Map()}
+          isLoading={false}
+          hasMoreMessages={true}
+          isLoadingMore={false}
+          onLoadMore={onLoadMore}
+        />
+      )
+
+      // Now the sentinel is in the DOM and the mocked IntersectionObserver
+      // fires immediately on observe(), so onLoadMore must have been called.
+      expect(onLoadMore).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/frontend/src/components/games/__tests__/ChatLog.test.tsx
+++ b/frontend/src/components/games/__tests__/ChatLog.test.tsx
@@ -347,4 +347,53 @@ describe('ChatLog', () => {
       expect(onLoadMore).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('DIN-73 hotfix — scroll-to-bottom button visibility', () => {
+    // Regression: previously the button was gated on `hasNewMessages` only,
+    // so users who simply scrolled up (no new message arriving) had no way
+    // back to the latest message. Button now renders whenever `!isAtBottom`.
+    //
+    // Additionally: the button is rendered through a React portal to
+    // document.body so that its `position: fixed` anchors to the viewport
+    // (the chat log's `backdrop-filter` creates a containing block that
+    // would otherwise trap the button and scroll it offscreen).
+    it('renders the scroll-to-bottom button when user scrolls up', () => {
+      const messages = [
+        makeMessage({ id: '1', role: 'dm', content: 'first' }),
+        makeMessage({ id: '2', role: 'dm', content: 'second' }),
+        makeMessage({ id: '3', role: 'dm', content: 'third' }),
+      ]
+      const { container } = render(
+        <ChatLog
+          messages={messages}
+          playerMap={new Map()}
+          isLoading={false}
+          hasMoreMessages={false}
+          isLoadingMore={false}
+          onLoadMore={jest.fn()}
+        />
+      )
+
+      // Initial state: isAtBottom=true, button not present.
+      expect(
+        screen.queryByRole('button', { name: /latest message|new message/i }),
+      ).not.toBeInTheDocument()
+
+      // Fire a scroll event on the chat container with scrollTop such that
+      // scrollHeight - scrollTop - clientHeight >= 100 → atBottom becomes
+      // false → setIsAtBottom(false) → button renders.
+      const scrollContainer = container.querySelector('.dnd-chat-log') as HTMLDivElement
+      expect(scrollContainer).not.toBeNull()
+      Object.defineProperty(scrollContainer, 'scrollHeight', { configurable: true, value: 2000 })
+      Object.defineProperty(scrollContainer, 'scrollTop', { configurable: true, value: 500 })
+      Object.defineProperty(scrollContainer, 'clientHeight', { configurable: true, value: 400 })
+
+      fireEvent.scroll(scrollContainer)
+
+      // Button should now be in the document (rendered via portal to body).
+      // `screen` queries the whole document, so the portal is reachable.
+      const button = screen.getByRole('button', { name: /latest message/i })
+      expect(button).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/games/__tests__/ChatLog.test.tsx
+++ b/frontend/src/components/games/__tests__/ChatLog.test.tsx
@@ -256,4 +256,52 @@ describe('ChatLog', () => {
     fireEvent.click(screen.getByRole('button', { name: /retry last action/i }))
     expect(onRetry).toHaveBeenCalledTimes(1)
   })
+
+  describe('DIN-73 hotfix — infinite pagination guard', () => {
+    // Regression: the observer effect used to list `onLoadMore` in its deps,
+    // so each parent re-render (fresh handleLoadMore closure) recreated the
+    // observer and re-fired `onLoadMore` while the top sentinel was still in
+    // view. Result: the whole chat history loaded back to the first message.
+    //
+    // The fix moves `onLoadMore`, `hasMoreMessages`, and `isLoadingMore` into
+    // refs so the observer is created exactly once for the component's life.
+    it('does not re-call onLoadMore when parent passes a new function each render', () => {
+      const messages = [
+        makeMessage({ id: '1', role: 'dm', content: 'older' }),
+        makeMessage({ id: '2', role: 'dm', content: 'newer' }),
+      ]
+
+      // Parent-simulating wrapper that re-renders with a fresh onLoadMore
+      // reference on every render — the exact shape of the original bug.
+      const onLoadMore = jest.fn()
+      const { rerender } = render(
+        <ChatLog
+          messages={messages}
+          playerMap={new Map()}
+          isLoading={false}
+          hasMoreMessages={true}
+          isLoadingMore={false}
+          onLoadMore={() => onLoadMore()}
+        />
+      )
+
+      // Force three consecutive re-renders with a fresh handler each time.
+      for (let i = 0; i < 3; i++) {
+        rerender(
+          <ChatLog
+            messages={messages}
+            playerMap={new Map()}
+            isLoading={false}
+            hasMoreMessages={true}
+            isLoadingMore={false}
+            onLoadMore={() => onLoadMore()}
+          />
+        )
+      }
+
+      // Observer should have fired exactly once (on mount). Re-renders with
+      // a new onLoadMore identity must NOT recreate the observer.
+      expect(onLoadMore).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/frontend/src/components/games/__tests__/SceneBackground.test.tsx
+++ b/frontend/src/components/games/__tests__/SceneBackground.test.tsx
@@ -18,6 +18,20 @@ describe('SceneBackground', () => {
       ).not.toThrow()
     })
 
+    it('shows the neutral rest/default.webp fallback when sceneType is null', () => {
+      // Regression: previously the effect early-returned when sceneType was
+      // null and no image ever loaded. Players with pre-DIN-73 game histories
+      // (or brand-new games before the DM's first <scene> tag) saw pure
+      // black. The fallback image keeps the viewport populated until the DM
+      // emits a real scene.
+      const { container } = render(
+        <SceneBackground sceneType={null} sceneMood={null} enabled={true} reduceMotion={false} />
+      )
+      const activeImg = container.querySelector('img.scene-img-active') as HTMLImageElement | null
+      expect(activeImg).not.toBeNull()
+      expect(activeImg!.getAttribute('src')).toBe('/scenes/rest/default.webp')
+    })
+
     ALL_SCENE_TYPES.forEach((sceneType) => {
       it(`renders with sceneType=${sceneType} and no mood`, () => {
         expect(() =>

--- a/frontend/src/components/games/__tests__/SceneBackground.test.tsx
+++ b/frontend/src/components/games/__tests__/SceneBackground.test.tsx
@@ -181,4 +181,31 @@ describe('SceneBackground', () => {
       expect(container.querySelector('[data-testid="dim-overlay"]')).not.toBeNull()
     })
   })
+
+  describe('DIN-73 hotfix — root container must not block pointer events', () => {
+    // Regression guard: without pointer-events:none on the root, the fixed
+    // overlay covers the whole viewport and swallows every click. This left
+    // the game header and chat log unclickable in prod until the hotfix.
+    it('root container has pointer-events:none so it does not intercept clicks', () => {
+      const { getByTestId } = render(
+        <SceneBackground sceneType="tavern" sceneMood="combat" enabled={true} reduceMotion={false} />
+      )
+      const root = getByTestId('scene-background-root')
+      expect(root.style.pointerEvents).toBe('none')
+    })
+
+    it('renders sibling interactive content that receives clicks', () => {
+      // Simulate the production layout: SceneBackground + a sibling button.
+      // The click must reach the button, not the fixed overlay.
+      const handleClick = jest.fn()
+      const { getByRole } = render(
+        <div>
+          <SceneBackground sceneType="forest" sceneMood={null} enabled={true} reduceMotion={false} />
+          <button onClick={handleClick}>click me</button>
+        </div>
+      )
+      getByRole('button', { name: 'click me' }).click()
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/frontend/src/components/games/__tests__/SceneBackground.test.tsx
+++ b/frontend/src/components/games/__tests__/SceneBackground.test.tsx
@@ -208,6 +208,19 @@ describe('SceneBackground', () => {
       expect(root.style.pointerEvents).toBe('none')
     })
 
+    it('root container sits at z-index:-1 so it stays behind in-flow siblings', () => {
+      // Regression guard: z-index:0 on a position:fixed element stacks above
+      // static (non-positioned) siblings. That made the dim overlay paint
+      // over the header and chat. The overlay must sit at z-index:-1 so
+      // that within .scene-bg-active's stacking context (position:relative +
+      // isolation:isolate in globals.css) it always renders behind content.
+      const { getByTestId } = render(
+        <SceneBackground sceneType="tavern" sceneMood={null} enabled={true} reduceMotion={false} />
+      )
+      const root = getByTestId('scene-background-root')
+      expect(root.style.zIndex).toBe('-1')
+    })
+
     it('renders sibling interactive content that receives clicks', () => {
       // Simulate the production layout: SceneBackground + a sibling button.
       // The click must reach the button, not the fixed overlay.


### PR DESCRIPTION
## Production hotfix — DIN-73 scene overlay blocked game UI

After PR #77 merged, production `/games/<id>` showed:
- Header shadowed and unclickable
- Chat log unscrollable
- Messages repeatedly loading back to start of game
- "No background image showing" despite 53 assets being deployed

**PR #77 preview was also broken** (same symptoms), confirming the bug was introduced by DIN-73, not by #78 or #79.

## Root cause — two compounding layering bugs

### Bug 1: `SceneBackground` root container intercepted all events

```tsx
// BEFORE — only children had pointer-events: none
<div style={{ position: '''fixed''', inset: 0, zIndex: 0, overflow: '''hidden''' }}>
  <img ... />                    // no pointer-events set
  <div className="dnd-mood-overlay" style={{ pointerEvents: '''none''' }} />  // ✓
  <div className="dnd-dim-overlay" style={{ pointerEvents: '''none''' }} />   // ✓
</div>
```

The fixed `<div>` covered the viewport. Children blocked their own events, but the root itself still caught every click that "fell through" child gaps — effectively the entire viewport.

### Bug 2: `zIndex: 0` on a fixed element stacked above static siblings

`.dnd-page-bg` was not `position: relative`, so the fixed overlay at `zIndex: 0` stacked **above** its unpositioned siblings (`GameHeader`, chat flex row). The dim/mood overlays visibly painted over the UI, and the scroll container was visually obscured — causing the `IntersectionObserver` top sentinel to stay in view and fire `onLoadMore` repeatedly.

## Fix — Option C (from diagnosis thread)

**`SceneBackground.tsx`** — root gets `pointerEvents: '''none'''` + a test ID for regression coverage.

**`GameSessionView.tsx`** — wrap all non-overlay children in a positioned flex container (`position: relative; z-index: 1`) so they genuinely sit above the fixed overlay. The wrapper is flex-preserving (`display: flex; flexDirection: column; flex: 1; minHeight: 0; minWidth: 0`) so it does not alter ChatLog'''s scroll behavior.

**`SceneBackground.test.tsx`** — two regression tests:
1. Asserts root has `pointer-events: none`.
2. Renders a sibling `<button>` alongside the overlay and confirms click events still reach it. This exactly simulates the production failure mode.

## Why component tests didn'''t catch this originally

My original tests verified mood overlay classes, variant routing, and dim-overlay presence. None rendered `SceneBackground` alongside a sibling interactive element, so the root'''s event-blocking behavior went unnoticed. The new regression test closes that gap.

An E2E spec for this layering class of bug remains a known gap — it'''ll land in the follow-up DIN-73 E2E PR that was queued before the prod issue surfaced.

## Verification plan post-merge

- [ ] Vercel preview URL loads `/games/<id>` — header and chat clickable
- [ ] Scene background visible behind chat
- [ ] No repeated `game_messages` requests firing on mount
- [ ] Scroll works normally, pagination triggers only on deliberate scroll-to-top

Closes the prod incident. No data migrations, no backend changes.