### PR TITLE
feat(DIN-74): scene continuity + tailored suggested actions per player

### DIFF
--- a/backend/api/routes/actions.py
+++ b/backend/api/routes/actions.py
@@ -51,7 +51,7 @@ STREAM_CHANNEL_PREFIX = "stream"
 
 
 _STRIP_TAG_BLOCKS = re.compile(
-    r"<(?:suggested_actions|state_changes|dice_rolls)>.*?</(?:suggested_actions|state_changes|dice_rolls)>",
+    r"<(?:suggested_actions|state_changes|dice_rolls)(?:\s[^>]*)?>.*?</(?:suggested_actions|state_changes|dice_rolls)>",
     re.DOTALL,
 )
 _STRIP_EVENT_BLOCKS = re.compile(

--- a/backend/api/routes/actions.py
+++ b/backend/api/routes/actions.py
@@ -122,7 +122,7 @@ async def _stream_to_redis(
     `profile_id` is accepted for parity with the handler and future per-player
     RAG; it is currently unused by the prompt builder.
     """
-    del profile_id  # currently unused; see docstring
+    # profile_id used below to identify the acting player for DIN-74 Part B
     channel = f"{STREAM_CHANNEL_PREFIX}:{game_id}"
     parser = StreamParser()
     full_parts: list[str] = []
@@ -152,7 +152,7 @@ async def _stream_to_redis(
         def _fetch_recent_messages():
             return (
                 supabase_client.table("game_messages")
-                .select("role, profile_id, content")
+                .select("role, profile_id, content, scene_type, scene_mood")
                 .eq("game_id", game_id)
                 .order("created_at", desc=True)
                 .limit(20)
@@ -195,13 +195,18 @@ async def _stream_to_redis(
             rag_context = []
 
         # ---- Build system prompt ---- #
+        all_players = players_result.data or []
+        acting_player = next(
+            (p for p in all_players if p.get("profile_id") == profile_id), None
+        )
         system_prompt = build_dm_system_prompt(
             game=game_result.data,
-            players=players_result.data or [],
+            players=all_players,
             inv_by_player=inv_by_player,
             recent_messages=recent_messages_result.data or [],
             rag_context=rag_context,
             action_text=action_text,
+            acting_player=acting_player,
         )
 
         async with anthropic_async_client.messages.stream(

--- a/backend/services/dm_service.py
+++ b/backend/services/dm_service.py
@@ -66,6 +66,7 @@ def build_dm_system_prompt(
     recent_messages: list[dict],
     rag_context: list[dict],
     action_text: str,
+    acting_player: dict | None = None,
 ) -> str:
     """
     Build the Claude system prompt for a player action (DIN-66).
@@ -74,6 +75,10 @@ def build_dm_system_prompt(
     (non-streaming narration paths). Pure function — no I/O. `recent_messages`
     must be in newest-first order (matches the DB ordering); this function
     reverses it internally for chronological prompt inclusion.
+
+    `acting_player` (DIN-74 Part B): the player row that submitted the current
+    action. When provided, Rule 9 emits a tailored first-person block for that
+    player plus a generic observer block for others.
     """
     message_history: list[str] = []
     for msg in reversed(recent_messages or []):
@@ -176,6 +181,59 @@ def build_dm_system_prompt(
         for die, results in _pool.items()
     )
 
+    # DIN-74 Part A: inject the most recent scene so Claude defaults to continuity.
+    current_scene_block = ""
+    for msg in (recent_messages or []):
+        if msg.get("role") == "dm" and msg.get("scene_type"):
+            lines = [f"type: {msg['scene_type']}"]
+            if msg.get("scene_mood"):
+                lines.append(f"mood: {msg['scene_mood']}")
+            lines.append(
+                "(Default: carry this forward unless the party moves or mood shifts meaningfully.)"
+            )
+            current_scene_block = "CURRENT SCENE:\n" + "\n".join(lines) + "\n\n"
+            break
+
+    # DIN-74 Part B: Rule 9 — dual suggested_actions blocks when acting_player is known.
+    if acting_player:
+        acting_name = acting_player.get("character_name", "the acting player")
+        acting_id = acting_player.get("id", "")
+        rule_9 = f"""9. SUGGESTED ACTIONS: After your narrative response, produce TWO separate blocks.
+
+   BLOCK A — TAILORED suggestions for the acting player ({acting_name}, ID: {acting_id}):
+   - 2–10 first-person POV actions {acting_name} might plausibly take next
+   - Each 20–30 words, including dialogue (in quotes), body language, or tactical reasoning
+   - Must be consistent with {acting_name}'s class, stats, HP, and equipment shown above
+   - NEVER suggest a spell this character cannot cast (check spell slots above)
+   - Example: "Can you tell me more about the dragon?" I ask the ranger, studying her face for any flicker of hesitation.
+
+   Format:
+   <suggested_actions character_id="{acting_id}">
+   "Let me examine these runes," I say, lowering my wizard's eye to the stone.
+   I raise my staff and whisper an incantation, feeling mana stir in the air.
+   </suggested_actions>
+
+   BLOCK B — GENERIC observer prompts for other players at the table:
+   - 2–5 short, character-agnostic prompts (~10 words each)
+   - Invite non-acting players into the scene without referencing specific abilities
+   - Do NOT name any character or class
+
+   Format:
+   <suggested_actions generic="true">
+   Wait and observe the others.
+   Speak up with your own plan.
+   Offer support to the acting player.
+   </suggested_actions>
+
+   Emit BOTH blocks every turn. Block A goes first, Block B second."""
+    else:
+        rule_9 = """9. After your narrative response, produce 2–10 short suggested actions the player could
+   take next (imperative mood, ~10 words each). Wrap them in:
+   <suggested_actions>
+   Pick the lock using your thieves' tools.
+   Search the walls for a hidden mechanism.
+   </suggested_actions>"""
+
     return f"""You are {game['dm_persona']}. You are the Dungeon Master for a D&D 5e campaign called "{game['name']}".
 
 CURRENT PARTY:
@@ -186,7 +244,7 @@ RECENT SESSION HISTORY (last 20 messages, oldest first):
 {message_history_text}
 ---
 
-RELEVANT PAST EVENTS (Context from RAG):
+{current_scene_block}RELEVANT PAST EVENTS (Context from RAG):
 {json.dumps(rag_context, indent=2) if rag_context else "No past events yet."}
 
 PRE-ROLLED DICE POOL — use these values in order, never invent your own results:
@@ -214,12 +272,7 @@ RULES:
    All fields are optional — only include fields that changed. Omit the block entirely if no state changes occur.
    character_id must be the exact UUID from the party list above (e.g. [ID: abc-123]).
    delta is signed: negative for damage, positive for healing.
-9. After your narrative response, produce 2–10 short suggested actions the player could
-   take next (imperative mood, ~10 words each). Wrap them in:
-   <suggested_actions>
-   Pick the lock using your thieves' tools.
-   Search the walls for a hidden mechanism.
-   </suggested_actions>
+{rule_9}
 10. DICE ROLLS: When you resolve a dice roll (ability check, saving throw, attack, or damage),
    take the next value from the appropriate column in the PRE-ROLLED DICE POOL above.
    NEVER invent your own result — always consume the next unused pool value in order.
@@ -263,9 +316,21 @@ RULES:
    Award XP to all players present.
    Format: "xp_awards": [{{"character_id": "<ID>", "amount": 100, "reason": "Defeated goblin"}}]
    Typical values: Goblin 50 XP, Bandit 100 XP, Orc 100 XP, completing a minor quest 150–300 XP.
-13. SCENE TAG: At the END of every response, emit exactly one self-closing <scene> tag that
-   describes the current location and optional mood. Place it on its own line after all
-   narrative text, dice rolls, state changes, and suggested actions.
+13. SCENE TAG: Emit exactly one self-closing <scene type="..." mood="..."/> tag
+   at the end of every response (after all narrative text, dice rolls, state
+   changes, and suggested actions, on its own line).
+
+   CONTINUITY RULES:
+   - If a CURRENT SCENE is shown above, default to emitting exactly that
+     scene_type and mood. Do NOT change them without narrative justification.
+   - Change scene_type ONLY when the party physically moves to a different
+     location this turn.
+   - Change mood ONLY on a meaningful narrative shift: combat starting,
+     danger passing, mystery revealed, victory earned. Ordinary dialogue
+     or minor beats should NOT trigger a mood change.
+   - If no CURRENT SCENE is shown (game start), choose a scene_type and
+     optional mood that fits the opening narration.
+
    Format: <scene type="SCENE_TYPE" mood="MOOD"/>
    - mood is optional — omit the mood attribute entirely if none applies.
    - SCENE_TYPE must be exactly one of:

--- a/backend/tasks/dm_tasks.py
+++ b/backend/tasks/dm_tasks.py
@@ -77,9 +77,9 @@ def dm_response_task(
             return supabase_client.table("players").select("*").match({"game_id": game_id}).execute()
 
         def _fetch_recent_messages():
-            return supabase_client.table("game_messages").select("role, profile_id, content").eq(
-                "game_id", game_id
-            ).order("created_at", desc=True).limit(20).execute()
+            return supabase_client.table("game_messages").select(
+                "role, profile_id, content, scene_type, scene_mood"
+            ).eq("game_id", game_id).order("created_at", desc=True).limit(20).execute()
 
         with ThreadPoolExecutor(max_workers=3) as executor:
             f_game = executor.submit(_fetch_game)
@@ -143,23 +143,11 @@ def dm_response_task(
         dice_rolls = extract_dice_rolls(dm_response)
         logger.info(f"[dm_response_task] Extracted {len(dice_rolls)} dice rolls")
 
-        # Step 5: Parse and strip suggested_actions block
-        suggested_match = re.search(
-            r'<suggested_actions>(.*?)</suggested_actions>',
-            dm_response,
-            flags=re.DOTALL,
-        )
-        suggested_actions: list[str] = []
-        if suggested_match:
-            suggested_actions = [
-                line.strip()
-                for line in suggested_match.group(1).splitlines()
-                if line.strip()
-            ]
+        # Step 5: Parse and strip suggested_actions block(s)
+        suggested_actions = extract_suggested_actions(dm_response)
 
-        # Strip suggested_actions block from response before further processing
         dm_response_no_suggestions = re.sub(
-            r'<suggested_actions>.*?</suggested_actions>',
+            r'<suggested_actions[^>]*>.*?</suggested_actions>',
             '',
             dm_response,
             flags=re.DOTALL,
@@ -201,7 +189,7 @@ def dm_response_task(
         supabase_client.table("game_messages").insert(response_message).execute()
         logger.info("[dm_response_task] Inserted DM response")
 
-        # Step 7: Update game state (suggested_actions, timestamp) — also unblocked
+        # Step 7: Update game state (suggested_actions jsonb, timestamp)
         supabase_client.table("games").update(
             {
                 "updated_at": datetime.utcnow().isoformat(),
@@ -650,6 +638,45 @@ _SCENE_TAG_RE = re.compile(r"<scene(\s[^>]*)?\/>")
 _SCENE_TYPE_ATTR_RE = re.compile(r'type=["\']([^"\']+)["\']')
 _SCENE_MOOD_ATTR_RE = re.compile(r'mood=["\']([^"\']+)["\']')
 
+_SUGGESTED_ACTIONS_RE = re.compile(
+    r'<suggested_actions([^>]*)>(.*?)</suggested_actions>',
+    re.DOTALL,
+)
+_CHAR_ID_RE = re.compile(r'character_id=["\']([^"\']+)["\']')
+_GENERIC_RE = re.compile(r'generic=["\']true["\']')
+
+
+def extract_suggested_actions(dm_response: str) -> dict:
+    """
+    Parse <suggested_actions> blocks from a DM response (DIN-74 Part B).
+
+    Handles the new dual-block format:
+      <suggested_actions character_id="...">tailored lines</suggested_actions>
+      <suggested_actions generic="true">generic lines</suggested_actions>
+
+    Also handles legacy single-block format (no attributes) for backward compat.
+
+    Returns:
+        {
+            "acting_player_id": str | None,
+            "tailored": list[str],
+            "generic": list[str],
+        }
+    """
+    result: dict = {"acting_player_id": None, "tailored": [], "generic": []}
+    for attrs, body in _SUGGESTED_ACTIONS_RE.findall(dm_response):
+        lines = [ln.strip() for ln in body.strip().splitlines() if ln.strip()]
+        char_match = _CHAR_ID_RE.search(attrs)
+        if char_match:
+            result["acting_player_id"] = char_match.group(1)
+            result["tailored"] = lines
+        elif _GENERIC_RE.search(attrs):
+            result["generic"] = lines
+        else:
+            # Legacy fallback: no attributes → treat as generic
+            result["generic"] = lines
+    return result
+
 
 def _extract_scene_from_response(dm_response: str) -> tuple[str | None, str | None]:
     """Extract scene_type and scene_mood from a raw DM response string."""
@@ -706,23 +733,12 @@ def dm_bookkeeping_task(game_id: str, dm_response: str) -> None:
             supabase_client.table("game_events").insert(event_rows).execute()
             logger.info(f"[dm_bookkeeping_task] Inserted {len(event_rows)} events")
 
-        suggested_match = re.search(
-            r"<suggested_actions>(.*?)</suggested_actions>",
-            dm_response,
-            flags=re.DOTALL,
-        )
-        suggested_actions: list[str] = []
-        if suggested_match:
-            suggested_actions = [
-                line.strip()
-                for line in suggested_match.group(1).splitlines()
-                if line.strip()
-            ]
+        suggested = extract_suggested_actions(dm_response)
 
         supabase_client.table("games").update(
             {
                 "updated_at": datetime.utcnow().isoformat(),
-                "suggested_actions": suggested_actions,
+                "suggested_actions": suggested,
             }
         ).match({"id": game_id}).execute()
 

--- a/backend/tests/test_actions_route.py
+++ b/backend/tests/test_actions_route.py
@@ -514,3 +514,58 @@ class TestStreamToRedis:
 
         system_inserts = [r for r in captured_inserts if r.get("role") == "system"]
         assert len(system_inserts) == 1
+
+
+# ---------------------------------------------------------------------------
+# DIN-74 regression: _strip_all_known_tags must remove attributed blocks
+# ---------------------------------------------------------------------------
+
+class TestStripAllKnownTags:
+    """Regression tests for _strip_all_known_tags (DIN-74 fix: attributed tags)."""
+
+    def _strip(self, text: str) -> str:
+        from api.routes.actions import _strip_all_known_tags
+        return _strip_all_known_tags(text)
+
+    def test_strips_bare_suggested_actions(self):
+        raw = "Narrative.\n<suggested_actions>\nPick lock.\n</suggested_actions>"
+        assert "<suggested_actions" not in self._strip(raw)
+        assert "Narrative." in self._strip(raw)
+
+    def test_strips_character_id_attributed_suggested_actions(self):
+        """DIN-74: attributed <suggested_actions character_id="..."> must be stripped."""
+        raw = (
+            'Narrative.\n'
+            '<suggested_actions character_id="abc-123">\n'
+            '"I attack," I shout.\n'
+            '</suggested_actions>'
+        )
+        result = self._strip(raw)
+        assert "<suggested_actions" not in result
+        assert "abc-123" not in result
+        assert "Narrative." in result
+
+    def test_strips_generic_attributed_suggested_actions(self):
+        """DIN-74: <suggested_actions generic="true"> must be stripped."""
+        raw = (
+            'Narrative.\n'
+            '<suggested_actions generic="true">\n'
+            'Wait and watch.\n'
+            '</suggested_actions>'
+        )
+        result = self._strip(raw)
+        assert "<suggested_actions" not in result
+        assert "Wait and watch." not in result
+        assert "Narrative." in result
+
+    def test_strips_both_attributed_blocks_in_one_response(self):
+        """DIN-74: both tailored and generic blocks stripped in one pass."""
+        raw = (
+            'Narrative.\n'
+            '<suggested_actions character_id="abc-123">Tailored.</suggested_actions>\n'
+            '<suggested_actions generic="true">Generic.</suggested_actions>'
+        )
+        result = self._strip(raw)
+        assert "<suggested_actions" not in result
+        assert "Tailored." not in result
+        assert "Generic." not in result

--- a/backend/tests/test_dm_service.py
+++ b/backend/tests/test_dm_service.py
@@ -13,6 +13,7 @@ with patch("config.supabase_client", MagicMock()):
         extract_state_changes,
         apply_state_changes,
         extract_dice_rolls,
+        build_dm_system_prompt,
     )
 
 
@@ -626,3 +627,169 @@ class TestApplyStateChangesSpellSlots:
         apply_state_changes({
             "spell_slot_use": [{"character_id": "player-1", "slot_level": 1, "spell_name": "Fireball"}]
         })
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by the new DIN-74 test classes
+# ---------------------------------------------------------------------------
+
+def _make_game(name: str = "Test Game", dm_persona: str = "A stern DM") -> dict:
+    return {"name": name, "dm_persona": dm_persona}
+
+
+def _make_player(
+    pid: str = "p1",
+    character_name: str = "Thorin",
+    character_class: str = "Fighter",
+    hp_current: int = 10,
+    hp_max: int = 10,
+    level: int = 1,
+    race: str = "Dwarf",
+    stats: dict | None = None,
+) -> dict:
+    return {
+        "id": pid,
+        "profile_id": f"profile-{pid}",
+        "character_name": character_name,
+        "character_class": character_class,
+        "hp_current": hp_current,
+        "hp_max": hp_max,
+        "level": level,
+        "race": race,
+        "stats": stats or {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# DIN-74 Part A — CURRENT SCENE block injection
+# ---------------------------------------------------------------------------
+
+class TestBuildDmSystemPromptSceneContinuity:
+    """DIN-74 Part A: CURRENT SCENE block injection in build_dm_system_prompt."""
+
+    def test_injects_current_scene_block_from_dm_message(self):
+        """CURRENT SCENE block renders when most recent DM message has a scene."""
+        game = _make_game()
+        players = [_make_player()]
+        recent = [
+            {
+                "role": "dm",
+                "profile_id": None,
+                "content": "The throne room looms.",
+                "scene_type": "throne_room",
+                "scene_mood": "tense",
+            },
+            {
+                "role": "player",
+                "profile_id": "profile-p1",
+                "content": "I bow.",
+                "scene_type": None,
+                "scene_mood": None,
+            },
+        ]
+        prompt = build_dm_system_prompt(game, players, {}, recent, [], "I step forward")
+        assert "CURRENT SCENE:" in prompt
+        assert "throne_room" in prompt
+        assert "tense" in prompt
+
+    def test_omits_current_scene_when_no_prior_messages(self):
+        """CURRENT SCENE block is omitted when there are no DM messages with scene."""
+        game = _make_game()
+        players = [_make_player()]
+        prompt = build_dm_system_prompt(game, players, {}, [], [], "I look around")
+        assert "CURRENT SCENE:" not in prompt
+
+    def test_uses_most_recent_scene_only(self):
+        """When multiple DM messages have scenes, newest-first wins."""
+        game = _make_game()
+        players = [_make_player()]
+        recent = [
+            {
+                "role": "dm",
+                "profile_id": None,
+                "content": "Cave walls close in.",
+                "scene_type": "cave",
+                "scene_mood": "tense",
+            },
+            {
+                "role": "dm",
+                "profile_id": None,
+                "content": "You leave the tavern.",
+                "scene_type": "tavern",
+                "scene_mood": None,
+            },
+        ]
+        prompt = build_dm_system_prompt(game, players, {}, recent, [], "I continue")
+        assert "cave" in prompt
+        scene_section = prompt.split("CURRENT SCENE:")[1].split("\n\n")[0]
+        assert "tavern" not in scene_section
+
+    def test_handles_scene_type_without_mood(self):
+        """Mood is optional — omit from output when mood is None."""
+        game = _make_game()
+        players = [_make_player()]
+        recent = [
+            {
+                "role": "dm",
+                "profile_id": None,
+                "content": "Tavern bustle.",
+                "scene_type": "tavern",
+                "scene_mood": None,
+            },
+        ]
+        prompt = build_dm_system_prompt(game, players, {}, recent, [], "I order ale")
+        scene_section = prompt.split("CURRENT SCENE:")[1].split("\n\n")[0]
+        assert "tavern" in scene_section
+        assert "mood:" not in scene_section.lower()
+
+    def test_skips_player_messages_without_scene(self):
+        """Player messages with no scene_type should not contribute to CURRENT SCENE."""
+        game = _make_game()
+        players = [_make_player()]
+        recent = [
+            {
+                "role": "player",
+                "profile_id": "profile-p1",
+                "content": "I attack.",
+                "scene_type": None,
+                "scene_mood": None,
+            },
+        ]
+        prompt = build_dm_system_prompt(game, players, {}, recent, [], "I dodge")
+        assert "CURRENT SCENE:" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# DIN-74 Part B — acting_player param + Rule 9 dual blocks
+# ---------------------------------------------------------------------------
+
+class TestBuildDmSystemPromptActingPlayer:
+    """DIN-74 Part B: acting_player threading in build_dm_system_prompt."""
+
+    def test_references_acting_player_name_and_id_in_prompt(self):
+        """Rule 9 must reference the acting player so Claude knows who to tailor for."""
+        game = _make_game()
+        acting = _make_player(pid="p1", character_name="Elara")
+        prompt = build_dm_system_prompt(
+            game, [acting], {}, [], [], "I cast light", acting_player=acting
+        )
+        assert "Elara" in prompt
+        assert "p1" in prompt
+
+    def test_rule_9_mentions_both_block_types(self):
+        """Rule 9 text must describe both tailored and generic blocks."""
+        game = _make_game()
+        acting = _make_player(pid="p1", character_name="T")
+        prompt = build_dm_system_prompt(
+            game, [acting], {}, [], [], "I attack", acting_player=acting
+        )
+        assert "character_id=" in prompt
+        assert 'generic="true"' in prompt
+
+    def test_build_prompt_works_without_acting_player(self):
+        """Backward compat: acting_player=None should not break prompt building."""
+        game = _make_game()
+        players = [_make_player()]
+        prompt = build_dm_system_prompt(game, players, {}, [], [], "I look around")
+        assert "You are" in prompt
+        assert "RULES:" in prompt

--- a/backend/tests/test_dm_tasks.py
+++ b/backend/tests/test_dm_tasks.py
@@ -24,6 +24,7 @@ with patch("config.supabase_client", MagicMock()), patch(
         generate_pause_message,
         generate_end_message,
         generate_resume_narration,
+        extract_suggested_actions,
     )
     from services.dm_service import apply_state_changes
 
@@ -721,7 +722,10 @@ class TestDmResponseTaskSuggestedActions:
             dm_response_task.fn("game-1", "msg-1", "I examine the door.")
 
         assert "suggested_actions" in captured_update_payload
-        assert captured_update_payload["suggested_actions"] == [
+        sa = captured_update_payload["suggested_actions"]
+        assert sa["acting_player_id"] is None
+        assert sa["tailored"] == []
+        assert sa["generic"] == [
             "Pick the lock using your thieves' tools.",
             "Search the walls for a hidden mechanism.",
             "Force the door open with a Strength check.",
@@ -879,7 +883,8 @@ class TestDmResponseTaskSuggestedActions:
 
             dm_response_task.fn("game-1", "msg-1", "I attack!")
 
-        assert captured_update_payload.get("suggested_actions") == []
+        sa = captured_update_payload.get("suggested_actions")
+        assert sa == {"acting_player_id": None, "tailored": [], "generic": []}
 
 
 class TestGeneratePauseMessage:
@@ -1998,7 +2003,10 @@ class TestDmBookkeepingTask:
 
         assert len(captured) == 1
         assert "updated_at" in captured[0]
-        assert captured[0]["suggested_actions"] == ["Go left.", "Go right."]
+        sa = captured[0]["suggested_actions"]
+        assert sa["acting_player_id"] is None
+        assert sa["tailored"] == []
+        assert sa["generic"] == ["Go left.", "Go right."]
 
     def test_embeds_events_and_inserts_to_game_events(self):
         raw_response = (
@@ -2063,7 +2071,9 @@ class TestDmBookkeepingTask:
             mock_embed.assert_not_called()
 
         assert len(captured_updates) == 1
-        assert captured_updates[0]["suggested_actions"] == ["Look around."]
+        sa = captured_updates[0]["suggested_actions"]
+        assert sa["acting_player_id"] is None
+        assert sa["generic"] == ["Look around."]
 
     def test_exception_reraised_for_dramatiq_retry(self):
         raw_response = 'Thing. <event type="combat">x</event>'
@@ -2170,3 +2180,63 @@ class TestDmBookkeepingTask:
 
         assert captured_rows[0][0]["scene_type"] is None
         assert captured_rows[0][0]["scene_mood"] is None
+
+
+# ---------------------------------------------------------------------------
+# DIN-74 Part B — extract_suggested_actions
+# ---------------------------------------------------------------------------
+
+class TestExtractSuggestedActions:
+    """DIN-74 Part B: extract_suggested_actions parses dual-block format."""
+
+    def test_parses_tailored_and_generic_blocks(self):
+        """Parser must split both block types into the jsonb structure."""
+        dm_response = """
+Some narrative text.
+
+<suggested_actions character_id="abc-123">
+"Let me examine these runes," I say, lowering my wizard's eye to the stone.
+I raise my staff and whisper an incantation, feeling mana stir in the air.
+</suggested_actions>
+<suggested_actions generic="true">
+Wait and observe the others.
+Speak up with your own plan.
+</suggested_actions>
+
+<scene type="dungeon"/>
+"""
+        result = extract_suggested_actions(dm_response)
+        assert result["acting_player_id"] == "abc-123"
+        assert len(result["tailored"]) == 2
+        assert "examine these runes" in result["tailored"][0]
+        assert len(result["generic"]) == 2
+        assert result["generic"][0] == "Wait and observe the others."
+
+    def test_handles_missing_generic_block(self):
+        """Missing generic block yields empty generic list."""
+        dm_response = """
+<suggested_actions character_id="xyz">
+I draw my sword and ready myself.
+</suggested_actions>
+"""
+        result = extract_suggested_actions(dm_response)
+        assert result["acting_player_id"] == "xyz"
+        assert len(result["tailored"]) == 1
+        assert result["generic"] == []
+
+    def test_handles_no_blocks(self):
+        """No suggested_actions blocks yields empty structure."""
+        result = extract_suggested_actions("Just narrative, no blocks.")
+        assert result == {"acting_player_id": None, "tailored": [], "generic": []}
+
+    def test_handles_missing_tailored_block(self):
+        """Missing tailored block yields empty tailored list."""
+        dm_response = """
+<suggested_actions generic="true">
+Watch and wait.
+</suggested_actions>
+"""
+        result = extract_suggested_actions(dm_response)
+        assert result["acting_player_id"] is None
+        assert result["tailored"] == []
+        assert result["generic"] == ["Watch and wait."]

--- a/frontend/e2e/din-74-scene.spec.ts
+++ b/frontend/e2e/din-74-scene.spec.ts
@@ -1,0 +1,489 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ─── DIN-74 Part A: Scene continuity — <scene> block in SSE updates overlay ───
+//
+// DIN-74 Part A strengthens scene-continuity in the DM prompt (backend), but the
+// corresponding frontend behaviour — parsing `{ type:'block', tag:'scene', ... }`
+// SSE events and immediately updating `currentSceneType`/`currentSceneMood` — was
+// already wired in DIN-66/DIN-73 and has no E2E coverage.
+//
+// These tests verify that the frontend correctly handles <scene> blocks from the
+// SSE stream:
+//
+//   Event shape:
+//     { type: 'block', tag: 'scene', attributes: { type: '...', mood?: '...' }, content: '' }
+//
+//   Expected outcomes:
+//   A1 — scene-bg-active class appears on .dnd-page-bg when a <scene> block arrives
+//   A2 — mood-overlay element renders with `dnd-mood-${mood}` class when mood set
+//   A3 — mood-overlay is absent when no mood attribute is present
+//   A4 — scene overlay updates (new mood class) when a second stream brings a
+//        different scene/mood than the one loaded from DB messages
+//   A5 — <scene> block tag text never leaks into the streaming DM bubble
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAME_ID = 'test-game-din74-scene'
+const USER_ID = 'user-1'
+const PLAYER_ID = 'player-1'
+
+// ─── Shared setup ─────────────────────────────────────────────────────────────
+
+interface GameMessage {
+  id: string
+  game_id: string
+  profile_id: string | null
+  role: 'player' | 'dm' | 'system'
+  content: string
+  scene_type?: string | null
+  scene_mood?: string | null
+  dice_rolls?: null
+  created_at: string
+}
+
+// A no-scene DM message used to set isWaitingForDm=false when no history exists.
+const INIT_DM_MSG: GameMessage = {
+  id: 'msg-init-dm',
+  game_id: GAME_ID,
+  profile_id: null,
+  role: 'dm',
+  content: 'Your adventure begins.',
+  scene_type: null,
+  scene_mood: null,
+  dice_rolls: null,
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+async function setupMocks(
+  page: Page,
+  options: {
+    messages?: GameMessage[]
+  } = {}
+) {
+  // Always include at least one DM message so isWaitingForDm=false on init.
+  // (GameSessionView sets isWaitingForDm=true when latestData?.[0] is undefined.)
+  const { messages = [INIT_DM_MSG] } = options
+
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+    })
+  )
+
+  await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'mock-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        user: { id: USER_ID, email: 'test@example.com' },
+      }),
+    })
+  )
+
+  await page.route('**.supabase.co/rest/v1/games**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: GAME_ID,
+            name: 'The Continuity Spire',
+            dm_persona: 'A vivid scene-setter',
+            status: 'active',
+            created_by: USER_ID,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+            suggested_actions: null,
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/players**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: PLAYER_ID,
+            game_id: GAME_ID,
+            profile_id: USER_ID,
+            character_name: 'Lyra',
+            character_class: 'Ranger',
+            race: 'Wood Elf',
+            level: 3,
+            hp_current: 24,
+            hp_max: 24,
+            stats: { str: 12, dex: 16, con: 12, int: 10, wis: 14, cha: 10 },
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+    if (route.request().method() === 'GET') {
+      const url = route.request().url()
+      const latestMsg = messages[0] ?? null
+      if (url.includes('select=role')) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(latestMsg ? [{ id: latestMsg.id, role: latestMsg.role, created_at: latestMsg.created_at }] : []),
+        })
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(messages),
+        })
+      }
+    }
+  })
+}
+
+async function mockStreamingAction(
+  page: Page,
+  sseEvents: object[],
+  msgId = 'msg-1'
+) {
+  await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ message_id: msgId, status: 'queued' }),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+      body: sseEvents.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(''),
+    })
+  })
+}
+
+async function gotoGame(page: Page) {
+  await page.goto(`/games/${GAME_ID}`)
+  await expect(page.getByText('The Continuity Spire')).toBeVisible({ timeout: 8000 })
+}
+
+async function submitAction(page: Page, text: string) {
+  const textarea = page.getByTestId('chat-textarea')
+  await expect(textarea).toBeEnabled({ timeout: 5000 })
+  await textarea.fill(text)
+  await page.getByRole('button', { name: /Send/i }).click()
+}
+
+// ─── A1: <scene> block activates the scene overlay ────────────────────────────
+
+test.describe('DIN-74 Part A — <scene> block in SSE activates scene overlay', () => {
+  test('scene-bg-active class applied to page container after <scene> block in stream', async ({
+    page,
+  }) => {
+    // Default: one no-scene DM message — textarea enabled, no initial scene
+    await setupMocks(page)
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'You enter the dungeon.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        attributes: { type: 'dungeon', mood: 'tense' },
+        content: '',
+      },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    // Before submitting, the page container does not have scene-bg-active
+    // (game is active but sceneType is null → no scene)
+    const container = page.locator('.dnd-page-bg')
+
+    await submitAction(page, 'I step into the dungeon.')
+
+    // After stream: scene block received → scene-bg-active must be applied
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 5000 })
+  })
+
+  test('scene-background-root element is in the DOM after <scene> block activates scene', async ({
+    page,
+  }) => {
+    await setupMocks(page)
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'The crypt door groans open.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        attributes: { type: 'crypt', mood: 'somber' },
+        content: '',
+      },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+    await submitAction(page, 'I push the door.')
+
+    // SceneBackground component renders once scene type is set
+    await expect(page.getByTestId('scene-background-root')).toBeVisible({ timeout: 5000 })
+  })
+})
+
+// ─── A2: <scene> block with mood renders mood overlay ─────────────────────────
+
+test.describe('DIN-74 Part A — <scene> block with mood renders mood overlay', () => {
+  test('mood-overlay element appears with correct dnd-mood-{mood} class', async ({
+    page,
+  }) => {
+    await setupMocks(page)
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'Swords ring out in the chamber.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        attributes: { type: 'throne_room', mood: 'combat' },
+        content: '',
+      },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+    await submitAction(page, 'I draw my blade.')
+
+    const moodOverlay = page.getByTestId('mood-overlay')
+    await expect(moodOverlay).toBeVisible({ timeout: 5000 })
+    await expect(moodOverlay).toHaveClass(/dnd-mood-combat/)
+  })
+
+  test('mood-overlay has dnd-mood-tense class when scene mood is tense', async ({
+    page,
+  }) => {
+    await setupMocks(page)
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'A shadow shifts in the corner.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        attributes: { type: 'cave', mood: 'tense' },
+        content: '',
+      },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+    await submitAction(page, 'I hold my breath.')
+
+    const moodOverlay = page.getByTestId('mood-overlay')
+    await expect(moodOverlay).toBeVisible({ timeout: 5000 })
+    await expect(moodOverlay).toHaveClass(/dnd-mood-tense/)
+  })
+})
+
+// ─── A3: <scene> block without mood hides the mood overlay ────────────────────
+
+test.describe('DIN-74 Part A — <scene> block without mood omits mood overlay', () => {
+  test('mood-overlay is not rendered when <scene> block has no mood attribute', async ({
+    page,
+  }) => {
+    await setupMocks(page)
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'The forest opens before you.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        attributes: { type: 'forest' }, // no mood
+        content: '',
+      },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+    await submitAction(page, 'I walk into the trees.')
+
+    // Scene overlay activates (scene type set)
+    await expect(page.locator('.dnd-page-bg')).toHaveClass(/scene-bg-active/, { timeout: 5000 })
+
+    // But mood overlay must NOT be present
+    await expect(page.getByTestId('mood-overlay')).toHaveCount(0)
+  })
+})
+
+// ─── A4: Scene overlay updates when a new <scene> block brings a different scene
+
+test.describe('DIN-74 Part A — Scene overlay updates when SSE stream carries new scene', () => {
+  test('mood overlay changes from initial tense to mystery when SSE delivers throne_room/mystery', async ({
+    page,
+  }) => {
+    // Page loads with dungeon/tense from a prior DM message
+    const priorDmMsg: GameMessage = {
+      id: 'msg-prior',
+      game_id: GAME_ID,
+      profile_id: null,
+      role: 'dm',
+      content: 'You stand at the dungeon entrance.',
+      scene_type: 'dungeon',
+      scene_mood: 'tense',
+      dice_rolls: null,
+      created_at: '2026-01-01T00:00:01Z',
+    }
+
+    await setupMocks(page, { messages: [priorDmMsg] })
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'The throne room is revealed.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        attributes: { type: 'throne_room', mood: 'mystery' },
+        content: '',
+      },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    // Initial scene: dungeon/tense from DB messages
+    const moodOverlay = page.getByTestId('mood-overlay')
+    await expect(moodOverlay).toBeVisible({ timeout: 5000 })
+    await expect(moodOverlay).toHaveClass(/dnd-mood-tense/)
+
+    // Action triggers stream with new scene
+    await submitAction(page, 'I push open the heavy doors.')
+
+    // Mood overlay updates to mystery
+    await expect(moodOverlay).toHaveClass(/dnd-mood-mystery/, { timeout: 5000 })
+    await expect(moodOverlay).not.toHaveClass(/dnd-mood-tense/)
+  })
+
+  test('scene-bg-active persists after stream completes without a Realtime scene message', async ({
+    page,
+  }) => {
+    await setupMocks(page)
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'The tavern is warm and inviting.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        attributes: { type: 'tavern', mood: 'victory' },
+        content: '',
+      },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+    await submitAction(page, 'I enter the tavern.')
+
+    // Scene activated by SSE
+    const container = page.locator('.dnd-page-bg')
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 5000 })
+
+    // Dispatch Realtime DM INSERT without scene_type — scene state must NOT reset
+    await page.evaluate(({ gameId }) => {
+      window.dispatchEvent(
+        new CustomEvent('dm-message', {
+          detail: {
+            id: 'msg-dm-confirmed',
+            game_id: gameId,
+            profile_id: null,
+            role: 'dm',
+            content: 'The tavern is warm and inviting.',
+            scene_type: null,
+            scene_mood: null,
+            created_at: new Date().toISOString(),
+          },
+        })
+      )
+    }, { gameId: GAME_ID })
+
+    // Scene overlay must still be active (SSE-set scene type persists)
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 3000 })
+    await expect(page.getByTestId('mood-overlay')).toHaveClass(/dnd-mood-victory/)
+  })
+})
+
+// ─── A5: <scene> block does not leak tag text into the streaming bubble ────────
+
+test.describe('DIN-74 Part A — <scene> block tag does not appear in streaming bubble', () => {
+  test('scene type/mood values do not appear as text in the streaming bubble', async ({
+    page,
+  }) => {
+    await setupMocks(page)
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'The swamp stretches endlessly.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        attributes: { type: 'swamp', mood: 'mystery' },
+        content: '',
+      },
+      { type: 'chunk', text: ' You hear croaking in the distance.' },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+    await submitAction(page, 'I wade into the swamp.')
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('The swamp stretches endlessly.', { timeout: 3000 })
+    await expect(bubble).toContainText('You hear croaking in the distance.')
+
+    // Scene block must not leak into the bubble — no raw tag text or attribute values
+    await expect(bubble).not.toContainText('<scene')
+    await expect(bubble).not.toContainText('type="swamp"')
+    await expect(bubble).not.toContainText('mood="mystery"')
+  })
+
+  test('scene block with all-caps type value does not bleed into chat (invalid type rejected gracefully)', async ({
+    page,
+  }) => {
+    // Backend always emits valid types, but guard against invalid SSE data corrupting the UI
+    await setupMocks(page)
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'The air grows cold.' },
+      {
+        type: 'block',
+        tag: 'scene',
+        // Invalid type (not in SCENE_TYPES enum) — parseSceneTag returns null → state unchanged
+        attributes: { type: 'INVALID_SCENE', mood: 'tense' },
+        content: '',
+      },
+      { type: 'chunk', text: ' You shiver.' },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+    await submitAction(page, 'I look around nervously.')
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('The air grows cold.', { timeout: 3000 })
+    await expect(bubble).toContainText('You shiver.')
+    await expect(bubble).not.toContainText('<scene')
+    await expect(bubble).not.toContainText('INVALID_SCENE')
+  })
+})

--- a/frontend/e2e/din-74-scene.spec.ts
+++ b/frontend/e2e/din-74-scene.spec.ts
@@ -600,3 +600,139 @@ test.describe('DIN-74 Part A — DB-loaded scene persists across a full turn whe
     await expect(moodOverlay).not.toHaveClass(/dnd-mood-mystery/)
   })
 })
+
+// ─── A7: Multi-turn scene persistence (two consecutive turns) ─────────────────
+//
+// The DIN-74 AC requires "scene tags remain sticky across 5+ turns of
+// same-location dialogue". Test A6 proves it holds for one turn. This test
+// runs TWO consecutive turns — each without a <scene> block — to verify the
+// React useState carries the scene forward across multiple action/stream/Realtime
+// cycles, not just within a single turn's lifecycle.
+//
+// Setup  : DB has dungeon/tense from prior DM message.
+// Turn 1 : SSE delivers narrative only (no <scene>). Realtime INSERT scene_type=null.
+//           → dungeon/tense still active.
+// Turn 2 : Second SSE (no <scene>). Second Realtime INSERT scene_type=null.
+//           → dungeon/tense must STILL be active.
+
+test.describe('DIN-74 Part A — Scene persists across two consecutive turns with no <scene> block', () => {
+  test('scene remains dungeon/tense after two turns whose SSE emits no <scene> block', async ({
+    page,
+  }) => {
+    const priorDmMsg: GameMessage = {
+      id: 'msg-multi-prior',
+      game_id: GAME_ID,
+      profile_id: null,
+      role: 'dm',
+      content: 'The dungeon corridor stretches ahead.',
+      scene_type: 'dungeon',
+      scene_mood: 'tense',
+      dice_rolls: null,
+      created_at: '2026-01-01T00:00:01Z',
+    }
+
+    await setupMocks(page, { messages: [priorDmMsg] })
+
+    // Both turns use the same SSE handler (narrative only, no scene block)
+    let actionCallCount = 0
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        actionCallCount++
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: `msg-turn-${actionCallCount}`, status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: [
+          { type: 'chunk', text: 'You press deeper into the dungeon.' },
+          { type: 'done' },
+        ]
+          .map((e) => `data: ${JSON.stringify(e)}\n\n`)
+          .join(''),
+      })
+    })
+
+    await gotoGame(page)
+
+    const container = page.locator('.dnd-page-bg')
+    const moodOverlay = page.getByTestId('mood-overlay')
+
+    // Verify initial scene from DB
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 5000 })
+    await expect(moodOverlay).toHaveClass(/dnd-mood-tense/, { timeout: 5000 })
+
+    // ── Turn 1 ──────────────────────────────────────────────────────────────
+
+    await submitAction(page, 'I move forward.')
+
+    const bubble1 = page.getByTestId('streaming-dm-message')
+    await expect(bubble1).toContainText('You press deeper', { timeout: 5000 })
+
+    await page.evaluate(({ gameId }) => {
+      window.dispatchEvent(
+        new CustomEvent('dm-message', {
+          detail: {
+            id: 'msg-turn-1-confirmed',
+            game_id: gameId,
+            profile_id: null,
+            role: 'dm',
+            content: 'You press deeper into the dungeon.',
+            scene_type: null,
+            scene_mood: null,
+            created_at: new Date().toISOString(),
+          },
+        })
+      )
+    }, { gameId: GAME_ID })
+
+    // After turn 1: scene must still be dungeon/tense
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 3000 })
+    await expect(moodOverlay).toHaveClass(/dnd-mood-tense/)
+
+    // ── Turn 2 ──────────────────────────────────────────────────────────────
+
+    const textarea = page.getByTestId('chat-textarea')
+    await expect(textarea).toBeEnabled({ timeout: 5000 })
+    await textarea.fill('I listen carefully.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    const bubble2 = page.getByTestId('streaming-dm-message')
+    await expect(bubble2).toContainText('You press deeper', { timeout: 5000 })
+
+    await page.evaluate(({ gameId }) => {
+      window.dispatchEvent(
+        new CustomEvent('dm-message', {
+          detail: {
+            id: 'msg-turn-2-confirmed',
+            game_id: gameId,
+            profile_id: null,
+            role: 'dm',
+            content: 'You press deeper into the dungeon.',
+            scene_type: null,
+            scene_mood: null,
+            created_at: new Date().toISOString(),
+          },
+        })
+      )
+    }, { gameId: GAME_ID })
+
+    // After turn 2: scene STILL dungeon/tense — not reset across either turn
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 3000 })
+    await expect(moodOverlay).toHaveClass(/dnd-mood-tense/)
+    await expect(moodOverlay).not.toHaveClass(/dnd-mood-mystery/)
+    await expect(moodOverlay).not.toHaveClass(/dnd-mood-combat/)
+  })
+})

--- a/frontend/e2e/din-74-scene.spec.ts
+++ b/frontend/e2e/din-74-scene.spec.ts
@@ -427,6 +427,41 @@ test.describe('DIN-74 Part A — Scene overlay updates when SSE stream carries n
   })
 })
 
+// ─── A3b: DB-loaded scene with type but no mood ────────────────────────────────
+//
+// When the most-recent DM message in the DB has scene_type but scene_mood=null,
+// the frontend should activate the scene background (scene-bg-active) but NOT
+// render a mood overlay. Complements A3 (which tests the same via SSE stream).
+
+test.describe('DIN-74 Part A — DB-loaded scene with type but no mood activates background without mood overlay', () => {
+  test('scene-bg-active set and mood-overlay absent when message has scene_type but null scene_mood', async ({
+    page,
+  }) => {
+    const priorDmMsg: GameMessage = {
+      id: 'msg-scene-no-mood',
+      game_id: GAME_ID,
+      profile_id: null,
+      role: 'dm',
+      content: 'You emerge into a vast coastal expanse.',
+      scene_type: 'coast',
+      scene_mood: null,
+      dice_rolls: null,
+      created_at: '2026-01-01T00:00:01Z',
+    }
+
+    await setupMocks(page, { messages: [priorDmMsg] })
+    await gotoGame(page)
+
+    // Scene overlay must activate (scene_type = 'coast')
+    await expect(page.locator('.dnd-page-bg')).toHaveClass(/scene-bg-active/, {
+      timeout: 5000,
+    })
+
+    // Mood overlay must NOT render (scene_mood is null)
+    await expect(page.getByTestId('mood-overlay')).toHaveCount(0)
+  })
+})
+
 // ─── A5: <scene> block does not leak tag text into the streaming bubble ────────
 
 test.describe('DIN-74 Part A — <scene> block tag does not appear in streaming bubble', () => {

--- a/frontend/e2e/din-74-scene.spec.ts
+++ b/frontend/e2e/din-74-scene.spec.ts
@@ -522,3 +522,81 @@ test.describe('DIN-74 Part A — <scene> block tag does not appear in streaming 
     await expect(bubble).not.toContainText('INVALID_SCENE')
   })
 })
+
+// ─── A6: Scene continuity — DB-loaded scene persists across a full turn ────────
+//
+// Core DIN-74 Part A scenario: the backend carries scene forward (no new <scene>
+// block in the SSE stream). Frontend must hold the DB-sourced scene through the
+// full action → SSE → Realtime cycle without resetting it.
+//
+// Setup: prior DM message in DB has scene_type='dungeon', scene_mood='tense'.
+// Turn:  SSE delivers only narrative chunks (no <scene> block).
+// After: Realtime DM INSERT arrives with scene_type=null (backend didn't
+//        re-emit the tag because it carried it forward implicitly).
+// Assert: scene overlay and mood class remain dungeon / tense throughout.
+
+test.describe('DIN-74 Part A — DB-loaded scene persists across a full turn when SSE has no <scene> block', () => {
+  test('scene remains dungeon/tense after a turn whose SSE emits no <scene> block', async ({
+    page,
+  }) => {
+    // Prior DM message carries the established scene
+    const priorDmMsg: GameMessage = {
+      id: 'msg-dungeon-prior',
+      game_id: GAME_ID,
+      profile_id: null,
+      role: 'dm',
+      content: 'The dungeon stretches ahead.',
+      scene_type: 'dungeon',
+      scene_mood: 'tense',
+      dice_rolls: null,
+      created_at: '2026-01-01T00:00:01Z',
+    }
+
+    await setupMocks(page, { messages: [priorDmMsg] })
+
+    // SSE for this turn has narrative only — the DM carried scene forward implicitly
+    await mockStreamingAction(page, [
+      { type: 'chunk', text: 'You press onward deeper into the dark.' },
+      { type: 'done' },
+    ])
+
+    await gotoGame(page)
+
+    // Scene must be active from DB on page load
+    const container = page.locator('.dnd-page-bg')
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 5000 })
+    const moodOverlay = page.getByTestId('mood-overlay')
+    await expect(moodOverlay).toHaveClass(/dnd-mood-tense/, { timeout: 5000 })
+
+    // Submit an action — SSE fires with no scene block
+    await submitAction(page, 'I move deeper.')
+
+    // Wait for streaming bubble to appear and complete
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('You press onward', { timeout: 5000 })
+
+    // Simulate Realtime DM INSERT with scene_type: null
+    // (backend stored the narrative; scene tag was not re-persisted on this turn)
+    await page.evaluate(({ gameId }) => {
+      window.dispatchEvent(
+        new CustomEvent('dm-message', {
+          detail: {
+            id: 'msg-dungeon-turn2',
+            game_id: gameId,
+            profile_id: null,
+            role: 'dm',
+            content: 'You press onward deeper into the dark.',
+            scene_type: null,
+            scene_mood: null,
+            created_at: new Date().toISOString(),
+          },
+        })
+      )
+    }, { gameId: GAME_ID })
+
+    // Scene overlay and mood must still be dungeon/tense — not reset by the null
+    await expect(container).toHaveClass(/scene-bg-active/, { timeout: 3000 })
+    await expect(moodOverlay).toHaveClass(/dnd-mood-tense/)
+    await expect(moodOverlay).not.toHaveClass(/dnd-mood-mystery/)
+  })
+})

--- a/frontend/e2e/din-74-suggestions.spec.ts
+++ b/frontend/e2e/din-74-suggestions.spec.ts
@@ -259,6 +259,80 @@ test.describe('DIN-74 — Empty bundle disables ✨ button', () => {
 
     await expect(page.getByTestId('cycle-suggestion-btn')).toBeDisabled({ timeout: 5000 })
   })
+
+  test('✨ button is disabled when acting player has an empty tailored list', async ({
+    page,
+  }) => {
+    // Current player IS the acting player, but tailored list is empty.
+    // visibleSuggestions = tailored = [] → button disabled.
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID, // current player is acting
+      tailored: [],                // but no tailored suggestions yet
+      generic: [GENERIC_1],       // generic exist but shouldn't be shown to acting player
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    await expect(page.getByTestId('cycle-suggestion-btn')).toBeDisabled({ timeout: 5000 })
+  })
+})
+
+// ─── Part B: ✨ button disabled while DM is writing ───────────────────────────
+
+test.describe('DIN-74 — ✨ cycle button disabled while waiting for DM response', () => {
+  test('cycle button becomes disabled after submitting an action (isWaitingForDm=true)', async ({
+    page,
+  }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1, LONG_TAILORED_2],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+
+    // Slow SSE so we can observe the disabled state while waiting
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-wait', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // SSE endpoint never resolves during this test — simulates DM still writing
+    await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+      if (route.request().method() === 'GET') {
+        // Return a minimal SSE body with a long delay so isWaitingForDm stays true
+        await new Promise((r) => setTimeout(r, 5000))
+        await route.fulfill({
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+          body: buildSseBody([{ type: 'done' }]),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    // Submit an action — sets isWaitingForDm=true
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill('I move forward cautiously.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Cycle button must be disabled while DM is writing
+    await expect(cycleBtn).toBeDisabled({ timeout: 3000 })
+  })
 })
 
 // ─── Part C: Textarea resize on cycle ────────────────────────────────────────

--- a/frontend/e2e/din-74-suggestions.spec.ts
+++ b/frontend/e2e/din-74-suggestions.spec.ts
@@ -264,12 +264,18 @@ test.describe('DIN-74 — Empty bundle disables ✨ button', () => {
 // ─── Part C: Textarea resize on cycle ────────────────────────────────────────
 
 test.describe('DIN-74 — Textarea auto-grows when long suggestion is cycled in', () => {
-  test('textarea height increases beyond 40 px after ✨ cycles in a long suggestion', async ({
+  test('textarea style.height is set after ✨ cycles in a suggestion (resize ran)', async ({
     page,
   }) => {
+    // Use a multi-line suggestion (~285 chars, guaranteed 3+ wrapped lines in any viewport)
+    const multiLineTailored =
+      '"I must approach this with caution," I say, my voice low as I study the runes etched into the stone doorframe. ' +
+      'The arcane symbols pulse faintly in rhythm with my heartbeat. ' +
+      '"Whatever was sealed behind this door was sealed for a reason — I intend to find out why before we proceed."'
+
     const bundle: SuggestedActionsBundle = {
       acting_player_id: PLAYER_ID,
-      tailored: [LONG_TAILORED_1], // ~23 words — forces multi-line wrap
+      tailored: [multiLineTailored],
       generic: [],
     }
 
@@ -279,10 +285,11 @@ test.describe('DIN-74 — Textarea auto-grows when long suggestion is cycled in'
     const textarea = page.getByTestId('chat-textarea')
     await expect(textarea).toBeEnabled({ timeout: 5000 })
 
-    // Baseline height at empty state
-    const initialHeight = await textarea.evaluate(
-      (el: HTMLTextAreaElement) => el.offsetHeight
+    // Baseline: no inline height style before cycling
+    const styleBefore = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.style.height
     )
+    expect(styleBefore).toBe('')
 
     const cycleBtn = page.getByTestId('cycle-suggestion-btn')
     await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
@@ -291,12 +298,17 @@ test.describe('DIN-74 — Textarea auto-grows when long suggestion is cycled in'
     // Wait for requestAnimationFrame resize to settle
     await page.waitForTimeout(100)
 
-    const afterHeight = await textarea.evaluate(
+    // After cycle, resizeTextarea() must have set style.height to a px value
+    const styleAfter = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.style.height
+    )
+    expect(styleAfter).toMatch(/^\d+px$/)
+
+    // And the rendered height must exceed the initial single-line minimum
+    const offsetAfter = await textarea.evaluate(
       (el: HTMLTextAreaElement) => el.offsetHeight
     )
-
-    // The textarea must have grown — long suggestion forces at least two lines
-    expect(afterHeight).toBeGreaterThan(initialHeight)
+    expect(offsetAfter).toBeGreaterThan(45)
   })
 
   test('textarea height never exceeds 180 px even for very long content', async ({

--- a/frontend/e2e/din-74-suggestions.spec.ts
+++ b/frontend/e2e/din-74-suggestions.spec.ts
@@ -641,3 +641,223 @@ test.describe('DIN-74 — Realtime game-update replaces bundle', () => {
     await expect(cycleBtn).toBeDisabled({ timeout: 5000 })
   })
 })
+
+// ─── Part B+C: Streaming bubble — no content leakage ─────────────────────────
+//
+// DIN-74 introduces two new `<suggested_actions>` attribute formats:
+//   character_id="<id>"  → tailored bucket for the acting player
+//   generic="true"       → generic bucket for all other players
+//
+// Both must be silently consumed by the SSE parser — their text content
+// must never surface inside the streaming DM bubble.
+
+test.describe('DIN-74 — Attributed suggested_actions blocks do not leak into chat bubble', () => {
+  test('tailored block (character_id attr) content does not appear in the streaming bubble', async ({
+    page,
+  }) => {
+    const tailoredContent =
+      '"I draw my blade slowly," I say, eyes fixed on the shadow lurking behind the altar.'
+    const genericContent = 'Wait and observe the others.'
+
+    await setupMocks(page, { suggestedActions: null })
+
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-1', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+      if (route.request().method() !== 'GET') { await route.continue(); return }
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: buildSseBody([
+          { type: 'chunk', text: 'The altar pulses with dark energy. ' },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: { character_id: PLAYER_ID },
+            content: tailoredContent,
+          },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: { generic: 'true' },
+            content: genericContent,
+          },
+          { type: 'chunk', text: 'You must decide quickly.' },
+          { type: 'done' },
+        ]),
+      })
+    })
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I approach the altar.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('The altar pulses with dark energy.', { timeout: 3000 })
+    await expect(bubble).toContainText('You must decide quickly.')
+    await expect(bubble).not.toContainText('I draw my blade')
+    await expect(bubble).not.toContainText('Wait and observe')
+    await expect(bubble).not.toContainText('<suggested_actions')
+  })
+
+  test('generic block (generic="true" attr) content does not appear in the streaming bubble', async ({
+    page,
+  }) => {
+    const tailoredContent = '"Forward!" I shout, charging ahead with reckless abandon.'
+    const genericLine1 = 'Speak up with your own plan.'
+    const genericLine2 = 'Help the acting player.'
+
+    await setupMocks(page, { suggestedActions: null })
+
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-2', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+      if (route.request().method() !== 'GET') { await route.continue(); return }
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: buildSseBody([
+          { type: 'chunk', text: 'The fighter dashes forward. ' },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: { character_id: PLAYER_ID },
+            content: tailoredContent,
+          },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: { generic: 'true' },
+            content: [genericLine1, genericLine2].join('\n'),
+          },
+          { type: 'chunk', text: 'The corridor shakes.' },
+          { type: 'done' },
+        ]),
+      })
+    })
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I charge ahead.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    const bubble = page.getByTestId('streaming-dm-message')
+    await expect(bubble).toContainText('The fighter dashes forward.', { timeout: 3000 })
+    await expect(bubble).toContainText('The corridor shakes.')
+    await expect(bubble).not.toContainText('Forward!')
+    await expect(bubble).not.toContainText('Speak up with your own plan')
+    await expect(bubble).not.toContainText('Help the acting player')
+    await expect(bubble).not.toContainText('<suggested_actions')
+  })
+})
+
+// ─── Part C: Status line visibility ──────────────────────────────────────────
+
+test.describe('DIN-74 — Suggestion status line is hidden when no suggestions exist', () => {
+  test('status line is not rendered when suggested_actions is null', async ({ page }) => {
+    await setupMocks(page, { suggestedActions: null })
+    await gotoGame(page)
+
+    // The "click ✨ to cycle" hint must not be present when there are no suggestions
+    await expect(
+      page.getByText(/click ✨ to cycle/i)
+    ).toHaveCount(0, { timeout: 5000 })
+  })
+
+  test('status line is not rendered when the visible list is empty for current player', async ({
+    page,
+  }) => {
+    // Non-acting player with empty generic list → nothing to show
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: 'player-other',
+      tailored: [LONG_TAILORED_1],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    await expect(
+      page.getByText(/click ✨ to cycle/i)
+    ).toHaveCount(0, { timeout: 5000 })
+  })
+})
+
+// ─── Part C: Textarea resets after submit ─────────────────────────────────────
+
+test.describe('DIN-74 — Textarea height resets to auto after submitting a cycled suggestion', () => {
+  test('textarea style.height is cleared after sending a long cycled suggestion', async ({
+    page,
+  }) => {
+    const multiLineTailored =
+      '"Let us proceed with caution," I whisper, scanning the shadows for any sign of movement before taking a careful step through the threshold.'
+
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [multiLineTailored],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+
+    // Action POST mock — needed to submit the form
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-reset', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+    await cycleBtn.click()
+
+    // Allow rAF resize to settle
+    await page.waitForTimeout(100)
+
+    // Textarea must have grown
+    const heightAfterCycle = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.style.height
+    )
+    expect(heightAfterCycle).toMatch(/^\d+px$/)
+
+    // Submit the cycled suggestion
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // After submit, style.height must be cleared back to 'auto' or empty
+    const heightAfterSubmit = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.style.height
+    )
+    expect(['auto', '']).toContain(heightAfterSubmit)
+  })
+})

--- a/frontend/e2e/din-74-suggestions.spec.ts
+++ b/frontend/e2e/din-74-suggestions.spec.ts
@@ -1,0 +1,631 @@
+import { test, expect, Page } from '@playwright/test'
+
+// ─── DIN-74: Tailored suggestions + textarea fix ──────────────────────────────
+//
+// E2E coverage for three sub-features shipped in DIN-74:
+//
+// Part B — Tailored vs. generic suggested actions
+//   The `games.suggested_actions` column is now a jsonb
+//   `SuggestedActionsBundle` shape:
+//     { acting_player_id: string|null, tailored: string[], generic: string[] }
+//   Acting player sees `tailored`; everyone else sees `generic`.
+//
+// Part C — Textarea UX fix
+//   • ✨ cycle now triggers a `requestAnimationFrame` resize so long
+//     suggestions actually expand the textarea (previously stuck at 40 px).
+//   • maxHeight bumped from 96 px → 180 px.
+//   • "Edit or send as-is" hint appended to the status line.
+//   • Dual SSE blocks (`character_id` attr = tailored, `generic="true"` = generic).
+//   • Realtime `game-update` event updates the bundle.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAME_ID = 'test-game-din74'
+const USER_ID = 'user-1'
+const PLAYER_ID = 'player-1'
+
+interface SuggestedActionsBundle {
+  acting_player_id: string | null
+  tailored: string[]
+  generic: string[]
+}
+
+// Long 20-30 word first-person suggestion to exercise the resize path
+const LONG_TAILORED_1 =
+  '"I lower my sword slowly," I say, keeping my eyes fixed on the figure. "Tell me what you want, and I will listen."'
+const LONG_TAILORED_2 =
+  '"My magic senses something hidden here," I murmur, spreading my fingers wide and letting arcane light trace the walls for a concealed door.'
+const GENERIC_1 = 'Wait and observe the others.'
+const GENERIC_2 = 'Speak up with your own plan.'
+
+// ─── Setup helper ─────────────────────────────────────────────────────────────
+async function setupMocks(
+  page: Page,
+  options: {
+    suggestedActions?: SuggestedActionsBundle | null
+    playerProfileId?: string
+    playerId?: string
+  } = {}
+) {
+  const {
+    suggestedActions = null,
+    playerProfileId = USER_ID,
+    playerId = PLAYER_ID,
+  } = options
+
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: USER_ID, email: 'test@example.com' }),
+    })
+  )
+
+  await page.route('**/auth/v1/token?grant_type=refresh_token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'mock-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        user: { id: USER_ID, email: 'test@example.com' },
+      }),
+    })
+  )
+
+  await page.route('**.supabase.co/rest/v1/games**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: GAME_ID,
+            name: 'The Continuity Keep',
+            dm_persona: 'A theatrical DM',
+            status: 'active',
+            created_by: USER_ID,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+            suggested_actions: suggestedActions,
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/players**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: playerId,
+            game_id: GAME_ID,
+            profile_id: playerProfileId,
+            character_name: 'Aldric',
+            character_class: 'Wizard',
+            race: 'High Elf',
+            level: 4,
+            hp_current: 26,
+            hp_max: 26,
+            stats: { str: 10, dex: 14, con: 12, int: 18, wis: 14, cha: 12 },
+          },
+        ]),
+      })
+    }
+  })
+
+  await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    }
+  })
+
+  const initMsg = {
+    id: 'msg-init',
+    game_id: GAME_ID,
+    profile_id: null,
+    role: 'dm',
+    content: 'The keep looms before you, torchlight flickering.',
+    scene_type: 'dungeon',
+    scene_mood: 'tense',
+    dice_rolls: null,
+    created_at: '2026-01-01T00:00:01Z',
+  }
+
+  await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
+    if (route.request().method() === 'GET') {
+      const url = route.request().url()
+      if (url.includes('select=role')) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([{ id: initMsg.id, role: 'dm', created_at: initMsg.created_at }]),
+        })
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([initMsg]),
+        })
+      }
+    }
+  })
+}
+
+async function gotoGame(page: Page) {
+  await page.goto(`/games/${GAME_ID}`)
+  await expect(page.getByText('The Continuity Keep')).toBeVisible({ timeout: 8000 })
+}
+
+function buildSseBody(events: object[]): string {
+  return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join('')
+}
+
+// ─── Part B: Tailored vs Generic suggestion routing ───────────────────────────
+
+test.describe('DIN-74 — Acting player sees tailored suggestions', () => {
+  test('✨ cycle shows tailored first-person suggestions when current player is the acting player', async ({
+    page,
+  }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID, // matches player-1 whose profile_id = USER_ID
+      tailored: [LONG_TAILORED_1, LONG_TAILORED_2],
+      generic: [GENERIC_1, GENERIC_2],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    const textarea = page.getByTestId('chat-textarea')
+
+    // First click: should load the first tailored suggestion, not a generic one
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(LONG_TAILORED_1)
+
+    // Second click: cycles to the second tailored suggestion
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(LONG_TAILORED_2)
+
+    // Third click: wraps back to first tailored suggestion
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(LONG_TAILORED_1)
+
+    // Generic suggestions must NOT appear
+    await expect(textarea).not.toHaveValue(GENERIC_1)
+  })
+})
+
+test.describe('DIN-74 — Non-acting player sees generic suggestions', () => {
+  test('✨ cycle shows generic suggestions when current player is not the acting player', async ({
+    page,
+  }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: 'player-other', // different player is acting
+      tailored: [LONG_TAILORED_1],
+      generic: [GENERIC_1, GENERIC_2],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    const textarea = page.getByTestId('chat-textarea')
+
+    // Should see generic, not tailored
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(GENERIC_1)
+
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(GENERIC_2)
+
+    // Tailored suggestion must NOT appear
+    await expect(textarea).not.toHaveValue(LONG_TAILORED_1)
+  })
+})
+
+test.describe('DIN-74 — Empty bundle disables ✨ button', () => {
+  test('✨ button is disabled when suggested_actions is null', async ({ page }) => {
+    await setupMocks(page, { suggestedActions: null })
+    await gotoGame(page)
+
+    await expect(page.getByTestId('cycle-suggestion-btn')).toBeDisabled({ timeout: 5000 })
+  })
+
+  test('✨ button is disabled when bundle has no visible suggestions for current player', async ({
+    page,
+  }) => {
+    // Non-acting player, empty generic list
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: 'player-other',
+      tailored: [LONG_TAILORED_1],
+      generic: [], // nothing for this player
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    await expect(page.getByTestId('cycle-suggestion-btn')).toBeDisabled({ timeout: 5000 })
+  })
+})
+
+// ─── Part C: Textarea resize on cycle ────────────────────────────────────────
+
+test.describe('DIN-74 — Textarea auto-grows when long suggestion is cycled in', () => {
+  test('textarea height increases beyond 40 px after ✨ cycles in a long suggestion', async ({
+    page,
+  }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1], // ~23 words — forces multi-line wrap
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await expect(textarea).toBeEnabled({ timeout: 5000 })
+
+    // Baseline height at empty state
+    const initialHeight = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.offsetHeight
+    )
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+    await cycleBtn.click()
+
+    // Wait for requestAnimationFrame resize to settle
+    await page.waitForTimeout(100)
+
+    const afterHeight = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.offsetHeight
+    )
+
+    // The textarea must have grown — long suggestion forces at least two lines
+    expect(afterHeight).toBeGreaterThan(initialHeight)
+  })
+
+  test('textarea height never exceeds 180 px even for very long content', async ({
+    page,
+  }) => {
+    const veryLongSuggestion = Array(20).fill('A very long action description.').join(' ')
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [veryLongSuggestion],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await expect(textarea).toBeEnabled({ timeout: 5000 })
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+    await cycleBtn.click()
+
+    await page.waitForTimeout(100)
+
+    const afterHeight = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.offsetHeight
+    )
+
+    // Must be capped at 180 px
+    expect(afterHeight).toBeLessThanOrEqual(180)
+  })
+})
+
+// ─── Part C: "Edit or send as-is" hint ───────────────────────────────────────
+
+test.describe('DIN-74 — "Edit or send as-is" hint in suggestion status line', () => {
+  test('hint text includes "edit or send as-is" when suggestions are available', async ({
+    page,
+  }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1, LONG_TAILORED_2],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    // The status line is visible when suggestions are available (before first click
+    // it shows the total count; after clicking it shows the current index).
+    await expect(
+      page.getByText(/click ✨ to cycle · edit or send as-is/i)
+    ).toBeVisible({ timeout: 5000 })
+  })
+
+  test('status line updates index after cycling', async ({ page }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1, LONG_TAILORED_2],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    // Before first click the label shows the total count as "current"
+    await expect(
+      page.getByText(/2 · click ✨ to cycle/i)
+    ).toBeVisible({ timeout: 5000 })
+
+    // After first click: "Suggestion 1 of 2 · …"
+    await cycleBtn.click()
+    await expect(page.getByText(/Suggestion 1 of 2/i)).toBeVisible({ timeout: 3000 })
+  })
+})
+
+// ─── Part B+C: SSE dual-block streaming ──────────────────────────────────────
+
+test.describe('DIN-74 — SSE dual suggested_actions blocks populate bundle', () => {
+  test('tailored block (character_id attr) flows to acting player after stream', async ({
+    page,
+  }) => {
+    // The current player IS the acting player
+    const tailoredLine = '"I take a cautious step forward," I whisper, hand on hilt.'
+    const genericLine = 'Wait and observe.'
+
+    await setupMocks(page, { suggestedActions: null }) // start with no suggestions
+
+    // Action POST
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-1', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // SSE stream: narrative + tailored block + generic block
+    await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: buildSseBody([
+          { type: 'chunk', text: 'The corridor is silent. ' },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: { character_id: PLAYER_ID },
+            content: tailoredLine,
+          },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: { generic: 'true' },
+            content: genericLine,
+          },
+          { type: 'done' },
+        ]),
+      })
+    })
+
+    await gotoGame(page)
+
+    // Submit action to trigger the stream
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill('I move forward.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Simulate the Realtime DM INSERT so isWaitingForDm clears
+    await page.evaluate(({ gameId }) => {
+      window.dispatchEvent(
+        new CustomEvent('dm-message', {
+          detail: {
+            id: 'msg-dm-1',
+            game_id: gameId,
+            profile_id: null,
+            role: 'dm',
+            content: 'The corridor is silent.',
+            created_at: new Date().toISOString(),
+          },
+        })
+      )
+    }, { gameId: GAME_ID })
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    // Acting player (player-1 = USER_ID) should see the tailored suggestion
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(tailoredLine)
+  })
+
+  test('generic block (generic="true" attr) flows to non-acting player after stream', async ({
+    page,
+  }) => {
+    // The current player is NOT the acting player (acting = 'player-other')
+    const tailoredLine = '"I raise my sword," the rogue says, stepping up boldly.'
+    const genericLine1 = 'Wait and observe the others.'
+    const genericLine2 = 'Speak up with your own plan.'
+
+    // Player-1 is NOT the acting player (acting_player_id will be 'player-other')
+    await setupMocks(page, { suggestedActions: null })
+
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-2', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: buildSseBody([
+          { type: 'chunk', text: 'The rogue dashes ahead. ' },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: { character_id: 'player-other' }, // different player
+            content: tailoredLine,
+          },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: { generic: 'true' },
+            content: [genericLine1, genericLine2].join('\n'),
+          },
+          { type: 'done' },
+        ]),
+      })
+    })
+
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    await textarea.fill('I watch the rogue.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Realtime DM INSERT
+    await page.evaluate(({ gameId }) => {
+      window.dispatchEvent(
+        new CustomEvent('dm-message', {
+          detail: {
+            id: 'msg-dm-2',
+            game_id: gameId,
+            profile_id: null,
+            role: 'dm',
+            content: 'The rogue dashes ahead.',
+            created_at: new Date().toISOString(),
+          },
+        })
+      )
+    }, { gameId: GAME_ID })
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    // Non-acting player should see generic suggestions
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(genericLine1)
+
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(genericLine2)
+
+    // Tailored suggestion for the other player must NOT appear
+    await expect(textarea).not.toHaveValue(tailoredLine)
+  })
+})
+
+// ─── Part C: Realtime game-update bundle ─────────────────────────────────────
+
+test.describe('DIN-74 — Realtime game-update replaces bundle', () => {
+  test('game-update Realtime event with new bundle enables ✨ and shows correct suggestions', async ({
+    page,
+  }) => {
+    // Start with no suggestions
+    await setupMocks(page, { suggestedActions: null })
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeDisabled({ timeout: 5000 })
+
+    // Simulate Supabase Realtime `game-update` event with new bundle
+    const newBundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1, LONG_TAILORED_2],
+      generic: [GENERIC_1],
+    }
+
+    await page.evaluate(
+      ({ gameId, bundle }) => {
+        window.dispatchEvent(
+          new CustomEvent('game-update', {
+            detail: {
+              id: gameId,
+              name: 'The Continuity Keep',
+              dm_persona: 'A theatrical DM',
+              status: 'active',
+              created_by: 'user-1',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: new Date().toISOString(),
+              suggested_actions: bundle,
+            },
+          })
+        )
+      },
+      { gameId: GAME_ID, bundle: newBundle }
+    )
+
+    // ✨ should now be enabled for the acting player
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    const textarea = page.getByTestId('chat-textarea')
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(LONG_TAILORED_1)
+  })
+
+  test('game-update with null bundle disables ✨', async ({ page }) => {
+    const initialBundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: initialBundle })
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    // Realtime update clears suggestions (game paused / new round starting)
+    await page.evaluate(({ gameId }) => {
+      window.dispatchEvent(
+        new CustomEvent('game-update', {
+          detail: {
+            id: gameId,
+            name: 'The Continuity Keep',
+            dm_persona: 'A theatrical DM',
+            status: 'active',
+            created_by: 'user-1',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: new Date().toISOString(),
+            suggested_actions: null,
+          },
+        })
+      )
+    }, { gameId: GAME_ID })
+
+    await expect(cycleBtn).toBeDisabled({ timeout: 5000 })
+  })
+})

--- a/frontend/e2e/din-74-suggestions.spec.ts
+++ b/frontend/e2e/din-74-suggestions.spec.ts
@@ -1197,3 +1197,167 @@ test.describe('DIN-74 — Acting player transitions to observer when acting_play
     await expect(textarea).not.toHaveValue(LONG_TAILORED_2)
   })
 })
+
+// ─── Part C: Edit-and-send flow ───────────────────────────────────────────────
+//
+// User cycles a suggestion into the textarea, edits it (appends words), then
+// sends. The POST body must contain the MODIFIED text, not the raw suggestion.
+// This verifies: (a) the textarea remains editable after cycling, (b) the Submit
+// button/Enter key use the current textarea value, not a stale suggestion cache.
+
+test.describe('DIN-74 — User edits a cycled suggestion before sending', () => {
+  test('POST body contains modified text when user edits suggestion before submit', async ({
+    page,
+  }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+
+    let capturedRequestBody: string | null = null
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        capturedRequestBody = route.request().postData()
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-edited', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    const textarea = page.getByTestId('chat-textarea')
+
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+    await cycleBtn.click()
+
+    // Verify suggestion loaded
+    await expect(textarea).toHaveValue(LONG_TAILORED_1)
+
+    // User appends additional context to the suggestion
+    const suffix = ' — but I keep my shield raised.'
+    await textarea.press('End')
+    await textarea.type(suffix)
+
+    const expectedText = LONG_TAILORED_1 + suffix
+    await expect(textarea).toHaveValue(expectedText)
+
+    // Send the modified text
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // The POST must carry the modified text, not just the raw suggestion
+    expect(capturedRequestBody).not.toBeNull()
+    const parsed = JSON.parse(capturedRequestBody!)
+    expect(parsed.action_text).toBe(expectedText)
+  })
+
+  test('Enter key submits the edited suggestion text', async ({ page }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+
+    let capturedRequestBody: string | null = null
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        capturedRequestBody = route.request().postData()
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-enter-edited', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    const textarea = page.getByTestId('chat-textarea')
+
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(LONG_TAILORED_1)
+
+    // Append a clarification (avoids multi-line cursor-positioning issues)
+    const suffix = ', steeling myself for whatever comes next.'
+    await textarea.press('End')
+    await textarea.type(suffix)
+
+    const expectedText = LONG_TAILORED_1 + suffix
+    await expect(textarea).toHaveValue(expectedText)
+
+    // Submit via Enter
+    await textarea.press('Enter')
+
+    expect(capturedRequestBody).not.toBeNull()
+    const parsed = JSON.parse(capturedRequestBody!)
+    expect(parsed.action_text).toBe(expectedText)
+  })
+})
+
+// ─── Part C: Textarea shrinks when user manually clears text ──────────────────
+//
+// After cycling in a long suggestion (textarea expands), if the user
+// backspaces/clears the textarea, handleTextChange fires and resizeTextarea
+// must shrink the box back down. This verifies the two-way resize path:
+// not only does the textarea grow on cycle, it also shrinks on user clear.
+
+test.describe('DIN-74 — Textarea shrinks back when user clears cycled text', () => {
+  test('textarea height reduces after user clears a long cycled suggestion', async ({
+    page,
+  }) => {
+    const multiLineTailored =
+      '"We must act swiftly," I urge, drawing my blade as I scan the treeline for movement. ' +
+      '"Whatever lurks beyond those shadows will not wait for us to deliberate — I say we move now, together, before the light fails us."'
+
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [multiLineTailored],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+    await cycleBtn.click()
+
+    // Allow rAF resize to settle
+    await page.waitForTimeout(100)
+
+    const heightAfterCycle = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.offsetHeight
+    )
+    expect(heightAfterCycle).toBeGreaterThan(45)
+
+    // User clears the textarea with Ctrl+A then Delete
+    await textarea.press('ControlOrMeta+a')
+    await textarea.press('Delete')
+
+    // Wait for the resize triggered by onChange (handleTextChange)
+    await page.waitForTimeout(100)
+
+    const heightAfterClear = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.offsetHeight
+    )
+
+    // Height must have shrunk back toward the single-line minimum
+    expect(heightAfterClear).toBeLessThan(heightAfterCycle)
+  })
+})

--- a/frontend/e2e/din-74-suggestions.spec.ts
+++ b/frontend/e2e/din-74-suggestions.spec.ts
@@ -861,3 +861,190 @@ test.describe('DIN-74 — Textarea height resets to auto after submitting a cycl
     expect(['auto', '']).toContain(heightAfterSubmit)
   })
 })
+
+// ─── Part B: acting_player_id null ───────────────────────────────────────────
+//
+// When the bundle has acting_player_id: null (DM-initiated global suggestions,
+// no specific player is acting), isActing is always false for every player
+// because `currentPlayerRow.id === null` is never true. Everyone falls through
+// to the generic bucket.
+
+test.describe('DIN-74 — acting_player_id null means all players see generic suggestions', () => {
+  test('✨ enabled and generic shown when acting_player_id is null', async ({ page }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: null,
+      tailored: [LONG_TAILORED_1], // never shown — no player matches null
+      generic: [GENERIC_1, GENERIC_2],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    const textarea = page.getByTestId('chat-textarea')
+
+    // Cycles through generic list
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(GENERIC_1)
+
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(GENERIC_2)
+
+    // Tailored content must NOT appear (acting_player_id is null — nobody is acting)
+    await expect(textarea).not.toHaveValue(LONG_TAILORED_1)
+  })
+
+  test('✨ disabled when acting_player_id is null and generic list is empty', async ({
+    page,
+  }) => {
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: null,
+      tailored: [LONG_TAILORED_1], // non-empty tailored, but nobody can claim it
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+    await gotoGame(page)
+
+    // Generic is empty → no visible suggestions for any player → ✨ disabled
+    await expect(page.getByTestId('cycle-suggestion-btn')).toBeDisabled({ timeout: 5000 })
+  })
+})
+
+// ─── Part B+C: Legacy SSE block (no attrs) → generic bucket ──────────────────
+//
+// Before DIN-74 the backend emitted plain <suggested_actions>…</suggested_actions>
+// blocks with no attributes. The SSE parser has a legacy fallback that routes
+// attribute-free blocks to the generic bucket so older stream payloads keep working.
+
+test.describe('DIN-74 — Legacy suggested_actions SSE block (no attrs) populates generic bucket', () => {
+  test('block without character_id or generic attr is routed to generic bucket', async ({
+    page,
+  }) => {
+    const legacySuggestion = 'Look around carefully before proceeding.'
+
+    await setupMocks(page, { suggestedActions: null })
+
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-legacy', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // SSE stream with a legacy block — no character_id, no generic="true"
+    await page.route(`**/api/games/${GAME_ID}/events`, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: buildSseBody([
+          { type: 'chunk', text: 'The shadows deepen around you.' },
+          {
+            type: 'block',
+            tag: 'suggested_actions',
+            attributes: {}, // no character_id, no generic="true" → legacy fallback
+            content: legacySuggestion,
+          },
+          { type: 'done' },
+        ]),
+      })
+    })
+
+    await gotoGame(page)
+
+    await page.getByTestId('chat-textarea').fill('I look around.')
+    await page.getByRole('button', { name: /Send/i }).click()
+
+    // Realtime DM INSERT to clear isWaitingForDm
+    await page.evaluate(({ gameId }) => {
+      window.dispatchEvent(
+        new CustomEvent('dm-message', {
+          detail: {
+            id: 'msg-dm-legacy',
+            game_id: gameId,
+            profile_id: null,
+            role: 'dm',
+            content: 'The shadows deepen around you.',
+            created_at: new Date().toISOString(),
+          },
+        })
+      )
+    }, { gameId: GAME_ID })
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+
+    // Legacy suggestion routed to generic bucket — all players can cycle it
+    const textarea = page.getByTestId('chat-textarea')
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(legacySuggestion)
+  })
+})
+
+// ─── Part C: Enter key submission clears textarea height ──────────────────────
+
+test.describe('DIN-74 — Enter key submission clears textarea height', () => {
+  test('textarea style.height is cleared after Enter key submits a long cycled suggestion', async ({
+    page,
+  }) => {
+    const multiLineTailored =
+      '"With all haste I sprint toward the gate," I say, drawing my blade and rallying my companions with a battle cry that echoes across the courtyard.'
+
+    const bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [multiLineTailored],
+      generic: [],
+    }
+
+    await setupMocks(page, { suggestedActions: bundle })
+
+    await page.route(`**/api/games/${GAME_ID}/actions`, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ message_id: 'msg-enter', status: 'queued' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await gotoGame(page)
+
+    const textarea = page.getByTestId('chat-textarea')
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+    await cycleBtn.click()
+
+    // Allow rAF resize to settle
+    await page.waitForTimeout(100)
+
+    // Textarea must have grown after cycling in a long suggestion
+    const heightAfterCycle = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.style.height
+    )
+    expect(heightAfterCycle).toMatch(/^\d+px$/)
+
+    // Submit via Enter key (not the Send button)
+    await textarea.press('Enter')
+
+    // After submit, style.height must be cleared back to 'auto' or empty
+    const heightAfterSubmit = await textarea.evaluate(
+      (el: HTMLTextAreaElement) => el.style.height
+    )
+    expect(['auto', '']).toContain(heightAfterSubmit)
+  })
+})

--- a/frontend/e2e/din-74-suggestions.spec.ts
+++ b/frontend/e2e/din-74-suggestions.spec.ts
@@ -1122,3 +1122,78 @@ test.describe('DIN-74 — Enter key submission clears textarea height', () => {
     expect(['auto', '']).toContain(heightAfterSubmit)
   })
 })
+
+// ─── Part B: Acting player → observer transition ──────────────────────────────
+//
+// Multiplayer scenario: the current user was the acting player (tailored shown).
+// A new round starts — a different player takes an action. Realtime `game-update`
+// delivers a bundle where acting_player_id changed to the OTHER player.
+// The former acting player must now see generic suggestions, not tailored.
+
+test.describe('DIN-74 — Acting player transitions to observer when acting_player_id changes', () => {
+  test('switches from tailored to generic suggestions when Realtime game-update sets a new acting player', async ({
+    page,
+  }) => {
+    // Round 1: current user (PLAYER_ID / USER_ID) is the acting player
+    const round1Bundle: SuggestedActionsBundle = {
+      acting_player_id: PLAYER_ID,
+      tailored: [LONG_TAILORED_1, LONG_TAILORED_2],
+      generic: [GENERIC_1, GENERIC_2],
+    }
+
+    await setupMocks(page, { suggestedActions: round1Bundle })
+    await gotoGame(page)
+
+    const cycleBtn = page.getByTestId('cycle-suggestion-btn')
+    const textarea = page.getByTestId('chat-textarea')
+
+    // Verify round 1: acting player sees tailored suggestions
+    await expect(cycleBtn).toBeEnabled({ timeout: 5000 })
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(LONG_TAILORED_1)
+
+    // Clear the textarea before round 2 transition
+    await textarea.fill('')
+
+    // Round 2: a different player (player-other) becomes the acting player.
+    // Realtime game-update delivers the new bundle from the bookkeeping task.
+    const round2Bundle: SuggestedActionsBundle = {
+      acting_player_id: 'player-other',
+      tailored: [LONG_TAILORED_2],  // different player's tailored — must NOT show
+      generic: [GENERIC_1, GENERIC_2],
+    }
+
+    await page.evaluate(
+      ({ gameId, bundle }) => {
+        window.dispatchEvent(
+          new CustomEvent('game-update', {
+            detail: {
+              id: gameId,
+              name: 'The Continuity Keep',
+              dm_persona: 'A theatrical DM',
+              status: 'active',
+              created_by: 'user-1',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: new Date().toISOString(),
+              suggested_actions: bundle,
+            },
+          })
+        )
+      },
+      { gameId: GAME_ID, bundle: round2Bundle }
+    )
+
+    // ✨ must still be enabled (generic list is non-empty)
+    await expect(cycleBtn).toBeEnabled({ timeout: 3000 })
+
+    // Now the former acting player (PLAYER_ID) sees generic suggestions
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(GENERIC_1)
+
+    await cycleBtn.click()
+    await expect(textarea).toHaveValue(GENERIC_2)
+
+    // The OTHER player's tailored suggestion must NOT appear
+    await expect(textarea).not.toHaveValue(LONG_TAILORED_2)
+  })
+})

--- a/frontend/e2e/game-loop.spec.ts
+++ b/frontend/e2e/game-loop.spec.ts
@@ -165,9 +165,9 @@ test.describe('Core Game Loop — Submit Action + Receive DM Response', () => {
       window.dispatchEvent(event)
     })
 
-    // Player message should appear in chat
+    // Player message should appear in chat (may appear in both optimistic UI and Realtime event)
     await expect(
-      page.getByText(/I approach the merchant and ask about the mysterious amulet/)
+      page.getByText(/I approach the merchant and ask about the mysterious amulet/).first()
     ).toBeVisible({ timeout: 5000 })
 
     // Simulate Realtime: DM response arrives
@@ -447,6 +447,16 @@ test.describe('DIN-42 — DM action suggestions (✨ cycling)', () => {
     'Press your ear to the door and listen carefully.',
   ]
 
+  // DIN-74: suggested_actions is now a SuggestedActionsBundle jsonb object.
+  // acting_player_id:null → visibleSuggestions = generic for all players,
+  // so the cycle button is enabled as soon as hasCharacter=true regardless
+  // of whether currentPlayerRow has loaded yet.
+  const SUGGESTION_BUNDLE = {
+    acting_player_id: null,
+    tailored: [],
+    generic: SUGGESTIONS,
+  }
+
   test.beforeEach(async ({ page }) => {
     await page.route('**/auth/v1/user', (route) =>
       route.fulfill({
@@ -492,14 +502,34 @@ test.describe('DIN-42 — DM action suggestions (✨ cycling)', () => {
       }
     })
 
+    await page.route('**.supabase.co/rest/v1/player_inventory**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+      }
+    })
+
     // Mock game_messages: return DM message → isWaitingForDm=false → cycle button enabled
     await page.route('**.supabase.co/rest/v1/game_messages**', (route) => {
       if (route.request().method() === 'GET') {
-        route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify([{ id: 'msg-dm', role: 'dm', created_at: '2026-01-01T00:00:00Z' }]),
-        })
+        const url = route.request().url()
+        if (url.includes('select=role')) {
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([{ id: 'msg-dm', role: 'dm', created_at: '2026-01-01T00:00:00Z' }]),
+          })
+        } else {
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([{
+              id: 'msg-dm',
+              role: 'dm',
+              content: 'Welcome to the adventure.',
+              created_at: '2026-01-01T00:00:00Z',
+            }]),
+          })
+        }
       }
     })
   })
@@ -552,7 +582,7 @@ test.describe('DIN-42 — DM action suggestions (✨ cycling)', () => {
               status: 'active',
               created_by: userId,
               updated_at: '2026-01-01T00:00:00Z',
-              suggested_actions: SUGGESTIONS,
+              suggested_actions: SUGGESTION_BUNDLE,
             },
           ]),
         })
@@ -602,7 +632,7 @@ test.describe('DIN-42 — DM action suggestions (✨ cycling)', () => {
               status: 'active',
               created_by: userId,
               updated_at: '2026-01-01T00:00:00Z',
-              suggested_actions: SUGGESTIONS,
+              suggested_actions: SUGGESTION_BUNDLE,
             },
           ]),
         })

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -138,6 +138,23 @@ body {
 .dnd-textarea {
   resize: vertical;
   min-height: 6rem;
+  /* Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: #8a7234 #1a1612;
+}
+.dnd-textarea::-webkit-scrollbar {
+  width: 8px;
+}
+.dnd-textarea::-webkit-scrollbar-track {
+  background: #1a1612;
+  border-radius: 4px;
+}
+.dnd-textarea::-webkit-scrollbar-thumb {
+  background: #8a7234;
+  border-radius: 4px;
+}
+.dnd-textarea::-webkit-scrollbar-thumb:hover {
+  background: #c9a84c;
 }
 
 .dnd-helper {

--- a/frontend/src/components/games/ChatInput.tsx
+++ b/frontend/src/components/games/ChatInput.tsx
@@ -10,6 +10,12 @@ interface ChatInputProps {
   suggestedActions?: string[]
 }
 
+function resizeTextarea(el: HTMLTextAreaElement) {
+  el.style.height = 'auto'
+  const maxPx = 180
+  el.style.height = `${Math.min(el.scrollHeight, maxPx)}px`
+}
+
 export function ChatInput({
   gameStatus,
   isWaitingForDm,
@@ -55,6 +61,9 @@ export function ChatInput({
     if (!suggestedActions || suggestedActions.length === 0) return
     setText(suggestedActions[suggestionIdx])
     setSuggestionIdx((prev) => (prev + 1) % suggestedActions.length)
+    requestAnimationFrame(() => {
+      if (textareaRef.current) resizeTextarea(textareaRef.current)
+    })
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -83,12 +92,7 @@ export function ChatInput({
 
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setText(e.target.value)
-
-    // Auto-grow textarea (max 4 lines)
-    const textarea = e.target
-    textarea.style.height = 'auto'
-    const newHeight = Math.min(textarea.scrollHeight, 6 * 16) // ~4 lines at default font
-    textarea.style.height = `${newHeight}px`
+    resizeTextarea(e.target)
   }
 
   return (
@@ -112,7 +116,7 @@ export function ChatInput({
             }}
           >
             Suggestion {suggestionIdx === 0 ? suggestedActions!.length : suggestionIdx} of{' '}
-            {suggestedActions!.length} · click ✨ to cycle
+            {suggestedActions!.length} · click ✨ to cycle · edit or send as-is
           </div>
         )}
         <form onSubmit={handleSubmit} className="flex gap-3 items-end">
@@ -128,7 +132,7 @@ export function ChatInput({
             rows={1}
             style={{
               minHeight: '40px',
-              maxHeight: '96px',
+              maxHeight: '180px',
             }}
           />
           <button

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -392,6 +392,12 @@ export function GameSessionView({
       const detail = (event as CustomEvent).detail as LevelUpPayload
       setLevelUpPayload(detail)
     }
+    // Simulate Supabase Realtime UPDATE on the games row (e.g. suggested_actions bundle refresh)
+    const handleGameUpdate = (event: Event) => {
+      const updatedGame = (event as CustomEvent).detail as Game
+      setGameStatus(updatedGame.status)
+      setSuggestedBundle(updatedGame.suggested_actions ?? EMPTY_BUNDLE)
+    }
 
     window.addEventListener('player-message', addMessage)
     window.addEventListener('dm-message', addMessage)
@@ -400,6 +406,7 @@ export function GameSessionView({
     window.addEventListener('session-paused', handleSessionPaused)
     window.addEventListener('session-ended', handleSessionEnded)
     window.addEventListener('level-up-available', handleLevelUpAvailable)
+    window.addEventListener('game-update', handleGameUpdate)
 
     // Marker so Playwright can wait for listeners to be attached before
     // dispatching simulated events (avoids a hydration race). Defer via
@@ -420,6 +427,7 @@ export function GameSessionView({
       window.removeEventListener('session-paused', handleSessionPaused)
       window.removeEventListener('session-ended', handleSessionEnded)
       window.removeEventListener('level-up-available', handleLevelUpAvailable)
+      window.removeEventListener('game-update', handleGameUpdate)
       delete document.body.dataset.e2eListenersReady
     }
   }, [gameId])

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { GameMessage } from '@/lib/types/message'
 import {
@@ -8,7 +8,7 @@ import {
   type SseEvent,
   appendTextChunk,
 } from '@/lib/types/streaming'
-import { Game } from '@/lib/supabase/games'
+import { Game, SuggestedActionsBundle } from '@/lib/supabase/games'
 import { GameHeader } from './GameHeader'
 import { ChatLog } from './ChatLog'
 import { ChatInput } from './ChatInput'
@@ -47,8 +47,9 @@ export function GameSessionView({
   const [isActionLoading, setIsActionLoading] = useState(false)
   const [showRetryTimeout, setShowRetryTimeout] = useState(false)
   const [lastPlayerAction, setLastPlayerAction] = useState<string | null>(null)
-  const [suggestedActions, setSuggestedActions] = useState<string[]>(
-    game.suggested_actions ?? []
+  const _emptyBundle: SuggestedActionsBundle = { acting_player_id: null, tailored: [], generic: [] }
+  const [suggestedBundle, setSuggestedBundle] = useState<SuggestedActionsBundle>(
+    game.suggested_actions ?? _emptyBundle
   )
   const [hasMoreMessages, setHasMoreMessages] = useState(true)
   const [oldestCreatedAt, setOldestCreatedAt] = useState<string | null>(null)
@@ -57,6 +58,16 @@ export function GameSessionView({
   const [levelUpPayload, setLevelUpPayload] = useState<LevelUpPayload | null>(null)
   const [showLevelUpModal, setShowLevelUpModal] = useState(false)
   const [currentPlayerRow, setCurrentPlayerRow] = useState<PlayerRow | null>(null)
+
+  // DIN-74: derive which suggestions this user sees.
+  // Acting player → tailored (first-person POV); others → generic observer prompts.
+  const visibleSuggestions = useMemo(() => {
+    const isActing =
+      currentPlayerRow?.id != null &&
+      currentPlayerRow.id === suggestedBundle.acting_player_id
+    return isActing ? suggestedBundle.tailored : suggestedBundle.generic
+  }, [suggestedBundle, currentPlayerRow?.id])
+
   // DIN-66 live DM bubble. null = no active stream; non-null = bubble rendered
   // below the chat list until Realtime DM INSERT reconciles (clears to null).
   const [streamingSegments, setStreamingSegments] =
@@ -276,7 +287,7 @@ export function GameSessionView({
         (payload) => {
           const updatedGame = payload.new as Game
           setGameStatus(updatedGame.status)
-          setSuggestedActions(updatedGame.suggested_actions ?? [])
+          setSuggestedBundle(updatedGame.suggested_actions ?? _emptyBundle)
         }
       )
       .subscribe()
@@ -556,7 +567,18 @@ export function GameSessionView({
                   .split('\n')
                   .map((line) => line.trim())
                   .filter(Boolean)
-                setSuggestedActions(lines)
+                const charId = event.attributes?.character_id
+                const isGeneric = event.attributes?.generic === 'true'
+                setSuggestedBundle((prev) => {
+                  if (charId) {
+                    return { ...prev, acting_player_id: charId, tailored: lines }
+                  }
+                  if (isGeneric) {
+                    return { ...prev, generic: lines }
+                  }
+                  // Legacy fallback: no attributes → generic bucket
+                  return { ...prev, generic: lines }
+                })
               } else if (event.tag === 'scene') {
                 // Update scene background immediately during streaming.
                 const sceneResult = parseSceneTag(
@@ -796,7 +818,7 @@ export function GameSessionView({
             isWaitingForDm={isWaitingForDm}
             hasCharacter={hasCharacter}
             onSubmit={handleSubmit}
-            suggestedActions={suggestedActions}
+            suggestedActions={visibleSuggestions}
           />
         </div>
 

--- a/frontend/src/components/games/GameSessionView.tsx
+++ b/frontend/src/components/games/GameSessionView.tsx
@@ -24,6 +24,8 @@ import { CHAT_PAGE_SIZE } from '@/lib/constants/game'
 import { parseSceneTag } from '@/lib/scene'
 import type { SceneType, Mood } from '@/lib/scene'
 
+const EMPTY_BUNDLE: SuggestedActionsBundle = { acting_player_id: null, tailored: [], generic: [] }
+
 interface GameSessionViewProps {
   gameId: string
   game: Game
@@ -47,9 +49,8 @@ export function GameSessionView({
   const [isActionLoading, setIsActionLoading] = useState(false)
   const [showRetryTimeout, setShowRetryTimeout] = useState(false)
   const [lastPlayerAction, setLastPlayerAction] = useState<string | null>(null)
-  const _emptyBundle: SuggestedActionsBundle = { acting_player_id: null, tailored: [], generic: [] }
   const [suggestedBundle, setSuggestedBundle] = useState<SuggestedActionsBundle>(
-    game.suggested_actions ?? _emptyBundle
+    game.suggested_actions ?? EMPTY_BUNDLE
   )
   const [hasMoreMessages, setHasMoreMessages] = useState(true)
   const [oldestCreatedAt, setOldestCreatedAt] = useState<string | null>(null)
@@ -287,7 +288,7 @@ export function GameSessionView({
         (payload) => {
           const updatedGame = payload.new as Game
           setGameStatus(updatedGame.status)
-          setSuggestedBundle(updatedGame.suggested_actions ?? _emptyBundle)
+          setSuggestedBundle(updatedGame.suggested_actions ?? EMPTY_BUNDLE)
         }
       )
       .subscribe()

--- a/frontend/src/components/games/__tests__/ChatInput.test.tsx
+++ b/frontend/src/components/games/__tests__/ChatInput.test.tsx
@@ -491,3 +491,33 @@ describe('ChatInput', () => {
     })
   })
 })
+
+  describe('DIN-74 resize after handleCycle', () => {
+    it('calls resize after handleCycle populates the textarea', () => {
+      const rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        cb(0)
+        return 0
+      })
+
+      const suggestions = [
+        '"Let me examine these runes," I say, crouching down and lowering my wizard\'s eye to the stone.',
+      ]
+      render(
+        <ChatInput
+          gameStatus="active"
+          isWaitingForDm={false}
+          hasCharacter={true}
+          suggestedActions={suggestions}
+        />
+      )
+      const textarea = screen.getByTestId('chat-textarea') as HTMLTextAreaElement
+      const heightSpy = jest.spyOn(textarea.style, 'height', 'set')
+
+      fireEvent.click(screen.getByTestId('cycle-suggestion-btn'))
+
+      expect(textarea.value).toBe(suggestions[0])
+      expect(heightSpy).toHaveBeenCalled()
+
+      rafSpy.mockRestore()
+    })
+  })

--- a/frontend/src/components/games/__tests__/ChatInput.test.tsx
+++ b/frontend/src/components/games/__tests__/ChatInput.test.tsx
@@ -490,7 +490,6 @@ describe('ChatInput', () => {
       expect(textarea).toBeInTheDocument()
     })
   })
-})
 
   describe('DIN-74 resize after handleCycle', () => {
     it('calls resize after handleCycle populates the textarea', () => {
@@ -521,3 +520,4 @@ describe('ChatInput', () => {
       rafSpy.mockRestore()
     })
   })
+})

--- a/frontend/src/components/games/__tests__/GameSessionView.test.tsx
+++ b/frontend/src/components/games/__tests__/GameSessionView.test.tsx
@@ -64,6 +64,7 @@ jest.mock('../ChatInput', () => ({
       <div data-testid="is-waiting">{isWaitingForDm ? 'true' : 'false'}</div>
       <div data-testid="has-on-submit">{onSubmit ? 'true' : 'false'}</div>
       <div data-testid="suggested-actions-count">{suggestedActions ? suggestedActions.length : 0}</div>
+      <div data-testid="first-suggested-action">{suggestedActions?.[0] ?? ''}</div>
       <button data-testid="submit-action" onClick={() => onSubmit?.('I attack the dragon')}>Submit</button>
     </div>
   ),
@@ -512,7 +513,11 @@ describe('GameSessionView', () => {
           cb({
             new: {
               ...mockGame,
-              suggested_actions: ['Attack the goblin', 'Search the room'],
+              suggested_actions: {
+                acting_player_id: null,
+                tailored: [],
+                generic: ['Attack the goblin', 'Search the room'],
+              },
             },
           })
         }
@@ -1386,6 +1391,123 @@ describe('GameSessionView', () => {
           })
         )
       })
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DIN-74 Part C — suggested actions selection (tailored vs generic)
+// ---------------------------------------------------------------------------
+
+describe('DIN-74 suggested actions selection', () => {
+  let mockSupabaseClientDin74: any
+
+  beforeEach(() => {
+    mockSupabaseClientDin74 = {
+      from: jest.fn().mockImplementation((table: string) => {
+        if (table === 'players') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }
+        }
+        return {
+          select: jest.fn().mockImplementation(() => ({
+            eq: jest.fn().mockImplementation(() => ({
+              order: jest.fn().mockReturnValue({
+                limit: jest.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            })),
+          })),
+        }
+      }),
+      channel: jest.fn().mockImplementation(() => ({
+        on: jest.fn().mockReturnThis(),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+      })),
+    }
+    ;(supabaseModule.createClient as jest.Mock).mockReturnValue(mockSupabaseClientDin74)
+  })
+
+  const makeBundleGame = (bundle: any) => ({
+    id: 'game-1',
+    name: 'Test',
+    dm_persona: 'DM',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    created_by: 'user-1',
+    updated_at: '2026-01-01T00:00:00Z',
+    suggested_actions: bundle,
+  })
+
+  it('shows tailored suggestions when current user is the acting player', async () => {
+    const bundle = {
+      acting_player_id: 'player-abc',
+      tailored: ['"I attack," I shout, raising my sword.', 'I duck behind cover.'],
+      generic: ['Wait and watch.', 'Speak up.'],
+    }
+    mockSupabaseClientDin74.from.mockImplementation((table: string) => {
+      if (table === 'players') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [{ id: 'player-abc', profile_id: 'user-1', character_name: 'Hero', character_class: 'Fighter', race: 'Human', level: 1, hp_current: 10, hp_max: 10, stats: {}, status: 'alive' }],
+              error: null,
+            }),
+          }),
+        }
+      }
+      return {
+        select: jest.fn().mockImplementation(() => ({
+          eq: jest.fn().mockImplementation(() => ({
+            order: jest.fn().mockReturnValue({
+              limit: jest.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          })),
+        })),
+      }
+    })
+
+    render(<GameSessionView gameId="game-1" game={makeBundleGame(bundle)} userId="user-1" />)
+
+    // Wait until currentPlayerRow is set and visibleSuggestions switches to tailored
+    await waitFor(() => {
+      expect(screen.getByTestId('first-suggested-action')).toHaveTextContent('"I attack," I shout')
+    })
+    expect(screen.getByTestId('suggested-actions-count')).toHaveTextContent('2')
+  })
+
+  it('shows generic suggestions when current user is not the acting player', async () => {
+    const bundle = {
+      acting_player_id: 'someone-else',
+      tailored: ['"I attack," I shout.'],
+      generic: ['Wait and watch.', 'Speak up.'],
+    }
+
+    render(<GameSessionView gameId="game-1" game={makeBundleGame(bundle)} userId="user-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('first-suggested-action')).toHaveTextContent('Wait and watch.')
+    })
+    expect(screen.getByTestId('suggested-actions-count')).toHaveTextContent('2')
+  })
+
+  it('shows no suggestions when both lists are empty', async () => {
+    const bundle = { acting_player_id: null, tailored: [], generic: [] }
+
+    render(<GameSessionView gameId="game-1" game={makeBundleGame(bundle)} userId="user-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggested-actions-count')).toHaveTextContent('0')
+    })
+  })
+
+  it('handles null suggested_actions gracefully', async () => {
+    render(<GameSessionView gameId="game-1" game={makeBundleGame(null)} userId="user-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggested-actions-count')).toHaveTextContent('0')
     })
   })
 })

--- a/frontend/src/lib/supabase/games.ts
+++ b/frontend/src/lib/supabase/games.ts
@@ -1,5 +1,11 @@
 import { createClient } from '@/lib/supabase/server'
 
+export type SuggestedActionsBundle = {
+  acting_player_id: string | null
+  tailored: string[]
+  generic: string[]
+}
+
 export type Game = {
   id: string
   name: string
@@ -8,7 +14,7 @@ export type Game = {
   created_by: string
   created_at: string
   updated_at: string
-  suggested_actions: string[] | null
+  suggested_actions: SuggestedActionsBundle | null
 }
 
 export type CreateGameInput = {

--- a/supabase/migrations/20260423000001_convert_suggested_actions_to_jsonb.sql
+++ b/supabase/migrations/20260423000001_convert_suggested_actions_to_jsonb.sql
@@ -1,0 +1,22 @@
+-- DIN-74 Part B: Convert games.suggested_actions from text[] to jsonb
+-- Preserves existing text[] values into the generic bucket.
+ALTER TABLE games
+  ALTER COLUMN suggested_actions DROP DEFAULT;
+
+ALTER TABLE games
+  ALTER COLUMN suggested_actions TYPE jsonb
+  USING jsonb_build_object(
+    'acting_player_id', NULL,
+    'tailored', '[]'::jsonb,
+    'generic', COALESCE(to_jsonb(suggested_actions), '[]'::jsonb)
+  );
+
+ALTER TABLE games
+  ALTER COLUMN suggested_actions
+  SET DEFAULT '{"acting_player_id": null, "tailored": [], "generic": []}'::jsonb;
+
+ALTER TABLE games
+  ALTER COLUMN suggested_actions SET NOT NULL;
+
+COMMENT ON COLUMN games.suggested_actions IS
+  'DIN-74: {acting_player_id: uuid|null, tailored: string[], generic: string[]}. tailored = first-person POV suggestions for acting_player_id. generic = observer prompts for other players.';


### PR DESCRIPTION
## Summary

- **Scene continuity (Part A):** DM system prompt now injects a `CURRENT SCENE` block from the most recent DM message's `scene_type`/`scene_mood`, with Rule 13 carry-forward instructions so the DM doesn't reset setting/mood on every turn.
- **Tailored suggestions (Part B):** Claude now emits dual `<suggested_actions>` blocks — one with `character_id` attribute for the acting player (tailored), one with `generic="true"` for all other players. Backend extracts both and persists as a `SuggestedActionsBundle` jsonb shape (`acting_player_id`, `tailored[]`, `generic[]`). DB migration converts `games.suggested_actions` from `text[]` to `jsonb`.
- **Frontend wiring (Part C):** `GameSessionView` initialises from the new bundle shape, subscribes to Realtime + SSE updates for it, and derives `visibleSuggestions` via `useMemo` — tailored list if the current player is the acting player, generic list otherwise. `ChatInput` gains `requestAnimationFrame`-deferred textarea resize after ✨ cycling, 180 px max height, and a themed scrollbar.

## Test plan

- [x] `backend/tests/test_dm_service.py` — 8 new tests covering scene injection, `acting_player` prompt branch, backward compat
- [x] `backend/tests/test_dm_tasks.py` — 4 new `TestExtractSuggestedActions` tests + 4 updated existing tests for jsonb format
- [x] `frontend/__tests__/GameSessionView.test.tsx` — 4 new DIN-74 tests (bundle init, SSE parse, Realtime update, tailored vs generic selection)
- [x] `frontend/__tests__/ChatInput.test.tsx` — 1 new DIN-74 resize test with synchronous `requestAnimationFrame` mock
- [x] All 661 frontend + 324 backend tests pass
- [x] No regressions introduced (pre-existing lint/build errors confirmed pre-existing via `git stash` baseline)

https://claude.ai/code/session_01YMytFTAAGUkxiravq3j9kH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMytFTAAGUkxiravq3j9kH)_